### PR TITLE
add some ordering when fetching event comments

### DIFF
--- a/src/models/EventCommentMapper.php
+++ b/src/models/EventCommentMapper.php
@@ -21,7 +21,7 @@ class EventCommentMapper extends ApiMapper {
 
     public function getEventCommentsByEventId($event_id, $resultsperpage, $start, $verbose = false) {
         $sql = $this->getBasicSQL();
-        $sql .= 'and event_id = :event_id ';
+        $sql .= 'and event_id = :event_id order by date_made ';
         $sql .= $this->buildLimit($resultsperpage, $start);
         $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(array(


### PR DESCRIPTION
We were relying on the database order which looks right if the comments are made in order and we never have to restore from backup or anything - but there are no guarantees so I added the sort order to make it always work this way.
