### PR TITLE
Fixed ambiguous SQL column name, added some tests.

### DIFF
--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -43,7 +43,7 @@ class UserMapper extends ApiMapper
 
     public function getUserById($user_id, $verbose = false) 
     {
-        $results = $this->getUsers(1, 0, 'ID=' . (int)$user_id, null);
+        $results = $this->getUsers(1, 0, 'user.ID=' . (int)$user_id, null);
         if ($results) {
             $retval = $this->transformResults($results, $verbose);
             return $retval;
@@ -136,7 +136,7 @@ class UserMapper extends ApiMapper
 
 
     public function isSiteAdmin($user_id) {
-        $results = $this->getUsers(1, 0, 'ID=' . (int)$user_id, null);
+        $results = $this->getUsers(1, 0, 'user.ID=' . (int)$user_id, null);
         if($results[0]['admin'] == 1) {
             return true;
         }

--- a/tests/frisby/newapi_spec.js
+++ b/tests/frisby/newapi_spec.js
@@ -121,6 +121,19 @@ frisby.create('Non-existent user')
   .expectJSON(["User not found"])
   .toss();
 
+frisby.create('Existing user')
+  .get(baseURL + "/v2.1/users/1")
+  .expectStatus(200)
+  .expectHeader("content-type", "application/json; charset=utf8")
+  .afterJSON(function(allUsers) {
+    if (typeof allUsers.users == "object") {
+      for (var u in allUsers.users) {
+        var user = allUsers.users[u];
+        checkUser(user);
+      }
+    }
+  })
+  .toss();
 
 function checkDate(fieldValue) {
   dateVal = new Date(fieldValue);
@@ -298,3 +311,21 @@ function checkTalk(talk) {
   expect(typeof talk.type).toBe('string');
 }
 
+function checkUser(user) {
+    expect(user.username).toBeDefined();
+    expect(typeof user.username).toBe('string');
+    expect(user.username).toBeDefined();
+    expect(typeof user.username).toBe('string');
+    expect(user.username).toBeDefined();
+    expect(typeof user.username).toBe('string');
+    expect(user.uri).toBeDefined();
+    expect(typeof user.uri).toBe('string');
+    expect(user.verbose_uri).toBeDefined();
+    expect(typeof user.verbose_uri).toBe('string');
+    expect(user.website_uri).toBeDefined();
+    expect(typeof user.website_uri).toBe('string');
+    expect(user.talks_uri).toBeDefined();
+    expect(typeof user.talks_uri).toBe('string');
+    expect(user.attended_events_uri).toBeDefined();
+    expect(typeof user.attended_events_uri).toBe('string');
+}


### PR DESCRIPTION
This is for the user retrieval side of things - `ID` was used in both the `user` and `user_attend` tables.  Also added a Frisby test for user retrieval and validation.
