### PR TITLE
Update instructions on how to run frisby tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ You should set the URL that the tests run against to be your local installation:
 
         export JOINDIN_API_BASE_URL=http://api.joindin.localhost
 
-Then run the tests by going to `/src/tests/api_tests` and running:
+Then run the tests by going to `/tests/frisby` and running:
 
-        jasmine-node newapi_spec.js
+        jasmine-node api_spec.js
 
 ### Unit Tests
 


### PR DESCRIPTION
The frisby tests are in `/test/frisby` and the file is called `api_spec.js` - looks like the README got missed when things moved around.