### PR TITLE
Useful administrative flags on the user record

### DIFF
--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -164,8 +164,19 @@ class UserMapper extends ApiMapper
             }
 
             foreach ($results as $key => $row) {
+                // can the logged in user edit this user?
+                $canEdit = false;
+                if ($userIsSiteAdmin || $row['ID'] == $this->_request->user_id) {
+                    $canEdit = true;
+                }
+                
                 if (true === $verbose) {
                     $list[$key]['gravatar_hash'] = md5(strtolower($row['email']));
+
+                    // if this record can be edited, then expose the email address
+                    if ($canEdit) {
+                        $list[$key]['email'] = $row['email'];
+                    }
 
                     // expose the admin field if the currently logged in user is a site admin
                     if ($userIsSiteAdmin) {
@@ -187,11 +198,6 @@ class UserMapper extends ApiMapper
                     . $row['ID'] . '/talk_comments/';
                 
                 if ($verbose && isset($this->_request->user_id)) {
-                    // can the logged in user edit this user?
-                    $canEdit = false;
-                    if ($userIsSiteAdmin || $row['ID'] == $this->_request->user_id) {
-                        $canEdit = true;
-                    }
                     $list[$key]['can_edit'] = $canEdit;
                 }
             }

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -157,9 +157,20 @@ class UserMapper extends ApiMapper
 
         // add per-item links 
         if(is_array($list) && count($list)) {
+            $userIsSiteAdmin = false;
+            if (isset($this->_request->user_id)
+                && $this->isSiteAdmin($this->_request->user_id)) {
+                $userIsSiteAdmin = true;
+            }
+
             foreach ($results as $key => $row) {
                 if (true === $verbose) {
                     $list[$key]['gravatar_hash'] = md5(strtolower($row['email']));
+
+                    // expose the admin field if the currently logged in user is a site admin
+                    if ($userIsSiteAdmin) {
+                        $list[$key]['admin'] = $row['admin'];
+                    }
                 }
                 $list[$key]['uri'] = $base . '/' . $version . '/users/' 
                     . $row['ID'];

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -158,8 +158,7 @@ class UserMapper extends ApiMapper
         // add per-item links 
         if(is_array($list) && count($list)) {
             $userIsSiteAdmin = false;
-            if (isset($this->_request->user_id)
-                && $this->isSiteAdmin($this->_request->user_id)) {
+            if ($this->isSiteAdmin($this->_request->user_id)) {
                 $userIsSiteAdmin = true;
             }
 

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -185,6 +185,15 @@ class UserMapper extends ApiMapper
                     . $row['ID'] . '/hosted/';
                 $list[$key]['talk_comments_uri'] = $base . '/' . $version . '/users/'
                     . $row['ID'] . '/talk_comments/';
+                
+                if ($verbose && isset($this->_request->user_id)) {
+                    // can the logged in user edit this user?
+                    $canEdit = false;
+                    if ($userIsSiteAdmin || $row['ID'] == $this->_request->user_id) {
+                        $canEdit = true;
+                    }
+                    $list[$key]['can_edit'] = $canEdit;
+                }
             }
         }
         $retval = array();


### PR DESCRIPTION
Add `can_edit` to the user record if the logged in user is a site admin or this is the current user's record.
Also expose the `admin` field for every user to site admins only.
Both fields are only available if a user is logged in.
