### PR TITLE
Pending events

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -12,6 +12,12 @@
         "verbs": ["POST"]
     },
     {
+        "path": "/events/(\\d+)/approval$",
+        "controller": "EventsController",
+        "action": "rejectAction",
+        "verbs": ["DELETE"]
+    },
+    {
         "path": "/events(/[^/]+)*/comments",
         "controller": "Event_commentsController",
         "action": "createComment",

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -6,6 +6,12 @@
         "verbs": ["GET"]
     },
     {
+        "path": "/events/(\\d+)/approval$",
+        "controller": "EventsController",
+        "action": "approveAction",
+        "verbs": ["POST"]
+    },
+    {
         "path": "/events(/[^/]+)*/comments",
         "controller": "Event_commentsController",
         "action": "createComment",

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -503,4 +503,37 @@ class EventsController extends ApiController {
             exit;
         }
     }
+
+    /**
+     * Approve a pending event by POSTing to /events/{id}/approval
+     *
+     * The body of this request is completely irrelevant, simply POSTing to this
+     * endpoint is all that's needed to approve an pending event
+     *
+     * @param  Request $request
+     * @param  PDO $db
+     * @return void
+     */
+    public function approveAction($request, $db)
+    {
+        if (!isset($request->user_id)) {
+            throw new Exception("You must be logged in to create data", 400);
+        }
+        
+        $event_id = $this->getItemId($request);
+        $event_mapper = new EventMapper($db, $request);
+
+        if (!$event_mapper->thisUserCanApproveEvents()) {
+            throw new Exception("You are not allowed to approve this event", 403);
+        }
+
+        $result = $event_mapper->approve($event_id);
+        if (!$result) {
+            throw new Exception("This event cannot be approved", 400);
+        }
+        
+        $location = $request->base . '/' . $request->version . '/events/' . $event_id;
+        header('Location: ' . $location, null, 204);
+        return;
+    }
 }

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -80,7 +80,7 @@ class EventsController extends ApiController {
                         $user_mapper= new UserMapper($db, $request);
                         $canApproveEvents = $user_mapper->isSiteAdmin($request->user_id);
                         if (!$canApproveEvents) {
-                            throw new Exception("You don't have permission to view pending events", 400);
+                            throw new Exception("You don't have permission to view pending events", 403);
                         }
                     }
                 }

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -544,4 +544,33 @@ class EventsController extends ApiController {
         header('Location: ' . $location, null, 204);
         return;
     }
