### PR TITLE
Docs update to create talk

### DIFF
--- a/talks.md
+++ b/talks.md
@@ -144,6 +144,8 @@ The following fields are understood:
      - Event related
 *  ``start_date``: The start date and time of the session in ISO format
 *  ``speakers``: An array of names of speakers (still an array if there is only one speaker)
+*  ``duration``: The length of the session in minutes (usually including breaks, so start_date plus duration gives end time)
+*  ``slides_link``: URL to the slides for this talk
 
 Example request/response:
 

--- a/talks.md
+++ b/talks.md
@@ -136,7 +136,7 @@ The following fields are understood:
      - Polish              
      - Finnish             
      - Brazilian Portuguese
-*  ``talk_type``: One of the following:
+*  ``type``: One of the following:
      - Talk *(default)*
      - Social event
      - Workshop


### PR DESCRIPTION
Update create talk documentation to add the fields duration and slides_link.
Also rename the `talk_type` field to `type` so that the field used in create is the same name as in the returned data.