### PR TITLE
Add event comment posting to API.

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -178,10 +178,9 @@ class EventsController extends ApiController {
 
                     $comment_mapper = new EventCommentMapper($db, $request);
                     $new_id = $comment_mapper->save($comment);
-
-                    header("Location: " . $request->base . $request->path_info, true, 201);
-                    $new_comment = $comment_mapper->getCommentById($new_id);
-                    return $new_comment;
+                    $uri = $request->base . '/' . $request->version . '/event_comments/' . $new_id;
+                    header("Location: " . $uri, NULL, 201);
+                    exit;
                 default:
                     throw new Exception("Operation not supported, sorry", 404);
             }

--- a/src/models/EventCommentMapper.php
+++ b/src/models/EventCommentMapper.php
@@ -110,5 +110,9 @@ class EventCommentMapper extends ApiMapper {
             ':cname' => $data['cname'],
             ':user_id' => $data['user_id']
             ));
+
+        $comment_id = $this->_db->lastInsertId();
+
+        return $comment_id;
     }
 }


### PR DESCRIPTION
As the title says - it seemed to be missing.  I've modelled this on the talk comment posting (which is why the code looks pretty similar).
