### PR TITLE
Use local methods in OAuthModel::getUserUri()

### DIFF
--- a/src/models/OAuthModel.php
+++ b/src/models/OAuthModel.php
@@ -143,7 +143,7 @@ class OAuthModel
      * @return string         user's uri.
      */
     public function getUserUri($userId) {
-        $userUri = $this->base . '/' . $this->version . '/users/' . $userId;
+        $userUri = $this->getBase() . '/' . $this->getVersion() . '/users/' . $userId;
 
         return $userUri;
     }


### PR DESCRIPTION
This is a result of two different PRs changing the same logic in different places and I missed that the new getUserUri() method didn't use the also new get methods.