### PR TITLE
Feature/controllers 404

### DIFF
--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -6,8 +6,11 @@ abstract class ApiController {
     /**
      * Handles a Request to this controller
      *
-     * @param Request $request
-     * @param mixed $db
+     * @param Request $request  The Request to respond to
+     * @param mixed $db         The PDO object
+     *
+     * @return mixed        The response to the handled Request. This is passed
+     *                      from the Router to a View object for rendering.
      *
      * @throws Exception    If a Request cannot be handled, an Exception is
      *                      thrown to respond accordingly. The Exception should

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -3,6 +3,16 @@
 abstract class ApiController {
     protected $config;
 
+    /**
+     * Handles a Request to this controller
+     *
+     * @param Request $request
+     * @param mixed $db
+     *
+     * @throws Exception    If a Request cannot be handled, an Exception is
+     *                      thrown to respond accordingly. The Exception should
+     *                      carry the HTTP status code as appropriate
+     */
 	abstract public function handle(Request $request, $db);
 
     public function __construct($config = null) {

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -1,7 +1,11 @@
 <?php
 
 class DefaultController extends ApiController {
-	public function handle(Request $request, $db) {
+	
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Request $request, $db) {
         $retval = array();
 
         // just add the available methods, with links

--- a/src/controllers/Event_commentsController.php
+++ b/src/controllers/Event_commentsController.php
@@ -1,12 +1,16 @@
 <?php
 
 class Event_commentsController extends ApiController {
+
+    /**
+     * {@inheritdoc}
+     */
     public function handle(Request $request, $db) {
         // only GET is implemented so far
         if($request->getVerb() == 'GET') {
             return $this->getAction($request, $db);
         }
-        return false;
+        throw new Exception('Endpoint not found', 404);
     }
 
 	public function getAction($request, $db) {

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -1,6 +1,10 @@
 <?php
 
 class EventsController extends ApiController {
+    
+    /**
+     * {@inheritdoc}
+     */
     public function handle(Request $request, $db) {
         // only GET is implemented so far
         if($request->getVerb() == 'GET') {
@@ -12,7 +16,8 @@ class EventsController extends ApiController {
         } elseif ($request->getVerb() == 'PUT') {
             return $this->putAction($request, $db);
         }
-        return false;
+
+        throw new Exception('Endpoint not found', 404);
     }
 
 	public function getAction($request, $db) {

--- a/src/controllers/Talk_commentsController.php
+++ b/src/controllers/Talk_commentsController.php
@@ -1,12 +1,16 @@
 <?php
 
 class Talk_commentsController extends ApiController {
+
+    /**
+     * {@inheritdoc}
+     */
     public function handle(Request $request, $db) {
         // only GET is implemented so far
         if($request->getVerb() == 'GET') {
             return $this->getAction($request, $db);
         }
-        return false;
+        throw new Exception('Endpoint not found', 404);
     }
 
 	public function getAction($request, $db) {

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -1,6 +1,10 @@
 <?php
 
 class TalksController extends ApiController {
+
+    /**
+     * {@inheritdoc}
+     */
     public function handle(Request $request, $db) {
         if($request->getVerb() == 'GET') {
             return $this->getAction($request, $db);
@@ -9,9 +13,8 @@ class TalksController extends ApiController {
         } elseif ($request->getVerb() == 'DELETE') {
             return $this->deleteAction($request, $db);
         } else {
-            throw new Exception("method not supported");
+            throw new Exception("method not supported", 415);
         }
-        return false;
     }
 
 	protected function getAction($request, $db) {

--- a/src/controllers/TokenController.php
+++ b/src/controllers/TokenController.php
@@ -4,6 +4,9 @@ class TokenController extends ApiController
 {
     protected $oauthModel;
 
+    /**
+     * {@inheritdoc}
+     */
     public function handle(Request $request, $db)
     {
         $this->oauthModel = $request->getOauthModel($db);
@@ -13,7 +16,7 @@ class TokenController extends ApiController
             return $this->postAction($request, $db);
         }
         
-        return false;
+        throw new Exception('Endpoint not found', 404);
     }
 
     public function postAction($request, $db)

--- a/src/controllers/TracksController.php
+++ b/src/controllers/TracksController.php
@@ -2,6 +2,10 @@
 
 class TracksController extends ApiController
 {
+
+    /**
+     * {@inheritdoc}
+     */
     public function handle(Request $request, $db) {
         if ($request->getVerb() == 'GET') {
             return $this->getAction($request, $db);
@@ -9,7 +13,7 @@ class TracksController extends ApiController
             throw new Exception("method not supported");
         }
 
-        return false;
+        throw new Exception('Endpoint not found', 404);
     }
 
     protected function getAction($request, $db) {

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1,12 +1,17 @@
 <?php
 
 class UsersController extends ApiController {
+
+    /**
+     * {@inheritdoc}
+     */
     public function handle(Request $request, $db) {
         // only GET is implemented so far
         if($request->getVerb() == 'GET') {
             return $this->getAction($request, $db);
         }
-        return false;
+        
+        throw new Exception('Endpoint not found', 404);
     }
 
 	public function getAction($request, $db) {

--- a/src/views/JsonView.php
+++ b/src/views/JsonView.php
@@ -25,6 +25,9 @@ class JsonView extends ApiView {
 
     protected function numeric_check($data)
     {
+        if (!is_array($data)) {
+            return $this->scalarNumericCheck('', $data);
+        }
         $output = array();
         foreach($data as $key => $value) {
             
@@ -32,15 +35,18 @@ class JsonView extends ApiView {
             if(is_array($value)) {
                 $output[$key] = $this->numeric_check($value);
             } else {
-
-                if(is_numeric($value) && !in_array($key, $this->string_fields)) {
-                    $output[$key] = (float)$value;
-                } else {
-                    $output[$key] = $value;
-                }
+                $output[$key] = $this->scalarNumericCheck($key, $value);
             }
         }
         return $output;
+    }
+
+    protected function scalarNumericCheck($key, $value)
+    {
+        if (is_numeric($value) && !in_array($key, $this->string_fields)) {
+            return (float)$value;
+        }
+        return $value;
     }
 
 }

--- a/tests/views/JsonViewTest.php
+++ b/tests/views/JsonViewTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @covers JsonView
+ */
+class JsonViewTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * DataProvider for testBuildOutput
+     *
+     * @return array
+     */
+    public function buildOutputProvider()
+    {
+        return array(
+            array( // #0
+                'input' => array('a' => 'b', 'c' => 10),
+                'expected' => '{"a":"b","c":10}'
+            ),
+            array( // #1
+                'input' => array('stub' => '10', 'b' => array('c', 'd')),
+                'expected' => '{"stub":"10","b":["c","d"],"meta":{"count":2}}'
+            ),
+            array( // #2 - JOINDIN-519
+                'input' => false,
+                'expected' => 'false'
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider buildOutputProvider
+     *
+     * @covers JsonView::buildOutput
+     *
+     * @param mixed $input
+     * @param string $expected
+     */
+    public function testBuildOutput($input, $expected)
+    {
+        $view = new JsonView();
+        $this->assertEquals($expected, $view->buildOutput($input));
+    }
+}


### PR DESCRIPTION
As part of JOINDIN-519, @akrabat asked whether a Controller's handle() method should return false (as per existing behavior) or throw an Exception to represent a 404.

It is my view that ```false``` is a valid response from ApiController::handle (not that I can supply a proper use case) and so to use it to signal a 404 is potentially confusing. Exception throwing will be a lot more extensible, and the mechanism will also be the fastest way to stop processing a Request and move into the app's error handling logic.

Going forward, this will probably become a moot point when a Router is created with explicit routing rules (rather than using the ```handle()``` mechanism) as has been discussed with @lornajane.