### PR TITLE
Add API endpoints for forgot password

### DIFF
--- a/db/patch56.sql
+++ b/db/patch56.sql
@@ -1,0 +1,9 @@
+-- store password reset tokens
+
+CREATE TABLE password_reset_tokens (
+      ID int(11) NOT NULL primary key auto_increment,
+      user_id int(11) NOT NULL,
+      token varchar(255) NOT NULL,
+      created_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP);
+
+INSERT INTO patch_history SET patch_number = 56;

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -113,6 +113,13 @@
     },
 
     {
+        "path": "/emails/reminders/password",
+        "controller": "EmailsController",
+        "action": "passwordReset",
+        "verbs": ["POST"]
+    },
+
+    {
         "path": "/?$",
         "controller": "DefaultController",
         "action": "handle"

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -64,6 +64,13 @@
     },
 
     {
+        "path": "/users/passwords$",
+        "controller": "UsersController",
+        "action": "passwordReset",
+        "verbs": ["POST"]
+    },
+
+    {
         "path": "/users(/[^/]+)*/?$",
         "controller": "UsersController",
         "action": "getAction",

--- a/src/controllers/EmailsController.php
+++ b/src/controllers/EmailsController.php
@@ -54,4 +54,31 @@ class EmailsController extends ApiController {
         }
     }
 
+    public function passwordReset($request, $db) {
+        $user_mapper= new UserMapper($db, $request);
+        $username = filter_var($request->getParameter("username"), FILTER_SANITIZE_STRING);
+        if(empty($username)) {
+            throw new Exception("A username must be supplied", 400);
+        } else {
+            $list = $user_mapper->getUserByUsername($username);
+            if(is_array($list['users']) && count($list['users'])) {
+                $user = $list['users'][0];
+
+                $user_id = $user_mapper->getUserIdFromUsername($username);
+                $email = $user_mapper->getEmailByUserId($user_id);
+                $recipients = array($email);
+
+                // we need a token to send so we know it is a valid reset
+                $token = $user_mapper->generatePasswordResetTokenForUserId($user_id);
+
+                $emailService = new UserPasswordResetEmailService($this->config, $recipients, $user, $token);
+                $emailService->sendEmail();
+
+                header("Content-Length: 0", NULL, 202);
+                exit;
+            }
+            throw new Exception("Can't find that user", 400);
+        }
+    }
+
 }

--- a/src/controllers/EmailsController.php
+++ b/src/controllers/EmailsController.php
@@ -64,6 +64,7 @@ class EmailsController extends ApiController {
             if(is_array($list['users']) && count($list['users'])) {
                 $user = $list['users'][0];
 
+                // neither user_id nor email are in the user resource returned by the mapper
                 $user_id = $user_mapper->getUserIdFromUsername($username);
                 $email = $user_mapper->getEmailByUserId($user_id);
                 $recipients = array($email);

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -267,4 +267,26 @@ class UsersController extends ApiController {
         }
         throw new Exception("Could not update user", 400);
     }
+
+    public function passwordReset(Request $request, $db)
+    {
+        $token = filter_var($request->getParameter("token"), FILTER_SANITIZE_STRING);
+        if(empty($token)) {
+            throw new Exception("Reset token must be supplied", 400);
+        }
+
+        $password = $request->getParameter("password");
+        if(empty($password)) {
+            throw new Exception("New password must be supplied", 400);
+        }
+
+        $user_mapper = new UserMapper($db, $request);
+        $success = $user_mapper->resetPassword($token, $password);
+        if($success) {
+            header("Content-Length: 0", NULL, 204);
+            exit; // no more content
+        } else {
+            throw new Exception("Verification failed", 400);
+        }
+    }
 }

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -279,14 +279,22 @@ class UsersController extends ApiController {
         if(empty($password)) {
             throw new Exception("New password must be supplied", 400);
         }
-
-        $user_mapper = new UserMapper($db, $request);
-        $success = $user_mapper->resetPassword($token, $password);
-        if($success) {
-            header("Content-Length: 0", NULL, 204);
-            exit; // no more content
+        // now check the password complies with our rules
+        $validity = $user_mapper->checkPasswordValidity($password);
+        if(true === $validity) {
+            // OK, go ahead
+            $user_mapper = new UserMapper($db, $request);
+            $success = $user_mapper->resetPassword($token, $password);
+            if($success) {
+                header("Content-Length: 0", NULL, 204);
+                exit; // no more content
+            } else {
+                throw new Exception("Password could not be reset", 400);
+            }
         } else {
-            throw new Exception("Verification failed", 400);
+            // the password wasn't acceptable, tell the user why
+            throw new Exception(implode(". ", $validity), 400);
         }
+
     }
 }

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -568,8 +568,7 @@ class UserMapper extends ApiMapper
             . "where token = :token";
 
         $select_stmt = $this->_db->prepare($select_sql);
