### PR TITLE
Add some randomness to generation of the url_friendly_name for events

### DIFF
--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -694,6 +694,8 @@ class EventMapper extends ApiMapper
             $inflected_name . $date->format('-Y'),
             $inflected_name . $date->format('-Y-m'),
             $inflected_name . $date->format('-Y-m-d'),
+			// weird/random friendly name is better than no friendly name
+			$inflected_name . $date->format('-Y-m-d') . '-' . mt_rand(1,99),
         );
 
         foreach ($name_choices as $inflected_name) {


### PR DESCRIPTION
We've seen some problems with events having blank url_friendly_name fields, which breaks a lot of web2 which uses this field for its URLs.  This adds a last resort for same-named events on the same day which can't have the same name and end up with no name at all.