### PR TITLE
Add routing for resending verification emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ To run the tests on your computer against your Vagrant VM, from the `tests/frisb
 
         npm test
 
+We also have a set of "destructive" tests, these create, edit and delete data as well as just reading it.  These aren't safe to run on a live platform, but are very valuable in testing.  Before you run them, you will need to run this query against your database:
+
+        insert into oauth_consumers (consumer_key, consumer_secret, user_id, enable_password_grant) values ('0000', '1111', '1', '1');
+
+Then run:
+
+        npm test_write
+
 ### Unit Tests
 
 There are some tests set up, which use PHPUnit; these can be found in the

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -84,6 +84,14 @@
         "action": "handle",
         "verbs": ["GET"]
     },
+
+    {
+        "path": "/emails/verifications",
+        "controller": "EmailsController",
+        "action": "verifications",
+        "verbs": ["POST"]
+    },
+
     {
         "path": "/?$",
         "controller": "DefaultController",

--- a/src/controllers/EmailsController.php
+++ b/src/controllers/EmailsController.php
@@ -6,45 +6,30 @@
 
 class EmailsController extends ApiController {
     public function handle(Request $request, $db) {
-        if ($request->getVerb() == 'POST') {
-            return $this->postAction($request, $db);
-        }
-        return false;
+        // really need to not require this to be declared
     }
 
-    public function postAction($request, $db){
-        if(isset($request->url_elements[3])) {
-            switch($request->url_elements[3]) {
-                case 'verifications':
-                            $user_mapper= new UserMapper($db, $request);
-                            $email = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
-                            if(empty($email)) {
-                                throw new Exception("The email address must be supplied", 400);
-                            } else {
-                                // need the user's ID rather than the representation
-                                $user_id = $user_mapper->getUserIdFromEmail($email);
-                                if($user_id) {
-
-                                    // Generate a verification token and email it to the user
-                                    $token = $user_mapper->generateEmailVerificationTokenForUserId($user_id);
-
-                                    $recipients = array($email);
-                                    $emailService = new UserRegistrationEmailService($this->config, $recipients, $token);
-                                    $emailService->sendEmail();
-
-                                    header("Content-Length: 0", NULL, 202);
-                                    exit;
-                                }
-                                throw new Exception("Can't find that email address", 400);
-                            }
-                            break;
-                default:
-                            throw new InvalidArgumentException('Unknown Subrequest', 404);
-                            break;
-            }
+    public function verifications($request, $db){
+        $user_mapper= new UserMapper($db, $request);
+        $email = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
+        if(empty($email)) {
+            throw new Exception("The email address must be supplied", 400);
         } else {
-            throw new InvalidArgumentException('Unknown Request', 404);
-            break;
+            // need the user's ID rather than the representation
+            $user_id = $user_mapper->getUserIdFromEmail($email);
+            if($user_id) {
+
+                // Generate a verification token and email it to the user
+                $token = $user_mapper->generateEmailVerificationTokenForUserId($user_id);
+
+                $recipients = array($email);
+                $emailService = new UserRegistrationEmailService($this->config, $recipients, $token);
+                $emailService->sendEmail();
+
+                header("Content-Length: 0", NULL, 202);
+                exit;
+            }
+            throw new Exception("Can't find that email address", 400);
         }
     }
 }

--- a/tests/frisby/api_write.js
+++ b/tests/frisby/api_write.js
@@ -19,12 +19,13 @@ function testRegisterUser() {
 	var randomSuffix = parseInt(Math.random() * 1000000).toString();
   var username = "testUser" + randomSuffix;
   var password = "pwpwpwpwpwpw";
+  var email = "testuser"+randomSuffix+"@example.com";
 	frisby.create('Register user')
 		.post(baseURL + "/v2.1/users", {
 			"username"  : username,
 			"password"  : password,
 			"full_name" : "A test user",
-			"email"     : "testuser"+randomSuffix+"@example.com"
+			"email"     : email
 		}, {json:true})
 		.expectStatus(201)
 		.expectHeaderContains("Location", baseURL + "/v2.1/users")
@@ -33,6 +34,8 @@ function testRegisterUser() {
         // Call the get user method on the place we're told to go
         testUserByUrl(res.headers.location);
         testUnverifiedUserFailsLogin(username, password);
+        testResendVerificationWorks(email);
+        testResendVerificationFails("doesntexist@lornajane.net");
       }
 		})
 	.toss();
@@ -105,6 +108,24 @@ function testUserLogin(username, password) {
         expect(typeof data.user_uri).toBe('string');
       }
     })
+    .toss();
+}
+
+function testResendVerificationWorks(email) {
+  frisby.create('Resend verification')
+    .post(baseURL + "/v2.1/emails/verifications", {
+      "email": email
+    }, {json:true})
+    .expectStatus(202)
+    .toss();
+}
+
+function testResendVerificationFails(email) {
+  frisby.create('Resend verification')
+    .post(baseURL + "/v2.1/emails/verifications", {
+      "email": email
+    }, {json:true})
+    .expectStatus(400)
     .toss();
 }
 


### PR DESCRIPTION
We had broken this in the routing rewrite, this reinstates it with a new way of naming controller actions and also includes tests.