-        $data = array(
-            "token" => $token);
+        $data = array("token" => $token);
 
         $response = $select_stmt->execute($data);
         if($response) {
@@ -585,17 +584,19 @@ class UserMapper extends ApiMapper
                 $update_data = array(
                     "password" => password_hash(md5($password), PASSWORD_DEFAULT),
                     "user_id"  => $user_id);
-                $update_stmt->execute($update_data);
+                $update_response = $update_stmt->execute($update_data);
 
-                // delete all the user's tokens; they don't need them now
-                $delete_sql = "delete from password_reset_tokens "
-                    . "where user_id = :user_id";
+                if($update_response) {
+                    // delete all the user's tokens; they don't need them now
+                    $delete_sql = "delete from password_reset_tokens "
+                        . "where user_id = :user_id";
 
-                $stmt = $this->_db->prepare($delete_sql);
-                $stmt->execute(array("user_id"  => $user_id));
+                    $stmt = $this->_db->prepare($delete_sql);
+                    $stmt->execute(array("user_id"  => $user_id));
 
-                // all good
-                return true;
+                    // all good
+                    return true;
+                }
             }
         }
     }

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -377,7 +377,8 @@ class UserMapper extends ApiMapper
      * @return $user_id The user's ID (or false, if we didn't find her)
      */
     public function getUserIdFromEmail($email) {
-        $sql = "select ID from user where email = :email";
+        $sql = "select ID from user " 
+            . "where email = :email and active = 1";
 
         $data = array("email" => $email);
         $stmt = $this->_db->prepare($sql);

--- a/src/services/UserPasswordResetEmailService.php
+++ b/src/services/UserPasswordResetEmailService.php
@@ -1,0 +1,40 @@
+<?php
+
+class UserPasswordResetEmailService extends EmailBaseService
+{
+    protected $user;
+    protected $website_url;
+
+    public function __construct($config, $recipients, $user, $token)
+    {
+        // set up the common stuff first
+        parent::__construct($config, $recipients);
+
+        $this->user        = $user;
+        $this->token       = $token;
+        $this->website_url = $config['website_url'];
+    }
+
+    public function sendEmail()
+    {
+        $this->setSubject('Resetting your joind.in password');
+
+        $replacements = array(
+            "full_name"   => $this->user['full_name'],
+            "username"    => $this->user['username'],
+            "website_url" => $this->website_url,
+            "token"       => $this->token,
+        );
+
+        $messageBody = $this->parseEmail("userPasswordReset.md", $replacements);
+        $messageHTML = $this->markdownToHtml($messageBody);
+
+        $this->setBody($this->htmlToPlainText($messageHTML));
+        $this->setHtmlBody($messageHTML);
+
+        $this->dispatchEmail();
+    }
+}
+
+
+

--- a/src/views/emails/userPasswordReset.md
+++ b/src/views/emails/userPasswordReset.md
@@ -2,7 +2,7 @@ Hi [full_name],
 
 Have you forgotten your joind.in password?  Click on the link below to set a new one:
 
-[[website_url]/user/new_password?token=[token]]([website_url]/user/new_password?token=[token])
+[[website_url]/user/new_password?token=[token]]([website_url]/user/new-password?token=[token])
 
 (This email was sent because someone requested the password reset.  If this wasn't you, you can safely ignore this mail)
 

--- a/src/views/emails/userPasswordReset.md
+++ b/src/views/emails/userPasswordReset.md
@@ -1,0 +1,8 @@
+Hi [full_name],
+
+Have you forgotten your joind.in password?  Click on the link below to set a new one:
+
+[[website_url]/user/new_password?token=[token]]([website_url]/user/new_password?token=[token])
+
+(This email was sent because someone requested the password reset.  If this wasn't you, you can safely ignore this mail)
+


### PR DESCRIPTION
This adds two endpoints:
 - one to request a password reset email be sent to the user
 - one to accept the token sent in that email, and accept a new password for this user (it also deletes the token)