### PR TITLE
#457: Event submit crashes when CFP Start/End is given

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -265,14 +265,14 @@ class EventsController extends ApiController {
             if($cfp_url) {
                 $event['cfp_url'] = $cfp_url;
             }
-            
-            $cfp_start_date = strtotime($request->getParameter("cfp_start_date"));
+
+            $cfp_start_date = date_create($request->getParameter("cfp_start_date"));
             if($cfp_start_date) {
-                $event['cfp_start_date'] = new DateTime($request->getParameter("cfp_start_date"), $tz);
+                $event['cfp_start_date'] = $cfp_start_date->format('U');
             }
-            $cfp_end_date = strtotime($request->getParameter("cfp_end_date"));
+            $cfp_end_date = date_create($request->getParameter("cfp_end_date"));
             if($cfp_end_date) {
-                $event['cfp_end_date'] = new DateTime($request->getParameter("cfp_end_date"), $tz);
+                $event['cfp_end_date'] = $cfp_end_date->format('U');
             }
 
             // How does it look?  With no errors, we can proceed


### PR DESCRIPTION
In this commit we fix a fatal error that occurs if a CFP start or end
date is given. The start and end date are converted to DateTime objects
but never back into strings before it is inserted in the database.

In addition the the CFP start and end date were not added onto the INSERT
query as prepared statements; causing the actual insert to fail as well.

Both issues are resolved with this commit.
