### PR TITLE
Fixed undefined var notice.

### DIFF
--- a/src/models/ApiMapper.php
+++ b/src/models/ApiMapper.php
@@ -44,7 +44,7 @@ class ApiMapper
                     }
                     $entry[$key] = Timezone::formattedEventDatetimeFromUnixtime($row[$value], $tz, 'c');
                 } else {
-                    $entry[$key] = $row[$value];
+                    $entry[$key] = array_key_exists($value, $row) ? $row[$value] : null;
                 }
             }
             $retval[] = $entry;


### PR DESCRIPTION
I'm not sure what the preferred default value would be here - I've left it as null for now.  This was causing the Frisby tests to fail, with an undefined key of `duration` (with PHP running in strict mode).
