### PR TITLE
Remove the speaker column from talks, it is not used

### DIFF
--- a/db/patch62.sql
+++ b/db/patch62.sql
@@ -1,0 +1,5 @@
+-- get rid of the old, unused speaker column
+
+alter table talks drop column speaker;
+
+INSERT INTO patch_history SET patch_number = 62;


### PR DESCRIPTION
This is a historical column, and when we adopted a separate speakers table the data was transferred across so it is now safe to drop this column