### PR TITLE
Catch exception when storing inflected title

### DIFF
--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -557,11 +557,15 @@ class TalkMapper extends ApiMapper
             where ID = :talk_id";
 
         $stmt   = $this->_db->prepare($sql);
-        $result = $stmt->execute(array(
-            "inflected_title" => $inflected_title,
-            "talk_id"         => $talk_id
-        ));
 
+        try {
+            $result = $stmt->execute(array(
+                "inflected_title" => $inflected_title,
+                "talk_id"         => $talk_id
+            ));
+        } catch (Exception $e) {
+            return false;
+        }
         return $result;
     }
 


### PR DESCRIPTION
As PDO exceptions are enabled, ensure that we catch it as we are checking for failed insertion when storing the inflected title.

Fixes [JOINDIN-667](https://joindin.jira.com/browse/JOINDIN-667)