### PR TITLE
Stop flagging risky tests in PHPUnit

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,7 +2,7 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          checkForUnintentionallyCoveredCode="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTestSize="true"


### PR DESCRIPTION
We're not running these on dev, and they create a LOT of output on the build which we're not making use of so it's basically noise