### PR TITLE
Fix the test that expects full name to be populated

### DIFF
--- a/tests/frisby/newapi_spec.js
+++ b/tests/frisby/newapi_spec.js
@@ -329,7 +329,9 @@ function checkUser(user) {
     expect(user.username).toBeDefined();
     expect(typeof user.username).toBe('string');
     expect(user.full_name).toBeDefined();
-    expect(typeof user.full_name).toBe('string');
+    if(typeof user.full_name != 'undefined' && user.full_name != null) {
+      expect(typeof user.full_name).toBe('string');
+    }
     expect(user.twitter_username).toBeDefined();
     if(typeof user.twitter_username != 'undefined' && user.twitter_username != null) {
       expect(typeof user.twitter_username).toBe('string');


### PR DESCRIPTION
This is a false assumption, users who sign up with social networks rather than registering on joind.in itself often have missing fields
