### PR TITLE
Allow reporting of event and talk comments

### DIFF
--- a/db/patch63.sql
+++ b/db/patch63.sql
@@ -1,0 +1,24 @@
+-- create storage for reported comments
+
+create table reported_talk_comments(
+    ID int auto_increment primary key,
+    talk_comment_id int not null, 
+    reporting_user_id int not null,
+    reporting_date datetime not null defaut CURRENT_TIMESTAMP,
+    decision varchar(20),
+    deciding_user_id int,
+    deciding_date datetime
+);
+
+create table reported_event_comments(
+    ID int auto_increment primary key,
+    event_comment_id int not null, 
+    reporting_user_id int not null,
+    reporting_date datetime not null defaut CURRENT_TIMESTAMP,
+    decision varchar(20),
+    deciding_user_id int,
+    deciding_date datetime
+);
+
+
+INSERT INTO patch_history SET patch_number = 63;

--- a/db/patch63.sql
+++ b/db/patch63.sql
@@ -4,7 +4,7 @@ create table reported_talk_comments(
     ID int auto_increment primary key,
     talk_comment_id int not null, 
     reporting_user_id int not null,
-    reporting_date datetime not null defaut CURRENT_TIMESTAMP,
+    reporting_date datetime not null,
     decision varchar(20),
     deciding_user_id int,
     deciding_date datetime
@@ -14,7 +14,7 @@ create table reported_event_comments(
     ID int auto_increment primary key,
     event_comment_id int not null, 
     reporting_user_id int not null,
-    reporting_date datetime not null defaut CURRENT_TIMESTAMP,
+    reporting_date datetime not null,
     decision varchar(20),
     deciding_user_id int,
     deciding_date datetime

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -124,6 +124,13 @@
     },
 
     {
+        "path": "/talk_comments(/[^/]+)*/reported?$",
+        "controller": "Talk_commentsController",
+        "action": "reportComment",
+        "verbs": ["POST"]
+    },
+
+    {
         "path": "/emails/verifications",
         "controller": "EmailsController",
         "action": "verifications",

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -117,6 +117,13 @@
     },
 
     {
+        "path": "/event_comments(/[^/]+)*/reported?$",
+        "controller": "Event_commentsController",
+        "action": "reportComment",
+        "verbs": ["POST"]
+    },
+
+    {
         "path": "/talk_comments(/[^/]+)*/?$",
         "controller": "Talk_commentsController",
         "action": "getComments",

--- a/src/controllers/Event_commentsController.php
+++ b/src/controllers/Event_commentsController.php
@@ -109,4 +109,21 @@ class Event_commentsController extends ApiController
         header("Location: " . $uri, null, 201);
         exit;
     }
+
+    public function reportcomment($request, $db)
+    {
+        $comment_mapper = new EventCommentMapper($db, $request);
+
+        $commentId = $this->getItemId($request);
+        $commentInfo = $comment_mapper->getCommentInfo($commentId);
+        $eventId = $commentInfo['event_id'];
+
+        $comment_mapper->userReportedComment($commentId, $request->user_id);
+
+        // send them to the comments collection 
+        $uri = $request->base . '/' . $request->version . '/events/' . $eventId . "/comments";
+        header("Location: " . $uri, true, 202);
+        exit;
+    }
+
 }

--- a/src/controllers/Talk_commentsController.php
+++ b/src/controllers/Talk_commentsController.php
@@ -25,4 +25,21 @@ class Talk_commentsController extends ApiController
 
         return false;
     }
+
+    public function reportcomment($request, $db)
+    {
+        $comment_mapper = new TalkCommentMapper($db, $request);
+
+        $commentId = $this->getItemId($request);
+        $commentInfo = $comment_mapper->getCommentInfo($commentId);
+        $eventId = $commentInfo['event_id']; // needed to check if user is event admin
+        $talkId = $commentInfo['talk_id'];
+
+        $comment_mapper->userReportedComment($commentId, $request->user_id);
+
+        // send them to the comments collection 
+        $uri = $request->base . '/' . $request->version . '/talks/' . $talkId . "/comments";
+        header("Location: " . $uri, true, 202);
+        exit;
+    }
 }

--- a/src/models/TalkCommentMapper.php
+++ b/src/models/TalkCommentMapper.php
@@ -143,6 +143,7 @@ class TalkCommentMapper extends ApiMapper
                 $list[$key]['verbose_uri'] = $base . '/' . $version . '/talk_comments/' . $row['ID'] . '?verbose=yes';
                 $list[$key]['talk_uri'] = $base . '/' . $version . '/talks/'. $row['talk_id'];
                 $list[$key]['talk_comments_uri'] = $base . '/' . $version . '/talks/' . $row['talk_id'] . '/comments';
+                $list[$key]['reported_uri'] = $base . '/' . $version . '/talk_comments/' . $row['ID'] . '/reported';
                 if ($row['user_id']) {
                     $list[$key]['user_uri'] = $base . '/' . $version . '/users/' . $row['user_id'];
                 }


### PR DESCRIPTION
This pull request introduces storage for reporting of comments - both event and talk comments.  When viewing a comments collection via the API, a reported_uri is available.  A POST request to this endpoint (no body data is needed) by a logged in user will result in a stored report against that comment and the comment itself being marked as inactive and therefore not returned as part of the collection.

This relates to JOINDIN-656 and JOINDIN-655