### PR TITLE
Adds searching events by date

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -87,6 +87,19 @@ class EventsController extends ApiController {
                     if ($list === false) {
                         throw new Exception('Event not found', 404);
                     }
+                } elseif(isset($request->parameters['startdate']) || isset($request->parameters['enddate'])) {
+                    $startdate = time();
+                    $enddate = null;
+                    if (isset($request->parameters['startdate'])) {
+                        $startdate = filter_var($request->parameters['startdate'], FILTER_SANITIZE_STRING);
+                    }
+                    if (isset($request->parameters['enddate'])) {
+                        $enddate = filter_var($request->parameters['enddate'], FILTER_SANITIZE_STRING);
+                    }
+                    $list  = $mapper->getEventsByDate($startdate, $enddate, $resultsperpage, $start, $verbose);
+                    if ($list === false) {
+                        throw new Exception('Event not found', 404);
+                    }
                 } elseif(isset($request->parameters['stub'])) {
                     $stub = filter_var($request->parameters['stub'], FILTER_SANITIZE_STRING);
                     $list = $mapper->getEventByStub($stub, $verbose);


### PR DESCRIPTION
This PR addresses JOINDIN-448 by adding a possibility to search events by date.

Start- and Enddate can be given as UTC-Timestamps or as any timestring recognized by DateTime that will then be converted into an UTC-Timestamp. Don't forget to URL-Escape the '+'-sign in a timestamp-definition by using "%2B".

This search will select events whose begin is within the bounds of start- and endtime. The end of the event is not checked currently.

The starttime is included in the searchresult, the endtime is excluded from the search result. So searching for Endtime of 00:00 Hours will not include events starting at that time.
