### PR TITLE
Remove handle() method from controllers

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -64,7 +64,7 @@
     {
         "path": "/token(/[^/]+)*/?$",
         "controller": "TokenController",
-        "action": "handle",
+        "action": "postAction",
         "verbs": ["POST"]
     },
 
@@ -106,14 +106,14 @@
     {
         "path": "/event_comments(/[^/]+)*/?$",
         "controller": "Event_commentsController",
-        "action": "handle",
+        "action": "getComments",
         "verbs": ["GET"]
     },
 
     {
         "path": "/talk_comments(/[^/]+)*/?$",
         "controller": "Talk_commentsController",
-        "action": "handle",
+        "action": "getComments",
         "verbs": ["GET"]
     },
 

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -3,8 +3,6 @@
 abstract class ApiController {
     protected $config;
 
-	abstract public function handle(Request $request, $db);
-
     public function __construct($config = null) {
         $this->config = $config;
     }

--- a/src/controllers/EmailsController.php
+++ b/src/controllers/EmailsController.php
@@ -5,10 +5,6 @@
  */
 
 class EmailsController extends ApiController {
-    public function handle(Request $request, $db) {
-        // really need to not require this to be declared
-    }
-
     public function verifications($request, $db){
         $user_mapper= new UserMapper($db, $request);
         $email = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);

--- a/src/controllers/Event_commentsController.php
+++ b/src/controllers/Event_commentsController.php
@@ -1,15 +1,7 @@
 <?php
 
 class Event_commentsController extends ApiController {
-    public function handle(Request $request, $db) {
-        // only GET is implemented so far
-        if($request->getVerb() == 'GET') {
-            return $this->getAction($request, $db);
-        }
-        return false;
-    }
-
-	public function getAction($request, $db) {
+	public function getComments($request, $db) {
         $comment_id = $this->getItemId($request);
 
         // verbosity

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -1,20 +1,6 @@
 <?php
 
 class EventsController extends ApiController {
-    public function handle(Request $request, $db) {
-        // only GET is implemented so far
-        if($request->getVerb() == 'GET') {
-            return $this->getAction($request, $db);
-        } elseif ($request->getVerb() == 'POST') {
-            return $this->postAction($request, $db);
-        } elseif ($request->getVerb() == 'DELETE') {
-            return $this->deleteAction($request, $db);
-        } elseif ($request->getVerb() == 'PUT') {
-            return $this->putAction($request, $db);
-        }
-        return false;
-    }
-
 	public function getAction($request, $db) {
         $event_id = $this->getItemId($request);
 

--- a/src/controllers/LanguagesController.php
+++ b/src/controllers/LanguagesController.php
@@ -2,9 +2,6 @@
 
 class LanguagesController extends ApiController
 {
-    public function handle(Request $request, $db) {
-    }
-
     public function getLanguage($request, $db) {
         $language_id = $this->getItemId($request);
         // verbosity - here for consistency as we don't have verbose language details to return at the moment

--- a/src/controllers/Talk_commentsController.php
+++ b/src/controllers/Talk_commentsController.php
@@ -1,15 +1,7 @@
 <?php
 
 class Talk_commentsController extends ApiController {
-    public function handle(Request $request, $db) {
-        // only GET is implemented so far
-        if($request->getVerb() == 'GET') {
-            return $this->getAction($request, $db);
-        }
-        return false;
-    }
-
-	public function getAction($request, $db) {
+	public function getComments($request, $db) {
         $comment_id = $this->getItemId($request);
 
         // verbosity

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -1,19 +1,6 @@
 <?php
 
 class TalksController extends ApiController {
-    public function handle(Request $request, $db) {
-        if($request->getVerb() == 'GET') {
-            return $this->getAction($request, $db);
-        } elseif($request->getVerb() == 'POST') {
-            return $this->postAction($request, $db);
-        } elseif ($request->getVerb() == 'DELETE') {
-            return $this->deleteAction($request, $db);
-        } else {
-            throw new Exception("method not supported");
-        }
-        return false;
-    }
-
 	public function getAction($request, $db) {
         $talk_id = $this->getItemId($request);
 

--- a/src/controllers/TokenController.php
+++ b/src/controllers/TokenController.php
@@ -4,20 +4,9 @@ class TokenController extends ApiController
 {
     protected $oauthModel;
 
-    public function handle(Request $request, $db)
-    {
-        $this->oauthModel = $request->getOauthModel($db);
-
-        // only POST is implemented so far
-        if($request->getVerb() == 'POST') {
-            return $this->postAction($request, $db);
-        }
-        
-        return false;
-    }
-
     public function postAction($request, $db)
     {
+        $this->oauthModel = $request->getOauthModel($db);
         // The "password" grant type posts here to exchange a username and
         // password for an access token. This is used by web2.
 

--- a/src/controllers/TracksController.php
+++ b/src/controllers/TracksController.php
@@ -2,16 +2,6 @@
 
 class TracksController extends ApiController
 {
-    public function handle(Request $request, $db) {
-        if ($request->getVerb() == 'GET') {
-            return $this->getAction($request, $db);
-        } else {
-            throw new Exception("method not supported");
-        }
-
-        return false;
-    }
-
     public function getAction($request, $db) {
         $track_id = $this->getItemId($request);
 

--- a/src/controllers/TwitterController.php
+++ b/src/controllers/TwitterController.php
@@ -8,10 +8,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
 
 class TwitterController extends ApiController {
-    public function handle(Request $request, $db) {
-        // really need to not require this to be declared
-    }
-
     public function getRequestToken($request, $db){
         // only trusted clients can change account details
         $clientId = $request->getParameter('client_id');

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1,16 +1,6 @@
 <?php
 
 class UsersController extends ApiController {
-    public function handle(Request $request, $db) {
-        // only GET is implemented so far
-        if($request->getVerb() == 'GET') {
-            return $this->getAction($request, $db);
-        } elseif ($request->getVerb() == 'POST') {
-            return $this->postAction($request, $db);
-        }
-        return false;
-    }
-
 	public function getAction($request, $db) {
         $user_id = $this->getItemId($request);
 


### PR DESCRIPTION
The previous routing strategy relied on verb routing inside the controllers; it is no longer needed but the parent controller class implemented the handle() method as an abstract so it always had to be declared.  The requirement to have it required is gone and the existing handle methods are also removed