### PR TITLE
Add support for content vs speaker rating

### DIFF
--- a/db/patch47.sql
+++ b/db/patch47.sql
@@ -1,0 +1,101 @@
+ALTER TABLE talk_comments CHANGE rating content_rating int(11) DEFAULT NULL;
+ALTER TABLE talk_comments ADD speaker_rating int(11) DEFAULT NULL;
+
+DROP FUNCTION IF EXISTS get_talk_rating;
+DROP FUNCTION IF EXISTS get_talk_content_rating;
+DROP FUNCTION IF EXISTS get_talk_speaker_rating;
+DROP FUNCTION IF EXISTS get_comment_rating;
+
+DELIMITER //
+
+CREATE FUNCTION get_talk_rating(talk_id INT) RETURNS int
+READS SQL DATA
+  BEGIN
+    DECLARE rating_out INT;
+    DECLARE EXIT HANDLER FOR NOT FOUND RETURN NULL;
+
+    SELECT IFNULL(ROUND(AVG((content_rating + COALESCE(speaker_rating, 2.5))/2)), 0) INTO rating_out
+    FROM talk_comments tc
+    WHERE
+      tc.talk_id = talk_id AND
+      tc.content_rating != 0 AND
+      tc.user_id NOT IN
+      (
+        SELECT IFNULL(ts.speaker_id,0) FROM talk_speaker ts WHERE ts.talk_id = talk_id
+        UNION
+        SELECT 0
+      );
+
+    RETURN rating_out;
+  END;
+//
+
+CREATE FUNCTION get_talk_content_rating(talk_id INT) RETURNS int
+READS SQL DATA
+  BEGIN
+    DECLARE rating_out INT;
+    DECLARE EXIT HANDLER FOR NOT FOUND RETURN NULL;
+
+    SELECT IFNULL(ROUND(AVG(content_rating)), 0) INTO rating_out
+    FROM talk_comments tc
+    WHERE
+      tc.talk_id = talk_id AND
+      tc.content_rating != 0 AND
+      tc.user_id NOT IN
+      (
+        SELECT IFNULL(ts.speaker_id,0) FROM talk_speaker ts WHERE ts.talk_id = talk_id
+        UNION
+        SELECT 0
+      );
+
+    RETURN rating_out;
+  END;
+//
+
+CREATE FUNCTION get_talk_speaker_rating(talk_id INT) RETURNS int
+READS SQL DATA
+  BEGIN
+    DECLARE rating_out INT;
+    DECLARE EXIT HANDLER FOR NOT FOUND RETURN NULL;
+
+    SELECT ROUND(AVG(speaker_rating)) INTO rating_out
+    FROM talk_comments tc
+    WHERE
+      tc.talk_id = talk_id AND
+      tc.speaker_rating != 0 AND
+      tc.user_id NOT IN
+      (
+        SELECT IFNULL(ts.speaker_id,0) FROM talk_speaker ts WHERE ts.talk_id = talk_id
+        UNION
+        SELECT 0
+      );
+
+    RETURN rating_out;
+  END;
+//
+
+CREATE FUNCTION get_comment_rating(talk_id INT, comment_id INT) RETURNS int
+READS SQL DATA
+  BEGIN
+    DECLARE rating_out INT;
+    DECLARE EXIT HANDLER FOR NOT FOUND RETURN 0;
+
+    SELECT COALESCE(ROUND((content_rating + COALESCE(speaker_rating, content_rating))/2), 0) INTO rating_out
+    FROM talk_comments tc
+    WHERE
+      tc.id = comment_id AND
+      tc.content_rating != 0 AND
+      tc.user_id NOT IN
+      (
+        SELECT COALESCE(ts.speaker_id, -1) FROM talk_speaker ts WHERE ts.talk_id = talk_id
+      );
+
+    RETURN rating_out;
+  END;
+//
+DELIMITER ;
+
+# SELECT get_talk_rating(13), get_talk_rating(4), get_talk_rating(96), get_talk_rating(186), get_talk_rating(146), get_talk_rating(180), get_talk_rating(114), get_talk_rating(26), get_talk_rating(125), get_talk_rating(91), get_talk_rating(22), get_talk_rating(150);
+# SELECT get_comment_rating(1), get_comment_rating(44), get_comment_rating(179);
+
+INSERT INTO patch_history SET patch_number = 47;

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -65,9 +65,16 @@ class TalksController extends ApiController {
                         throw new Exception('The field "comment" is required', 400);
                     }
 
