### PR TITLE
Enable dispatching to TalksController::postAction

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -56,7 +56,7 @@ class TalksController extends ApiController {
         return $list;
 	}
 
-    protected function postAction($request, $db) {
+    public function postAction($request, $db) {
         if(!isset($request->user_id)) {
             throw new Exception("You must be logged in to create data", 400);
         }

--- a/src/controllers/TracksController.php
+++ b/src/controllers/TracksController.php
@@ -12,7 +12,7 @@ class TracksController extends ApiController
         return false;
     }
 
-    protected function getAction($request, $db) {
+    public function getAction($request, $db) {
         $track_id = $this->getItemId($request);
 
         // verbosity


### PR DESCRIPTION
Now that dispatching is an external operation, postAction needs to be public.

Fixes JOINDIN-536.