### PR TITLE
JOINDIN-590 - Increase range of duplicate inflected titles from 5 to 9

### DIFF
--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -443,22 +443,21 @@ class TalkMapper extends ApiMapper {
      */
     protected function generateInflectedTitle($title, $talk_id)
     {
+        // Try to store without a suffix
         $inflected_title = $this->inflect($title);
         $result = $this->storeInflectedTitle($inflected_title, $talk_id);
         if ($result) {
             return $inflected_title;
         }
-        
-        // Add a number to the
-        $inflected_title .= '-1';
-        for ($i=2; $i <=5; $i++) {
-            $inflected_title = preg_replace('/-(\d)$/', "-$i", $inflected_title);
-            $result = $this->storeInflectedTitle($inflected_title, $talk_id);
-            if ($result) {
-                return $inflected_title;
-            }
+
+        // If that doesn't work, try to store with the talk ID tacked on
+        $inflected_title .= '-' . $talk_id;
+        $result = $this->storeInflectedTitle($inflected_title, $talk_id);
+        if ($result) {
+            return $inflected_title;
         }
 
+        // If neither of those worked, fail. We shouldn't get to here.
         return false;
     }
 


### PR DESCRIPTION
When the API is used to retrieve a talk that doesn't have any value in
the url_friendly_talk_title, it attempts to create a value for the
field. If there are multiple talks with the same title for the same
event, it will try over and over to append a new number at the end. It
will stop after attempting suffixes 2 through 9 if none of those work.
It should be Good Enough™ for now.