### PR TITLE
Added ability to add private talk comments.

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -65,11 +65,14 @@ class TalksController extends ApiController {
                     throw new Exception('The field "rating" is required', 400);
                 }
 
+                $private = ($request->getParameter('private') ? 1 : 0);
+
                 $comment_mapper = new TalkCommentMapper($db, $request);
                 $data['user_id'] = $request->user_id;
                 $data['talk_id'] = $talk_id;
                 $data['comment'] = $comment;
                 $data['rating'] = $rating;
+                $data['private'] = $private;
 
                 $new_id = $comment_mapper->save($data);
                 $uri = $request->base . '/' . $request->version . '/talk_comments/' . $new_id;

--- a/src/models/TalkCommentMapper.php
+++ b/src/models/TalkCommentMapper.php
@@ -121,14 +121,15 @@ class TalkCommentMapper extends ApiMapper {
     public function save($data) {
         $sql = 'insert into talk_comments (talk_id, rating, comment, user_id, '
             . 'source, date_made, private, active) '
-            . 'values (:talk_id, :rating, :comment, :user_id, "api-v2", UNIX_TIMESTAMP(), 0, 1)';
+            . 'values (:talk_id, :rating, :comment, :user_id, "api-v2", UNIX_TIMESTAMP(), :private, 1)';
 
         $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(array(
             ':talk_id' => $data['talk_id'],
             ':rating' => $data['rating'],
             ':comment' => $data['comment'],
-            ':user_id' => $data['user_id']
+            ':user_id' => $data['user_id'],
+            ':private' => $data['private'],
             ));
 
         $comment_id = $this->_db->lastInsertId();


### PR DESCRIPTION
Posting private comments on talks wasn't available via the API. This PR addresses that - send the `private` parameter with a true value to set a comment to private.
