### PR TITLE
Implement /facebook/token to log a user in

### DIFF
--- a/src/config.php.dist
+++ b/src/config.php.dist
@@ -24,6 +24,12 @@ $config =  array(
         'consumer_key' => '',
         'consumer_secret' => ''
     ),
+    'facebook' => array(
+        // set up at https://developers.facebook.com/apps/
+        // configure url in OAuth Settings as /user/facebook-access on web2
+        'app_id' => '',
+        'app_secret' => '',
+    ),
     'features' => array(
         'allow_auto_verify_users' => false,
         'allow_auto_approve_events' => false,

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -194,6 +194,13 @@
     },
 
     {
+        "path": "/facebook/token",
+        "controller": "FacebookController",
+        "action": "logUserIn",
+        "verbs": ["POST"]
+    },
+
+    {
         "path": "/?$",
         "controller": "DefaultController",
         "action": "handle"

--- a/src/controllers/FacebookController.php
+++ b/src/controllers/FacebookController.php
@@ -16,6 +16,11 @@ class FacebookController extends ApiController
      */
     public function logUserIn($request, $db)
     {
+        if (empty($this->config['facebook']['app_id'])
+            || empty($this->config['facebook']['app_secret'])) {
+            throw new Exception("Cannot login via Facebook", 501);
+        }
+
         $clientId = $request->getParameter('client_id');
         $clientSecret = $request->getParameter('client_secret');
         $this->oauthModel = $request->getOauthModel($db);

--- a/src/controllers/FacebookController.php
+++ b/src/controllers/FacebookController.php
@@ -73,7 +73,8 @@ class FacebookController extends ApiController
             throw new Exception("Could not sign in with Facebook", 403);
         }
 
-        trigger_error('Unexpected Facebook error (' . $res->getStatusCode() . ': ' . $res->getBody() . ')', E_USER_WARNING);
+        trigger_error('Unexpected Facebook error (' . $res->getStatusCode()
+            . ': ' . $res->getBody() . ')', E_USER_WARNING);
         throw new Exception("Unexpected Facebook error", 500);
     }
 }

--- a/src/controllers/FacebookController.php
+++ b/src/controllers/FacebookController.php
@@ -73,6 +73,7 @@ class FacebookController extends ApiController
             throw new Exception("Could not sign in with Facebook", 403);
         }
 
-        throw new Exception("Facebook: error (" . $res->getStatusCode() . ": " . $res->getBody() . ")", 500);
+        trigger_error('Unexpected Facebook error (' . $res->getStatusCode() . ': ' . $res->getBody() . ')', E_USER_WARNING);
+        throw new Exception("Unexpected Facebook error", 500);
     }
 }

--- a/src/controllers/FacebookController.php
+++ b/src/controllers/FacebookController.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Facebook-specific endpoints live here
+ */
+
+use GuzzleHttp\Client;
+
+class FacebookController extends ApiController
+{
+    public function handle(Request $request, $db)
+    {
+        // really need to not require this to be declared
+    }
+
+    /**
+     * Take the verification code from the client, send to Facebook to get an access token.
+     * With the access token, read the user's profile to get their email address.
+     * From that, look up who they are, create them a new access token and return
+     * the same format as we do when logging in a user
+     */
+    public function logUserIn($request, $db)
+    {
+        $clientId = $request->getParameter('client_id');
+        $clientSecret = $request->getParameter('client_secret');
+        $this->oauthModel = $request->getOauthModel($db);
+        if (!$this->oauthModel->isClientPermittedPasswordGrant($clientId, $clientSecret)) {
+            throw new Exception("This client cannot perform this action", 403);
+        }
+
+        // check incoming values
+        if (empty($code = $request->getParameter("code"))) {
+            throw new Exception("The request code must be supplied");
+        }
+
+        // exchange code for access token
+        $client = new Client([
+            'headers' => ['Accept' => 'application/json']
+        ]);
+
+        $res = $client->get('https://graph.facebook.com/v2.3/oauth/access_token', [
+            'query' => [
+                'client_id' => $this->config['facebook']['app_id'],
+                'redirect_uri' => $this->config['website_url'] . '/user/facebook-access',
+                'client_secret' => $this->config['facebook']['app_secret'],
+                'code' => $code,
+            ]
+        ]);
+
+        if ($res->getStatusCode() == 200) {
+            $data = json_decode((string)$res->getBody(), true);
+            $access_token = $data['access_token'];
+
+            // retrieve email address from Facebook profile
+            $res = $client->get('https://graph.facebook.com/me', [
+                'query' => [
+                    'access_token' => $access_token,
+                ]
+            ]);
+            if ($res->getStatusCode() == 200) {
+                $data = json_decode((string)$res->getBody(), true);
+                if (!array_key_exists('email', $data)) {
+                    throw new Exception("Email address is unavailable", 403);
+                }
+                $email = $data['email'];
+                
+                $result = $this->oauthModel->createAccessTokenFromTrustedEmail($clientId, $email);
+                if ($result) {
+                    return array('access_token' => $result['access_token'], 'user_uri' => $result['user_uri']);
+                }
+            }
+
+            throw new Exception("Could not sign in with Facebook", 403);
+        }
+
+        throw new Exception("Facebook: error (" . $res->getStatusCode() . ": " . $res->getBody() . ")", 500);
+    }
+}

--- a/src/controllers/FacebookController.php
+++ b/src/controllers/FacebookController.php
@@ -8,11 +8,6 @@ use GuzzleHttp\Client;
 
 class FacebookController extends ApiController
 {
-    public function handle(Request $request, $db)
-    {
-        // really need to not require this to be declared
-    }
-
     /**
      * Take the verification code from the client, send to Facebook to get an access token.
      * With the access token, read the user's profile to get their email address.

--- a/src/models/OAuthModel.php
+++ b/src/models/OAuthModel.php
@@ -377,7 +377,7 @@ class OAuthModel
      *
      * @param  string $clientId         aka consumer_key (of the joindin client)
      * @param  string $email            User's email address (that we just got back from authenticating them)
-     * @return string                   access token
+     * @return array|false              Array of access token and user uri on success or false or failure
      */
     public function createAccessTokenFromTrustedEmail($clientId, $email)
     {

--- a/src/models/OAuthModel.php
+++ b/src/models/OAuthModel.php
@@ -370,4 +370,35 @@ class OAuthModel
 
         return false;
     }
+
+    /**
+     * Create an access token for someone identified by email address via a
+     * third party authentication system such as Facebook
+     *
+     * @param  string $clientId         aka consumer_key (of the joindin client)
+     * @param  string $email            User's email address (that we just got back from authenticating them)
+     * @return string                   access token
+     */
+    public function createAccessTokenFromTrustedEmail($clientId, $email)
+    {
+        $sql = "select ID from user "
+            . "where email = :email "
+            . "and verified = 1";
+
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute(array("email" => $email));
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($result) {
+            $userId = $result['ID'];
+
+            // create new token
+            $accessToken = $this->newAccessToken($clientId, $userId);
+
+            // we also want to send back the logged in user's uri
+            $userUri = $this->getUserUri($userId);
+
+            return array('access_token' => $accessToken, 'user_uri' => $userUri);
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
API half of logging in with Facebook.

We take the verification code from the client, send to Facebook to get an access token.
With the access token, read the user's profile to get their email address. From that,
look up who they are, create them a new access token and return which is converted to
an access token from which we read the user's email address and then attempt to log
them in.