### PR TITLE
Added url_friendly_talk_title to talk comments [JOINDIN-216]

### DIFF
--- a/src/models/TalkCommentMapper.php
+++ b/src/models/TalkCommentMapper.php
@@ -18,6 +18,7 @@ class TalkCommentMapper extends ApiMapper {
             'comment' => 'comment',
             'user_display_name' => 'full_name',
             'talk_title' => 'talk_title',
+            'url_friendly_talk_title' => 'url_friendly_talk_title',
             'source' => 'source',
             'created_date' => 'date_made'
             );
@@ -114,7 +115,7 @@ class TalkCommentMapper extends ApiMapper {
     }
 
     protected function getBasicSQL() {
-        $sql = 'select tc.*, user.full_name, t.talk_title, e.event_tz_cont, e.event_tz_place '
+        $sql = 'select tc.*, user.full_name, t.talk_title, t.url_friendly_talk_title, e.event_tz_cont, e.event_tz_place '
             . 'from talk_comments tc '
             . 'inner join talks t on t.ID = tc.talk_id '
             . 'inner join events e on t.event_id = e.ID '


### PR DESCRIPTION
Related to issue: https://joindin.jira.com/browse/JOINDIN-216

Added url_friendly_talk_title i.e. slug to talk comment verbose response.
This is needed to create a link to each talk when listing events all talk comments.
It is possible to get the talk slug from redis in web2, but it gets a bit ugly (have to fetch the talk if not found in cache, have to keep the slugs separate from the comments since we probably don't want to set it in the comment entity etc.). So if we have this already in the API response, it makes the code much cleaner on the web2 side.
