### PR TITLE
Adds possibility to search events by tags

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -87,6 +87,12 @@ class EventsController extends ApiController {
                     if ($list === false) {
                         throw new Exception('Event not found', 404);
                     }
+                } elseif(isset($request->parameters['tags'])) {
+                    $tags = filter_var($request->parameters['tags'], FILTER_SANITIZE_STRING);
+                    $list  = $mapper->getEventsByTags($tags, $resultsperpage, $start, $verbose);
+                    if ($list === false) {
+                        throw new Exception('Event not found', 404);
+                    }
                 } elseif(isset($request->parameters['stub'])) {
                     $stub = filter_var($request->parameters['stub'], FILTER_SANITIZE_STRING);
                     $list = $mapper->getEventByStub($stub, $verbose);


### PR DESCRIPTION
This PR introduces the possibility to search for events containing at least one of the given tags. The URI would then be `/v2.1/events/?tags=<tag1>,<tag2>,<tag3>`

The value given to the tags-keyword is a comma-separated list of tags. The selected events will have at least one of those keywords.

Implemented is an OR-style tags-selection.