-                    $rating = $request->getParameter('rating');
-                    if(empty($rating)) {
-                        throw new Exception('The field "rating" is required', 400);
+                    $content_rating = $request->getParameter('content_rating');
+                    $speaker_rating = $request->getParameter('speaker_rating');
+
+                    if (empty($content_rating)) {
+                        $rating = $request->getParameter('rating');
+                        if(empty($rating)) { // BC
+                            throw new Exception('The field "content_rating" (or "rating") is required.', 400);
+                        }
+                    } elseif (empty($speaker_rating)) {
+                        throw new Exception('The field "speaker_rating" is required.', 400);
                     }
 
                     $private = ($request->getParameter('private') ? 1 : 0);
@@ -80,7 +87,9 @@ class TalksController extends ApiController {
                     $data['user_id'] = $request->user_id;
                     $data['talk_id'] = $talk_id;
                     $data['comment'] = $comment;
-                    $data['rating'] = $rating;
+                    $data['content_rating'] = $content_rating;
+                    $data['speaker_rating'] = $speaker_rating;
+                    $data['rating'] = $rating; // BC
                     $data['private'] = $private;
                     $data['source'] = $consumer_name;
 

--- a/src/models/TalkCommentMapper.php
+++ b/src/models/TalkCommentMapper.php
@@ -3,6 +3,8 @@
 class TalkCommentMapper extends ApiMapper {
     public function getDefaultFields() {
         $fields = array(
+            'content_rating' => 'content_rating',
+            'speaker_rating' => 'speaker_rating',
             'rating' => 'rating',
             'comment' => 'comment',
             'user_display_name' => 'full_name',
@@ -14,6 +16,8 @@ class TalkCommentMapper extends ApiMapper {
 
     public function getVerboseFields() {
         $fields = array(
+            'content_rating' => 'content_rating',
+            'speaker_rating' => 'speaker_rating',
             'rating' => 'rating',
             'comment' => 'comment',
             'user_display_name' => 'full_name',
@@ -108,7 +112,7 @@ class TalkCommentMapper extends ApiMapper {
     }
 
     protected function getBasicSQL() {
-        $sql = 'select tc.*, user.full_name, t.talk_title, e.event_tz_cont, e.event_tz_place '
+        $sql = 'select tc.*, get_comment_rating(t.ID, tc.id) AS rating, user.full_name, t.talk_title, e.event_tz_cont, e.event_tz_place '
             . 'from talk_comments tc '
             . 'inner join talks t on t.ID = tc.talk_id '
             . 'inner join events e on t.event_id = e.ID '
@@ -119,15 +123,16 @@ class TalkCommentMapper extends ApiMapper {
     }
 
     public function save($data) {
-        $sql = 'insert into talk_comments (talk_id, rating, comment, user_id, '
+        $sql = 'insert into talk_comments (talk_id, content_rating, speaker_rating, comment, user_id, '
             . 'source, date_made, private, active) '
-            . 'values (:talk_id, :rating, :comment, :user_id, :source, UNIX_TIMESTAMP(), '
+            . 'values (:talk_id, :content_rating, :speaker_rating, :comment, :user_id, :source, UNIX_TIMESTAMP(), '
             . ':private, 1)';
 
         $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(array(
             ':talk_id' => $data['talk_id'],
-            ':rating' => $data['rating'],
+            ':content_rating' => (isset($data['content_rating'])) ? $data['content_rating'] : $data['rating'],
+            ':speaker_rating' => (isset($data['speaker_rating'])) ? $data['speaker_rating'] : null,
             ':comment' => $data['comment'],
             ':user_id' => $data['user_id'],
             ':private' => $data['private'],

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -31,6 +31,8 @@ class TalkMapper extends ApiMapper {
 			'duration' => 'duration',
             'stub' => 'stub',
             'average_rating' => 'avg_rating',
+            'average_content_rating' => 'avg_content_rating',
+            'average_speaker_rating' => 'avg_speaker_rating',
             'comments_enabled' => 'comments_enabled',
             'comment_count' => 'comment_count',
             'starred' => 'starred',
@@ -167,6 +169,8 @@ class TalkMapper extends ApiMapper {
         $sql = 'select t.*, l.lang_name, e.event_tz_place, e.event_tz_cont, '
             . '(select COUNT(ID) from talk_comments tc where tc.talk_id = t.ID) as comment_count, '
             . '(select get_talk_rating(t.ID)) as avg_rating, '
+            . '(select get_talk_content_rating(t.ID)) as avg_content_rating, '
+            . '(select get_talk_speaker_rating(t.ID)) as avg_speaker_rating, '
             . '(select count(*) from user_talk_star where user_talk_star.tid = t.ID)
                 as starred_count, '
             . 'CASE


### PR DESCRIPTION
Should be 100% BC, allowing `rating` instead of the separate fields. If you submit `content_rating` then you must also submit `speaker_rating`.

Responses should also be BC.

**Note:** This PR has a new DB migration.

Exposed via the UI in joindin/joindin-web2#112
Updates to joind.in site to handle schema changes here: joindin/joind.in#798
