### PR TITLE
Fix "source" column length for comments.

### DIFF
--- a/db/patch47.sql
+++ b/db/patch47.sql
@@ -3,3 +3,5 @@
 
 ALTER TABLE `event_comments` CHANGE `source` `source` VARCHAR(255);
 ALTER TABLE `talk_comments` CHANGE `source` `source` VARCHAR(255);
+
+INSERT INTO patch_history SET patch_number = 47;


### PR DESCRIPTION
It now matches the length of the data potentially being inserted into it - from the `application` column in the `oauth_consumers`.

Locally this threw a MySQL error for me, so any comments that had a source longer than 25 chars never got inserted.
