### PR TITLE
Fixed missing table declaration in where-clause

### DIFF
--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -43,7 +43,7 @@ class UserMapper extends ApiMapper
 
     public function getUserById($user_id, $verbose = false) 
     {
-        $results = $this->getUsers(1, 0, 'ID=' . (int)$user_id, null);
+        $results = $this->getUsers(1, 0, 'user.ID=' . (int)$user_id, null);
         if ($results) {
             $retval = $this->transformResults($results, $verbose);
             return $retval;


### PR DESCRIPTION
A recent change (https://github.com/joindin/joindin-api/commit/afb8d6539a1f101c3c5dee05ed645fbc7c5c0452) introduced a bug because it introduced a JOIN which caused an ambiguous "ID"-field. This should fix that.
