### PR TITLE
Do not HTML encode quotes

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -89,12 +89,12 @@ class EventsController extends ApiController
                 }
 
                 if (isset($request->parameters['title'])) {
-                    $title           = filter_var($request->parameters['title'], FILTER_SANITIZE_STRING);
+                    $title           = filter_var($request->parameters['title'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                     $params["title"] = $title;
                 }
 
                 if (isset($request->parameters['stub'])) {
-                    $stub           = filter_var($request->parameters['stub'], FILTER_SANITIZE_STRING);
+                    $stub           = filter_var($request->parameters['stub'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                     $params["stub"] = $stub;
                 }
 
@@ -102,10 +102,10 @@ class EventsController extends ApiController
                     // if it isn't an array, make it one
                     if (is_array($request->parameters['tags'])) {
                         foreach ($request->parameters['tags'] as $t) {
-                            $tags[] = filter_var(trim($t), FILTER_SANITIZE_STRING);
+                            $tags[] = filter_var(trim($t), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                         }
                     } else {
-                        $tags = array(filter_var(trim($request->parameters['tags']), FILTER_SANITIZE_STRING));
+                        $tags = array(filter_var(trim($request->parameters['tags']), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES));
                     }
                     $params["tags"] = $tags;
                 }
@@ -157,17 +157,17 @@ class EventsController extends ApiController
             $event  = array();
             $errors = array();
 
-            $event['name'] = filter_var($request->getParameter("name"), FILTER_SANITIZE_STRING);
+            $event['name'] = filter_var($request->getParameter("name"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
             if (empty($event['name'])) {
                 $errors[] = "'name' is a required field";
             }
 
-            $event['description'] = filter_var($request->getParameter("description"), FILTER_SANITIZE_STRING);
+            $event['description'] = filter_var($request->getParameter("description"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
             if (empty($event['description'])) {
                 $errors[] = "'description' is a required field";
             }
 
-            $event['location'] = filter_var($request->getParameter("location"), FILTER_SANITIZE_STRING);
+            $event['location'] = filter_var($request->getParameter("location"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
             if (empty($event['location'])) {
                 $errors[] = "'location' is a required field (for virtual events, 'online' works)";
             }
@@ -179,8 +179,8 @@ class EventsController extends ApiController
             } else {
                 // if the dates are okay, sort out timezones
 
-                $event['tz_continent'] = filter_var($request->getParameter("tz_continent"), FILTER_SANITIZE_STRING);
-                $event['tz_place']     = filter_var($request->getParameter("tz_place"), FILTER_SANITIZE_STRING);
+                $event['tz_continent'] = filter_var($request->getParameter("tz_continent"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+                $event['tz_place']     = filter_var($request->getParameter("tz_place"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                 try {
                     // make the timezone, and read in times with respect to that
                     $tz                  = new DateTimeZone($event['tz_continent'] . '/' . $event['tz_place']);
@@ -236,7 +236,7 @@ class EventsController extends ApiController
                 if (is_array($incoming_tag_list)) {
                     $tags = array_map(
                         function ($tag) {
-                            $tag = filter_var($tag, FILTER_SANITIZE_STRING);
+                            $tag = filter_var($tag, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                             $tag = trim($tag);
                             $tag = strtolower($tag);
 
@@ -353,17 +353,17 @@ class EventsController extends ApiController
             $event  = array("event_id" => $event_id);
             $errors = array();
 
-            $event['name'] = filter_var($request->getParameter("name"), FILTER_SANITIZE_STRING);
+            $event['name'] = filter_var($request->getParameter("name"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
             if (empty($event['name'])) {
                 $errors[] = "'name' is a required field";
             }
 
-            $event['description'] = filter_var($request->getParameter("description"), FILTER_SANITIZE_STRING);
+            $event['description'] = filter_var($request->getParameter("description"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
             if (empty($event['description'])) {
                 $errors[] = "'description' is a required field";
             }
 
-            $event['location'] = filter_var($request->getParameter("location"), FILTER_SANITIZE_STRING);
+            $event['location'] = filter_var($request->getParameter("location"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
             if (empty($event['location'])) {
                 $errors[] = "'location' is a required field (for virtual events, 'online' works)";
             }
@@ -374,8 +374,8 @@ class EventsController extends ApiController
                 $errors[] = "Both 'start_date' and 'end_date' must be supplied in a recognised format";
             } else {
                 // if the dates are okay, sort out timezones
-                $event['tz_continent'] = filter_var($request->getParameter("tz_continent"), FILTER_SANITIZE_STRING);
-                $event['tz_place']     = filter_var($request->getParameter("tz_place"), FILTER_SANITIZE_STRING);
+                $event['tz_continent'] = filter_var($request->getParameter("tz_continent"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+                $event['tz_place']     = filter_var($request->getParameter("tz_place"), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                 try {
                     // make the timezone, and read in times with respect to that
                     $tz                  = new DateTimeZone($event['tz_continent'] . '/' . $event['tz_place']);
@@ -432,7 +432,7 @@ class EventsController extends ApiController
             if (is_array($incoming_tag_list)) {
                 $tags = array_map(
                     function ($tag) {
-                        $tag = filter_var($tag, FILTER_SANITIZE_STRING);
+                        $tag = filter_var($tag, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                         $tag = trim($tag);
                         $tag = strtolower($tag);
 


### PR DESCRIPTION
Added flag FILTER_FLAG_NO_ENCODE_QUOTES to FILTER_SANITIZE_STRING to prevent encoding of quotes, because Twig will double escape them.