### PR TITLE
Change URL in event submission email to web2

### DIFF
--- a/src/views/emails/eventSubmission.md
+++ b/src/views/emails/eventSubmission.md
@@ -8,6 +8,6 @@ Please review a new event submission to joind.in:
 
 *Description:* [description]
 
-View all pending submissions here: [https://joind.in/event/pending](https://joind.in/event/pending)
+View all pending submissions here: [https://m.joind.in/event/pending](https://m.joind.in/event/pending)
 [count]
 

--- a/src/views/emails/eventSubmission.md
+++ b/src/views/emails/eventSubmission.md
@@ -1,1 +1,13 @@
-Please review a new event submission to joind.in:*Title:* [title]*Contact:* [contact_name]*Date:* [date]*Description:* [description]View all pending submissions here: [https://joind.in/event/pending](https://joind.in/event/pending)[count]
+Please review a new event submission to joind.in:
+
+*Title:* [title]
+
+*Contact:* [contact_name]
+
+*Date:* [date]
+
+*Description:* [description]
+
+View all pending submissions here: [https://joind.in/event/pending](https://joind.in/event/pending)
+[count]
+


### PR DESCRIPTION
Web2 has the better event pending process, so we want to use that in preference to web1.

At the moment, it's slightly ironic that web1 submission emails direct us to web2 and web2 submission emails direct us to web1...