### PR TITLE
Accept Bearer in Auth token, but don't break BC

### DIFF
--- a/src/inc/Request.php
+++ b/src/inc/Request.php
@@ -330,7 +330,8 @@ class Request
             if (count($oauth_pieces) <> 2) {
                 throw new InvalidArgumentException('Invalid Authorization Header', '400');
             }
-            if (strtolower($oauth_pieces[0]) != "oauth") {
+            if (strtolower($oauth_pieces[0]) != "bearer"
+                || strtolower($oauth_pieces[0]) != "oauth") {
                 throw new InvalidArgumentException('Unknown Authorization Header Received', '400');
             }
             $oauth_model   = $this->getOauthModel($db);


### PR DESCRIPTION
The Authorization header should be "Authorization: Bearer token" but it
was incorrectly implemented as "Authorization: OAuth token".  Code
now accepts either.