### PR TITLE
JOINDIN-332: Creating new talk comment returns comment URI

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -71,8 +71,9 @@ class TalksController extends ApiController {
                 $data['comment'] = $comment;
                 $data['rating'] = $rating;
 
-                $comment_mapper->save($data);
-                header("Location: " . $request->base . $request->path_info, true, 201);
+                $new_id = $comment_mapper->save($data);
+                $uri = $request->base . '/' . $request->version . '/talk_comments/' . $new_id;
+                header("Location: " . $uri, true, 201);
                 exit;
             }
         } else {

--- a/src/models/TalkCommentMapper.php
+++ b/src/models/TalkCommentMapper.php
@@ -130,5 +130,9 @@ class TalkCommentMapper extends ApiMapper {
             ':comment' => $data['comment'],
             ':user_id' => $data['user_id']
             ));
+
+        $comment_id = $this->_db->lastInsertId();
+
+        return $comment_id;
     }
 }


### PR DESCRIPTION
The URI to the newly-created comment is now returned upon a successful creation, rather than the URI to the comment collection.
