### PR TITLE
Add /users/me URI for logged-in users.

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -12,6 +12,16 @@ class UsersController extends ApiController {
 	public function getAction($request, $db) {
         $user_id = $this->getItemId($request);
 
+        // Are we checking the currently-logged-in user?
+        if (!$user_id && !empty($request->url_elements[3]) && $request->url_elements[3] == "me") {
+            if ($request->user_id) {
+                $user_id = $request->user_id;
+            } else {
+                // User isn't signed in
+                throw new Exception("You must be logged in to request your own user record", 400);
+            }
+        }
+
         // verbosity
         $verbose = $this->getVerbosity($request);
 

--- a/tests/frisby/newapi_spec.js
+++ b/tests/frisby/newapi_spec.js
@@ -147,6 +147,13 @@ frisby.create('Non-existent user')
   .expectJSON(["User not found"])
   .toss();
 
+frisby.create('User record without logging in')
+  .get(baseURL + "/v2.1/users/me")
+  .expectStatus(400)
+  .expectHeader("content-type", "application/json; charset=utf8")
+  .expectJSON(["You must be logged in to request your own user record"])
+  .toss();
+
 frisby.create('Existing user')
   .get(baseURL + "/v2.1/users/1")
   .expectStatus(200)


### PR DESCRIPTION
Includes a Frisby test.

There's been discussion previously about this both in IRC and also on [JIRA](https://joindin.jira.com/browse/JOINDIN-349).  In doing some Android work, I still consider that it might be useful to have some sort of "default" user URI (for want of a better term), that is advertised in the docs.

The use case for me at the moment is down to the following workflow:
- Non-logged-in user sees a "My Events" tab on the Android app, alongside "Hot", "Upcoming" and "Past"
- Non-logged-in-user sees a message on this tab, prompting them to log in
- They proceed to the Settings area and log in via OAuth as normal, returning to the Settings area and seeing "You're logged in"
- They press Back on their device, taking them back to My Events
- The app doesn't know who they are, or subsequently their "attended" URI so can't list their events straight away. The user sees an empty tab.

Applying this patch would enable the app to immediately request `/users/me` upon a successful authentication, and get all the user details back (including their "attended" URI), rather than requesting an unrelated API route to find out the current user's URI. Then as the user clicks Back, the app can request details from the "attended" URI.