+
+    /**
+     * Reject a pending event by DELETEing to /events/{id}/approval
+     *
+     * @param  Request $request
+     * @param  PDO $db
+     * @return void
+     */
+    public function rejectAction($request, $db)
+    {
+        if (!isset($request->user_id)) {
+            throw new Exception("You must be logged in to create data", 400);
+        }
+        
+        $event_id = $this->getItemId($request);
+        $event_mapper = new EventMapper($db, $request);
+
+        if (!$event_mapper->thisUserCanApproveEvents()) {
+            throw new Exception("You are not allowed to reject this event", 403);
+        }
+
+        $result = $event_mapper->reject($event_id, $request->user_id);
+        if (!$result) {
+            throw new Exception("This event cannot be rejected", 400);
+        }
+        
+        header("Content-Length: 0", null, 204);
+        return;
+    }
 }

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -58,8 +58,12 @@ class EventsController extends ApiController {
             }
         } else {
             $mapper = new EventMapper($db, $request);
+            $user_mapper= new UserMapper($db, $request);
+            $isSiteAdmin = $user_mapper->isSiteAdmin($request->user_id);
+            $activeEventsOnly = $isSiteAdmin ? false : true;
+
             if($event_id) {
-                $list = $mapper->getEventById($event_id, $verbose);
+                $list = $mapper->getEventById($event_id, $verbose, $activeEventsOnly);
                 if(count($list['events']) == 0) {
                     throw new Exception('Event not found', 404);
                 }

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -531,6 +531,14 @@ class EventsController extends ApiController {
         if (!$result) {
             throw new Exception("This event cannot be approved", 400);
         }
+
+        if ($result) {
+            // Send a notification email as we have approved
+            $event = $event_mapper->getEventById($event_id, true)['events'][0];
+            $recipients = $event_mapper->getHostsEmailAddresses($event_id);
+            $emailService = new EventApprovedEmailService($this->config, $recipients, $event);
+            $emailService->sendEmail();
+        }
         
         $location = $request->base . '/' . $request->version . '/events/' . $event_id;
         header('Location: ' . $location, null, 204);

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -68,9 +68,21 @@ class EventsController extends ApiController {
                 $params = array();
 
                 // collection type filter
-                $filters = array("hot", "upcoming", "past", "cfp");
+                $filters = array("hot", "upcoming", "past", "cfp", "pending");
                 if(isset($request->parameters['filter']) && in_array($request->parameters['filter'], $filters)) {
                     $params["filter"] = $request->parameters['filter'];
+
+                    // for pending events we need a logged in user with the correct permissions
+                    if ($params["filter"] == 'pending') {
+                        if (!isset($request->user_id)) {
+                            throw new Exception("You must be logged in to view pending events", 400);
+                        }
+                        $user_mapper= new UserMapper($db, $request);
+                        $canApproveEvents = $user_mapper->isSiteAdmin($request->user_id);
+                        if (!$canApproveEvents) {
+                            throw new Exception("You don't have permission to view pending events", 400);
+                        }
+                    }
                 }
 
                 if(isset($request->parameters['title'])) {

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -452,6 +452,26 @@ class EventMapper extends ApiMapper
     }
 
     /**
+     * Fetch the email addresses of the event hosts so that we can email them
+     *
+     * @param int $event_id
+     * @return array The email addresses of people hosting the event
+     */
+    public function getHostsEmailAddresses($event_id)
+    {
+        $base = $this->_request->base;
+        $version = $this->_request->version;
+
+        $host_sql = 'select u.email'
+            . ' from user_admin a '
+            . ' inner join user u on u.ID = a.uid '
+            . ' where rid = :event_id and rtype="event" and (rcode!="pending" OR rcode is null)';
+        $host_stmt = $this->_db->prepare($host_sql);
+        $host_stmt->execute(array("event_id" => $event_id));
+        return $host_stmt->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    /**
      * Return an array of tags for the event
      * 
      * @param int $event_id The event whose tags we want

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -177,9 +177,9 @@ class EventMapper extends ApiMapper
         }
 
         if ($active) {
-            $sql .= " and events.active = 1 and (events.pending = 0 or events.pending is NULL) ";
+            $where .= " and events.active = 1 and (events.pending = 0 or events.pending is NULL) ";
         } else {
-            $sql .= " and events.active = 0 and events.pending = 1 ";
+            $where .= " and events.active = 0 and events.pending = 1 ";
         }
 
         if (array_key_exists("stub", $params)) {

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -990,4 +990,27 @@ class EventMapper extends ApiMapper
         $stmt = $this->_db->prepare($sql);
         return $stmt->execute(["event_id" => $event_id]);
     }
+
+    /**
+     * Reject a pending event
+     *
+     * Currently, this is done by deleting it
+     *
+     * @param  integer $event_id
+     * @return boolean
+     */
+    public function reject($event_id)
+    {
+        $sql = "select ID from events where pending = 1 and active = 0 and ID = :event_id";
+        $stmt = $this->_db->prepare($sql);
+        $response = $stmt->execute(["event_id" => $event_id]);
+        $result = $stmt->fetch();
+        if ($result === false) {
+            return false;
+        }
+
+        $sql = "delete from events WHERE pending = 1 and active = 0 and ID = :event_id";
+        $stmt = $this->_db->prepare($sql);
+        return $stmt->execute(["event_id" => $event_id]);
+    }
 }

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -1009,7 +1009,7 @@ class EventMapper extends ApiMapper
             return false;
         }
 
-        $sql = "delete from events WHERE pending = 1 and active = 0 and ID = :event_id";
+        $sql = "update events set pending = 0, active = 0 where ID = :event_id";
         $stmt = $this->_db->prepare($sql);
         return $stmt->execute(["event_id" => $event_id]);
     }

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -85,9 +85,9 @@ class EventMapper extends ApiMapper
      * 
      * @return array the event detail
      */
-    public function getEventById($event_id, $verbose = false) 
+    public function getEventById($event_id, $verbose = false, $activeEventsOnly = true)
     {
-        $results = $this->getEvents(1, 0, array("event_id" => $event_id));
+        $results = $this->getEvents(1, 0, array("event_id" => $event_id, 'active' => $activeEventsOnly));
         if ($results) {
             $retval = $this->transformResults($results, $verbose);
             return $retval;
@@ -145,6 +145,9 @@ class EventMapper extends ApiMapper
         }
 
         $active = true;
+        if(array_key_exists("active", $params)) {
+            $active = $params['active'];
+        }
         if(array_key_exists("filter", $params)) {
             switch($params['filter']) {
                 case "hot": // current and popular events

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -137,7 +137,6 @@ class EventMapper extends ApiMapper
                 left join tags on tags.ID = tags_events.tag_id ";
         }
 
-
         $sql .= ' where (events.private <> "y" OR events.private IS NULL) ';
 
         if(array_key_exists("event_id", $params)) {
@@ -948,5 +947,27 @@ class EventMapper extends ApiMapper
             // Add an association with the event
             $addTagToEventStmt->execute(array('tag_id' => $tagId, 'event_id' => $event_id));
         }
+    }
+
+    /**
+     * Approve a pending event
+     *
+     * @param  integer $event_id
+     * @return boolean
+     */
+    public function approve($event_id)
+    {
+        $sql = "select ID from events where pending = 1 and active = 0 and ID = :event_id";
+        $stmt = $this->_db->prepare($sql);
+        $response = $stmt->execute(["event_id" => $event_id]);
+        $result = $stmt->fetch();
+        if ($result === false) {
+            // Event either doesn't exist or is not pending
+            return false;
+        }
+
+        $sql = "update events set pending = 0, active = 1 where ID = :event_id";
+        $stmt = $this->_db->prepare($sql);
+        return $stmt->execute(["event_id" => $event_id]);
     }
 }

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -163,7 +163,6 @@ class EventMapper extends ApiMapper
                     $order .= 'events.event_start';
                     break;
                 case "pending": // events to be approved
-                    $where .= ' and events.active = 0 AND events.pending = 1';
                     $order .= 'events.event_start';
                     $active = false;
                     break;

--- a/src/services/EventApprovedEmailService.php
+++ b/src/services/EventApprovedEmailService.php
@@ -1,0 +1,39 @@
+<?php
+
+class EventApprovedEmailService extends EmailBaseService
+{
+    protected $event;
+    protected $website_url;
+
+    public function __construct($config, $recipients, $event)
+    {
+        // set up the common stuff first
+        parent::__construct($config, $recipients);
+
+        $this->event       = $event;
+        $this->website_url = $config['website_url'];
+    }
+
+    public function sendEmail()
+    {
+        $this->setSubject('Your joind.in username');
+
+        $date = new DateTime($this->event['start_date']);
+        $replacements = array(
+            "title"        => $this->event['name'],
+            "description"  => $this->event['description'],
+            "date"         => $date->format('jS M, Y'),
+            "contact_name" => $this->event['contact_name'],
+            "website_url"  => $this->website_url,
+            "event_url"    => $this->website_url . '/event/' . $this->event['url_friendly_name'],
+        );
+
+        $messageBody = $this->parseEmail("eventApproved.md", $replacements);
+        $messageHTML = $this->markdownToHtml($messageBody);
+
+        $this->setBody($this->htmlToPlainText($messageHTML));
+        $this->setHtmlBody($messageHTML);
+
+        $this->dispatchEmail();
+    }
+}

--- a/src/views/emails/eventApproved.md
+++ b/src/views/emails/eventApproved.md
@@ -1,0 +1,1 @@
+Your event, *[title]* has now been approved.You can see the event listing [here]([event_url]).As you get closer to your event, please add approriate tracks and talks to theevent listing so that your speakers can claim them and then, on the day, yourattendees can provide feedback on the talks that they see.


### PR DESCRIPTION
List pending events using a new filter on the /events collection.
Approve and reject pending events on the /events/{id}/approval end point.

Note that approval sends an email, but this is not tested as the VM currently has a regex issue.