### PR TITLE
Only allow each user to rate a talk once

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -106,6 +106,11 @@ class TalksController extends ApiController {
                             }
                         }
 
+                        // should rating be allowed?
+                        if ($comment_mapper->hasUserRatedThisTalk($data['user_id'], $data['talk_id'])) {
+                            $data['rating'] = 0;
+                        }
+
                         $new_id = $comment_mapper->save($data);
                     } catch (Exception $e) {
                         // just throw this again but with a 400 status code

--- a/src/models/TalkCommentMapper.php
+++ b/src/models/TalkCommentMapper.php
@@ -185,4 +185,28 @@ class TalkCommentMapper extends ApiMapper {
 
         return $comment_id;
     }
+
+    /**
+     * Has this user provided a rating for this talk which is greater than zero?
+     *
+     * @param  integer  $user_id
+     * @param  integer  $talk_id
+     * @return boolean
+     */
+    public function hasUserRatedThisTalk($user_id, $talk_id)
+    {
+        $sql = 'select ID from talk_comments '
+            . 'where talk_id = :talk_id and user_id = :user_id and rating > 0';
+
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute(array(
+            ':talk_id' => $talk_id,
+            ':user_id' => $user_id,
+        ));
+
+        if ($stmt->fetch()) {
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
This is the sister PR to the one that prevents a user from rating an event twice. Note that we still need to stop hosts & speakers from rating their own events or talks, but that's a different issue to this one.