### PR TITLE
Add icon_url into event output

### DIFF
--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -32,6 +32,7 @@ class EventMapper extends ApiMapper
             'tracks_count' => 'track_count',
             'talks_count' => 'talk_count',
             'icon' => 'event_icon',
+            'icon_url' => 'event_icon',
             'location' => 'event_loc'
             );
         return $fields;
@@ -55,6 +56,7 @@ class EventMapper extends ApiMapper
             'stub' => 'event_stub',
             'href' => 'event_href',
             'icon' => 'event_icon',
+            'icon_url' => 'event_icon',
             'latitude' => 'event_lat',
             'longitude' => 'event_long',
             'tz_continent' => 'event_tz_cont',
@@ -368,6 +370,11 @@ class EventMapper extends ApiMapper
                 }
                 $list[$key]['attendees_uri'] = $base . '/' . $version . '/events/' 
                     . $row['ID'] . '/attendees';
+
+                // Prefix the icon filename for the full URL
+                if (strlen($list[$key]['icon']) > 0) {
+                    $list[$key]['icon_url'] = 'https://joind.in/inc/img/event_icons/' . $list[$key]['icon_url'];
+                }
             }
         }
         $retval = array();

--- a/tests/frisby/data.js
+++ b/tests/frisby/data.js
@@ -36,6 +36,7 @@ function checkEventData(ev) {
 	expect(ev.description).toBeDefined();
 	expect(ev.href).toBeDefined();
 	expect(ev.icon).toBeDefined();
+	expect(ev.icon_url).toBeDefined();
 	expect(ev.attendee_count).toBeDefined();
 	expect(ev.uri).toBeDefined();
 	expect(ev.verbose_uri).toBeDefined();
@@ -67,6 +68,7 @@ function checkVerboseEventData(evt) {
   expect(evt.description).toBeDefined();
   expect(evt.href).toBeDefined();
   expect(evt.icon).toBeDefined();
+  expect(evt.icon_url).toBeDefined();
   expect(evt.latitude).toBeDefined();
   expect(evt.longitude).toBeDefined();
   expect(evt.tz_continent).toBeDefined();


### PR DESCRIPTION
This adds the full URL to the event's icon filename, if there is one (field is blank otherwise) - saves any clients having to know what to prefix to the icon filename.This adds the full URL to the event's icon filename, if there is one (field is blank otherwise) - saves any clients having to know what to prefix to the icon filename themselves, and allows moving of assets at a later date if required.