### PR TITLE
Notify event admins of an event comment report

### DIFF
--- a/src/controllers/Event_commentsController.php
+++ b/src/controllers/Event_commentsController.php
@@ -130,6 +130,15 @@ class Event_commentsController extends ApiController
 
         $comment_mapper->userReportedComment($commentId, $request->user_id);
 
+        // notify event admins
+        $comment      = $comment_mapper->getCommentById($commentId, true, true);
+        $event_mapper = new EventMapper($db, $request);
+        $recipients   = $event_mapper->getHostsEmailAddresses($eventId);
+        $event        = $event_mapper->getEventById($eventId, true, true);
+
+        $emailService = new EventCommentReportedEmailService($this->config, $recipients, $comment, $event);
+        $emailService->sendEmail();
+
         // send them to the comments collection
         $uri = $request->base . '/' . $request->version . '/events/' . $eventId . "/comments";
         header("Location: " . $uri, true, 202);

--- a/src/models/EventCommentMapper.php
+++ b/src/models/EventCommentMapper.php
@@ -46,9 +46,9 @@ class EventCommentMapper extends ApiMapper
         return false;
     }
 
-    public function getCommentById($comment_id, $verbose = false)
+    public function getCommentById($comment_id, $verbose = false, $include_hidden = false)
     {
-        $sql = $this->getBasicSQL();
+        $sql = $this->getBasicSQL($include_hidden);
         $sql .= 'and ec.ID = :comment_id ';
         $stmt     = $this->_db->prepare($sql);
         $response = $stmt->execute(array(
@@ -112,14 +112,17 @@ class EventCommentMapper extends ApiMapper
         return $retval;
     }
 
-    protected function getBasicSQL()
+    protected function getBasicSQL($include_hidden = false)
     {
         $sql = 'select ec.*, user.email, user.full_name, e.event_tz_cont, e.event_tz_place '
                . 'from event_comments ec '
                . 'left join user on user.ID = ec.user_id '
                . 'inner join events e on ec.event_id = e.ID '
-               . 'where ec.active = 1 ';
+               . 'where 1 ';
 
+        if (!$include_hidden) {
+            $sql .= 'and ec.active = 1 ';
+        }
         return $sql;
 
     }

--- a/src/services/EventCommentReportedEmailService.php
+++ b/src/services/EventCommentReportedEmailService.php
@@ -1,0 +1,57 @@
+<?php
+
+class EventCommentReportedEmailService extends EmailBaseService
+{
+
+    protected $comment;
+    protected $event;
+
+    public function __construct($config, $recipients, $comment, $event)
+    {
+        // set up the common stuff first
+        parent::__construct($config, $recipients);
+
+        // this email needs comment info
+        $this->comment = $comment['comments'][0];
+        $this->event = $event['events'][0];
+    }
+
+    public function sendEmail()
+    {
+        $this->setSubject("Joind.in: A comment was reported");
+
+        $byLine = '';
+
+        if (isset($this->comment['user_display_name'])) {
+            $byLine = ' by ' . $this->comment['user_display_name'];
+        }
+
+        if (empty($byLine) && isset($this->comment['username'])) {
+            $byLine = ' by' . $this->comment['username'];
+        }
+
+        if (empty($byLine)) {
+            $byLine = ' by (anonymous)';
+        }
+
+        $rating = $this->comment['rating'];
+        if ($rating == 0) {
+            $rating = 'Not rated';
+        }
+
+        $replacements = array(
+            "name"   => $this->event['name'],
+            "rating"  => $rating,
+            "comment" => $this->comment['comment'],
+            "byline"  => $byLine
+        );
+
+        $messageBody = $this->parseEmail("eventCommentReported.md", $replacements);
+        $messageHTML = $this->markdownToHtml($messageBody);
+
+        $this->setBody($this->htmlToPlainText($messageHTML));
+        $this->setHtmlBody($messageHTML);
+
+        $this->dispatchEmail();
+    }
+}

--- a/src/views/emails/EventCommentReported.md
+++ b/src/views/emails/EventCommentReported.md
@@ -1,0 +1,10 @@
+A coment on your event has been reported.  It will be hidden until you moderate it; the details are below:
+
+**Event:** [name]
+
+**Rating:** [rating] [byline]
+
+**Comment:** [comment]
+
+*A reported comment usually indicates a comment that is inappropriate, offensive, or considered to be spam.  Please visit the event dashboard to moderate this comment.*
+


### PR DESCRIPTION
Send an email when an event comment is reported. For this initial implementation, it uses the same wording as for the reported talk comment notification email.