### PR TITLE
Allow getParameter to detect a parameter set to NULL

### DIFF
--- a/src/inc/Request.php
+++ b/src/inc/Request.php
@@ -193,7 +193,7 @@ class Request
     public function getParameter($param, $default = '')
     {
         $value = $default;
-        if (isset($this->parameters[$param])) {
+        if (array_key_exists($param, $this->parameters)) {
             $value = $this->parameters[$param];
         }
 


### PR DESCRIPTION
If the data sent into the api contains a valid key that is set to null, then the Request's getParameter method cannot detect this due to the use of isset(). This PR fixes this and is required in order to allow web2's edit profile to clear the Twitter username without having to resort to a cast to string before sending to the API.