### PR TITLE
Add track_uri to track entries when retrieving a talk.

### DIFF
--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -214,8 +214,9 @@ class TalkMapper extends ApiMapper {
     }
 
     protected function getTracks($talk_id) {
-        $host = $this->_request->host;
-        $track_sql = 'select et.track_name '
+        $base = $this->_request->base;
+        $version = $this->_request->version;
+        $track_sql = 'select et.ID,et.track_name '
             . 'from talk_track tt '
             . 'inner join event_track et on et.ID = tt.track_id '
             . 'where tt.talk_id = :talk_id';
@@ -225,7 +226,12 @@ class TalkMapper extends ApiMapper {
         $retval = array();
         if(is_array($tracks)) {
            foreach($tracks as $track) {
-               $retval[] = $track;
+               // Make the track_uri
+               $track_uri = $base . '/' . $version . '/tracks/' . $track['ID'];
+               $retval[] = array(
+                   'track_name' => $track['track_name'],
+                   'track_uri' => $track_uri,
+               );
            }
         }
         return $retval;


### PR DESCRIPTION
This makes it somewhat easier to retrieve the track details if you only have the talk data, rather than having to retrieve the event followed by the event's tracks and then comparing names.
