### PR TITLE
Refactor TalkMapper to introduce TalkModelCollection and TalkModel

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -17,7 +17,8 @@ class EventsController extends ApiController
             switch ($request->url_elements[4]) {
                 case 'talks':
                     $talk_mapper = new TalkMapper($db, $request);
-                    $list        = $talk_mapper->getTalksByEventId($event_id, $resultsperpage, $start, $verbose);
+                    $talks = $talk_mapper->getTalksByEventId($event_id, $resultsperpage, $start, $verbose);
+                    $list = $talks->getOutputView($request, $verbose);
                     break;
                 case 'comments':
                     $event_comment_mapper = new EventCommentMapper($db, $request);

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -51,6 +51,9 @@ class TalksController extends ApiController
             throw new Exception("You must be logged in to create data", 400);
         }
         $talk_id = $this->getItemId($request);
+        
+        // Retrieve the talk. It if doesn't exist, then 404 with talk not found
+        $talk= $this->getTalkById($db, $request, $talk_id);
 
         if (isset($request->url_elements[4])) {
             switch ($request->url_elements[4]) {
@@ -115,7 +118,6 @@ class TalksController extends ApiController
 
                     if ($new_id) {
                         $comment    = $comment_mapper->getCommentById($new_id);
-                        $talk       = $talk_mapper->getTalkById($talk_id);
                         $speakers   = $talk_mapper->getSpeakerEmailsByTalkId($talk_id);
                         $recipients = array();
                         foreach ($speakers as $person) {

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -183,15 +183,27 @@ class TalksController extends ApiController
         }
     }
 
-    protected function getTalkById($db, $request, $talk_id, $verbose = false)
+    /**
+     * Get a single talk
+     *
+     * @param  PDO      $db
+     * @param  Request  $request
+     * @param  integer  $talk_id
+     * @param  boolean $verbose
+     *
+     * @throws Exception if the talk is not found
+     *
+     * @return TalkModelCollection
+     */
+    protected function getTalkById($db, $request, $talk_id)
     {
         $mapper = new TalkMapper($db, $request);
-        $list   = $mapper->getTalkById($talk_id, $verbose);
-        if (false === $list) {
+        $talk   = $mapper->getTalkById($talk_id);
+        if (false === $talk) {
             throw new Exception('Talk not found', 404);
         }
 
-        return $list;
+        return $talk;
     }
 
     /**

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -167,8 +167,10 @@ class TalksController extends ApiController
             // delete the talk
             $talk_id     = $this->getItemId($request);
             $talk_mapper = new TalkMapper($db, $request);
-            $list        = $talk_mapper->getTalkById($talk_id);
-            if (false === $list) {
+            
+            // note: use the mapper's getTalkById as we don't want to throw a not found exception
+            $talk = $talk_mapper->getTalkById($talk_id);
+            if (false === $talk) {
                 // talk isn't there so it's as good as deleted
                 header("Content-Length: 0", null, 204);
                 exit; // no more content

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -27,15 +27,15 @@ class TalksController extends ApiController
             }
         } else {
             if ($talk_id) {
-                $list = $this->getTalkById($db, $request, $talk_id, $verbose);
-                if (false === $list) {
-                    throw new Exception('Talk not found', 404);
-                }
+                $talk = $this->getTalkById($db, $request, $talk_id);
+                $collection = new TalkModelCollection([$talk], 1);
+                $list = $collection->getOutputView($request, $verbose);
             } elseif (isset($request->parameters['title'])) {
                 $keyword = filter_var($request->parameters['title'], FILTER_SANITIZE_STRING);
 
                 $mapper = new TalkMapper($db, $request);
-                $list   = $mapper->getTalksByTitleSearch($keyword, $resultsperpage, $start, $verbose);
+                $talks = $mapper->getTalksByTitleSearch($keyword, $resultsperpage, $start, $verbose);
+                $list = $talks->getOutputView($request, $verbose);
             } else {
                 // listing makes no sense
                 throw new Exception('Generic talks listing not supported', 405);
@@ -314,8 +314,10 @@ class TalksController extends ApiController
         $uri = $request->base . '/' . $request->version . '/talks/' . $new_id;
         header("Location: " . $uri, true, 201);
 
-        $new_talk = $talk_mapper->getTalkById($new_id);
+        $new_talk = $this->getTalkById($db, $request, $new_id);
+        $collection = new TalkModelCollection([$new_talk], 1);
+        $list = $collection->getOutputView($request);
 
-        return $new_talk;
+        return $list;
     }
 }

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -17,7 +17,8 @@ class UsersController extends ApiController
             switch ($request->url_elements[4]) {
                 case 'talks':
                     $talk_mapper = new TalkMapper($db, $request);
-                    $list        = $talk_mapper->getTalksBySpeaker($user_id, $resultsperpage, $start, $verbose);
+                    $talks       = $talk_mapper->getTalksBySpeaker($user_id, $resultsperpage, $start, $verbose);
+                    $list        = $talks->getOutputView($request, $verbose);
                     break;
                 case 'hosted':
                     $event_mapper = new EventMapper($db, $request);

--- a/src/models/AbstractModel.php
+++ b/src/models/AbstractModel.php
@@ -1,0 +1,82 @@
+<?php
+
+abstract class AbstractModel
+{
+    /**
+     * @var array
+     */
+    protected $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Retrieve a single element from the model or false if it doesn't exist
+     *
+     * @param  string $field
+     * @return mixed
+     */
+    public function __get($field)
+    {
+        if (isset($this->data[ $field ])) {
+            return $this->data[ $field ];
+        }
+
+        return false;
+    }
+
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    abstract protected function getDefaultFields();
+
+    /**
+     * Verbose fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    abstract protected function getVerboseFields();
+
+    /**
+     * List of subresource keys that may be in the data set from the mapper
+     * but are not database columns that need to be in the output view
+     *
+     * format: [public facing name => field in $this->data]
+     *
+     * @return array
+     */
+    public function getSubResources()
+    {
+        return [];
+    }
+
+    /**
+     * Return this object with client-facing fields and hypermedia, ready for output
+     */
+    public function getOutputView(Request $request, $verbose = false)
+    {
+        $item    = array();
+
+        if ($verbose) {
+            $fields = $this->getVerboseFields();
+        } else {
+            $fields = $this->getDefaultFields();
+        }
+
+        $fields = array_merge($fields, $this->getSubResources());
+
+        foreach ($fields as $output_name => $name) {
+            $item[ $output_name ] = $this->$name;
+        }
+
+        return $item;
+    }
+}

--- a/src/models/AbstractModel.php
+++ b/src/models/AbstractModel.php
@@ -63,7 +63,7 @@ abstract class AbstractModel
      */
     public function getOutputView(Request $request, $verbose = false)
     {
-        $item    = array();
+        $item = array();
 
         if ($verbose) {
             $fields = $this->getVerboseFields();
@@ -73,8 +73,22 @@ abstract class AbstractModel
 
         $fields = array_merge($fields, $this->getSubResources());
 
+        // special handling for dates
+        if ($this->event_tz_place != '' && $this->event_tz_cont != '') {
+            $tz = $this->event_tz_cont . '/' . $this->event_tz_place;
+        } else {
+            $tz = 'UTC';
+        }
+
         foreach ($fields as $output_name => $name) {
-            $item[ $output_name ] = $this->$name;
+            $value = $this->$name;
+
+            // override if it is a date
+            if (substr($output_name, - 5) == '_date' && ! empty($value)) {
+                $value = Timezone::formattedEventDatetimeFromUnixtime($value, $tz, 'c');
+            }
+
+            $item[$output_name] = $value;
         }
 
         return $item;

--- a/src/models/AbstractModelCollection.php
+++ b/src/models/AbstractModelCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+abstract class AbstractModelCollection
+{
+    protected $list = [];
+    protected $total;
+
+    /**
+     * Adds count, total, and this_page links.  Also adds next_page and prev_page
+     * as appropriate
+     */
+    protected function addPaginationLinks($request)
+    {
+        $meta['count'] = count($this->list);
+
+        $meta['total']     = $this->total;
+        $meta['this_page'] = $request->base . $request->path_info . '?' .
+                             http_build_query($request->paginationParameters);
+        
+        $next_params = $prev_params = $counter_params = $request->paginationParameters;
+
+        $firstOnNextPage = $counter_params['start'] + $counter_params['resultsperpage'];
+        $firstOnThisPage = $counter_params['start'];
+
+        if ($firstOnNextPage < $this->total) {
+            $next_params['start'] = $next_params['start'] + $next_params['resultsperpage'];
+            $meta['next_page']    = $request->base . $request->path_info . '?' . http_build_query($next_params);
+        }
+        if (0 < $firstOnThisPage) {
+            $prev_params['start'] = $prev_params['start'] - $prev_params['resultsperpage'];
+            if ($prev_params['start'] < 0) {
+                $prev_params['start'] = 0;
+            }
+            $meta['prev_page'] = $request->base . $request->path_info . '?' . http_build_query($prev_params);
+        }
+
+        return $meta;
+    }
+}

--- a/src/models/TalkModel.php
+++ b/src/models/TalkModel.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Object that represents a talk
+ */
+class TalkModel extends AbstractModel
+{
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    public function getDefaultFields()
+    {
+        $fields = array(
+            'talk_title'              => 'talk_title',
+            'url_friendly_talk_title' => 'url_friendly_talk_title',
+            'talk_description'        => 'talk_desc',
+            'type'                    => 'talk_type',
+            'start_date'              => 'date_given',
+            'duration'                => 'duration',
+            'stub'                    => 'stub',
+            'average_rating'          => 'avg_rating',
+            'comments_enabled'        => 'comments_enabled',
+            'comment_count'           => 'comment_count',
+            'starred'                 => 'starred',
+            'starred_count'           => 'starred_count',
+        );
+
+        return $fields;
+    }
+
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    public function getVerboseFields()
+    {
+        $fields = $this->getDefaultFields();
+
+        $fields['slides_link'] = 'slides_link';
+        $fields['language']    = 'lang_name';
+
+        return $fields;
+    }
+
+    /**
+     * List of subresource keys that may be in the data set from the mapper
+     * but are not database columns that need to be in the output view
+     *
+     * format: [public facing name => field in $this->data]
+     *
+     * @return array
+     */
+    public function getSubResources()
+    {
+        return [
+            'speakers' => 'speakers',
+            'tracks'   => 'tracks',
+        ];
+    }
+
+    /**
+     * Return this object with client-facing fields and hypermedia, ready for output
+     */
+    public function getOutputView(Request $request, $verbose = false)
+    {
+        $item = parent::getOutputView($request, $verbose);
+        
+        // add Hypermedia
+        $base    = $request->base;
+        $version = $request->version;
+
+        $item['uri']                  = $base . '/' . $version . '/talks/' . $this->ID;
+        $item['verbose_uri']          = $base . '/' . $version . '/talks/' . $this->ID . '?verbose=yes';
+        $item['website_uri']          = 'http://joind.in/talk/view/' . $this->ID;
+        $item['starred_uri']          = $base . '/' . $version . '/talks/' . $this->ID . '/starred';
+        $item['comments_uri']         = $base . '/' . $version . '/talks/' . $this->ID . '/comments';
+        $item['verbose_comments_uri'] = $base . '/' . $version . '/talks/' . $this->ID
+                                        . '/comments?verbose=yes';
+        $item['event_uri']            = $base . '/' . $version . '/events/' . $this->event_id;
+
+        return $item;
+    }
+}

--- a/src/models/TalkModelCollection.php
+++ b/src/models/TalkModelCollection.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Container for multiple TalkModel objects, also handles
+ * collection metadata such as pagination
+ */
+class TalkModelCollection extends AbstractModelCollection
+{
+    protected $list = array();
+    protected $total;
+
+    /**
+     * Take arrays of data and create a collection of models; store metadata
+     */
+    public function __construct(array $data, $total)
+    {
+        $this->total = $total;
+
+        // hydrate the model objects if necessary and store to list
+        foreach ($data as $item) {
+            if (!$item instanceof TalkModel) {
+                $item = new TalkModel($item);
+            }
+            $this->list[] = $item;
+        }
+    }
+
+    /**
+     * Present this collection ready for the output handlers
+     *
+     * This creates the expected output structure, converting each resource
+     * to it's presentable representation and adding the meta fields for totals
+     * and pagination
+     */
+    public function getOutputView($request, $verbose = false)
+    {
+        // handle the collection first
+        $retval['talks'] = [];
+        foreach ($this->list as $item) {
+            $retval['talks'][] = $item->getOutputView($request, $verbose);
+        }
+
+        // add other fields
+        $retval['meta'] = $this->addPaginationLinks($request);
+
+        return $retval;
+    }
+
+    /**
+     * Return the list of talks (internal representation)
+     *
+     * @return array
+     */
+    public function getTalks()
+    {
+        return $this->list;
+    }
+ 
+    /**
+     * Return a single talk (internal representation)
+     *
+     * @return TalkModel|false
+     */
+    public function getTalk($index)
+    {
+        if (!isset($this->list[$index])) {
+            return false;
+        }
+
+        return $this->list[$index];
+    }
+}

--- a/src/models/TwitterRequestTokenModel.php
+++ b/src/models/TwitterRequestTokenModel.php
@@ -3,27 +3,14 @@
 /**
  * Object to represent a twitter request token
  */
-class TwitterRequestTokenModel
+class TwitterRequestTokenModel extends AbstractModel
 {
-
-    protected $data;
-
-    public function __construct($data)
-    {
-        $this->data = $data;
-    }
-
-    public function __get($field)
-    {
-        if (isset($this->data[ $field ])) {
-            return $this->data[ $field ];
-        }
-
-        return false;
-    }
-
     /**
-     * The fields to return, with public-facing name first, and database column second
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
      */
     protected function getDefaultFields()
     {
@@ -34,6 +21,13 @@ class TwitterRequestTokenModel
         return $fields;
     }
 
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
     protected function getVerboseFields()
     {
         $fields = array(
@@ -48,23 +42,14 @@ class TwitterRequestTokenModel
     /**
      * Return this object with client-facing fields and hypermedia, ready for output
      */
-    public function getOutputView($request, $verbose = false)
+    public function getOutputView(Request $request, $verbose = false)
     {
-        $item    = array();
+        $item = parent::getOutputView($request, $verbose);
+
+        // add Hypermedia
         $base    = $request->base;
         $version = $request->version;
 
-        if ($verbose) {
-            $fields = $this->getVerboseFields();
-        } else {
-            $fields = $this->getDefaultFields();
-        }
-
-        foreach ($fields as $output_name => $name) {
-            $item[ $output_name ] = $this->$name;
-        }
-
-        // what else?  Hypermedia
         $item['uri']         = $base . '/' . $version . '/twitter/request_tokens/' . $this->ID;
         $item['verbose_uri'] = $base . '/' . $version . '/twitter/request_tokens/' . $this->ID . '?verbose=yes';
 

--- a/src/models/TwitterRequestTokenModelCollection.php
+++ b/src/models/TwitterRequestTokenModelCollection.php
@@ -4,15 +4,12 @@
  * Container for multiple TwitterRequestTokenModel objects, also handles
  * collection metadata such as pagination
  */
-class TwitterRequestTokenModelCollection
+class TwitterRequestTokenModelCollection extends AbstractModelCollection
 {
-    protected $list = array();
-    protected $total;
-
     /**
      * Take arrays of data and create a collection of models; store metadata
      */
-    public function __construct($data, $total = 0)
+    public function __construct(array $data, $total = 0)
     {
         $this->total = $total;
 
@@ -42,38 +39,5 @@ class TwitterRequestTokenModelCollection
         $retval['meta'] = $this->addPaginationLinks($request);
 
         return $retval;
-    }
-
-    /**
-     * Direct port of the function in ApiMapper
-     *
-     * Adds count, total, and this_page links.  Also adds next_page and prev_page
-     * as appropriate
-     */
-    protected function addPaginationLinks($request)
-    {
-        $count         = count($this->list);
-        $meta['count'] = $count;
-
-        $meta['total']     = $this->total;
-        $meta['this_page'] = $request->base . $request->path_info . '?' .
-                             http_build_query($request->paginationParameters);
-        $next_params       = $prev_params = $counter_params = $request->paginationParameters;
-        $firstOnNextPage   = $counter_params['start'] + $counter_params['resultsperpage'];
-        $firstOnThisPage   = $counter_params['start'];
-
-        if ($firstOnNextPage < $this->total) {
-            $next_params['start'] = $next_params['start'] + $next_params['resultsperpage'];
-            $meta['next_page']    = $request->base . $request->path_info . '?' . http_build_query($next_params);
-        }
-        if (0 < $firstOnThisPage) {
-            $prev_params['start'] = $prev_params['start'] - $prev_params['resultsperpage'];
-            if ($prev_params['start'] < 0) {
-                $prev_params['start'] = 0;
-            }
-            $meta['prev_page'] = $request->base . $request->path_info . '?' . http_build_query($prev_params);
-        }
-
-        return $meta;
     }
 }

--- a/src/services/TalkCommentEmailService.php
+++ b/src/services/TalkCommentEmailService.php
@@ -2,23 +2,26 @@
 
 class TalkCommentEmailService extends EmailBaseService
 {
-
+    /**
+     * @var TalkModel
+     */
     protected $talk;
+
     protected $comment;
 
-    public function __construct($config, $recipients, $talk, $comment)
+    public function __construct($config, $recipients, TalkModel $talk, $comment)
     {
         // set up the common stuff first
         parent::__construct($config, $recipients);
 
         // this email needs talk and comment info
-        $this->talk    = $talk['talks'][0];
+        $this->talk    = $talk;
         $this->comment = $comment['comments'][0];
     }
 
     public function sendEmail()
     {
-        $this->setSubject("New feedback on " . $this->talk['talk_title']);
+        $this->setSubject("New feedback on " . $this->talk->talk_title);
 
         $byLine = '';
 
@@ -31,10 +34,10 @@ class TalkCommentEmailService extends EmailBaseService
         }
 
         $replacements = array(
-            "title"   => $this->talk['talk_title'],
+            "title"   => $this->talk->talk_title,
             "rating"  => $this->comment['rating'],
             "comment" => $this->comment['comment'],
-            "url"     => $this->talk['website_uri'],
+            "url"     => $this->talk->website_uri,
             "byline"  => $byLine
         );
 

--- a/tests/inc/TalkCommentEmailServiceTest.php
+++ b/tests/inc/TalkCommentEmailServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace JoindinTest\Inc;
 
+use \TalkModel;
+
 require_once __DIR__ . '/../../src/services/TalkCommentEmailService.php';
 
 class TalkCommentEmailServiceTest extends \PHPUnit_Framework_Testcase {
@@ -14,7 +16,7 @@ class TalkCommentEmailServiceTest extends \PHPUnit_Framework_Testcase {
     public function createService() {
         $config = array("email" => array("from" => "test@joind.in"));
         $recipients = array("test@joind.in");
-        $talk = array("talks" => array(array("talk_title" => "sample talk")));
+        $talk = new TalkModel(array("talk_title" => "sample talk"));
         $comment = array("comments" => array(array("comment" => "test comment", "rating" => 3)));
 
         $service = new \TalkCommentEmailService($config, $recipients, $talk, $comment);
@@ -29,7 +31,7 @@ class TalkCommentEmailServiceTest extends \PHPUnit_Framework_Testcase {
     public function createServiceWithEmailRedirect() {
         $config = array("email" => array("from" => "test@joind.in", "forward_all_to" => "blackhole@joind.in"));
         $recipients = array("test@joind.in");
-        $talk = array("talks" => array(array("talk_title" => "sample talk")));
+        $talk = new TalkModel(array("talk_title" => "sample talk"));
         $comment = array("comments" => array(array("comment" => "test comment", "rating" => 3)));
 
         $service = new \TalkCommentEmailService($config, $recipients, $talk, $comment);
@@ -44,7 +46,7 @@ class TalkCommentEmailServiceTest extends \PHPUnit_Framework_Testcase {
     public function templateReplacements() {
         $config = array("email" => array("from" => "test@joind.in"));
         $recipients = array("test@joind.in");
-        $talk = array("talks" => array(array("talk_title" => "sample talk")));
+        $talk = new TalkModel(array("talk_title" => "sample talk"));
         $comment = array("comments" => array(array("comment" => "test comment", "rating" => 3)));
 
         $service = new \TalkCommentEmailService($config, $recipients, $talk, $comment);
@@ -74,7 +76,7 @@ Questions? Comments?  Get in touch: [feedback@joind.in](mailto:feedback@joind.in
         
         $config = array("email" => array("from" => "test@joind.in"));
         $recipients = array("test@joind.in");
-        $talk = array("talks" => array(array("talk_title" => "sample talk")));
+        $talk = new TalkModel(array("talk_title" => "sample talk"));
         $comment = array("comments" => array(array("comment" => "test comment", "rating" => 3)));
 
         $service = new \TalkCommentEmailService($config, $recipients, $talk, $comment);


### PR DESCRIPTION
Implement TalkModelCollection and TalkModel to separate the output representation from the mapper.

This is a fairly large change-set, so I've tried to explain my thinking in each commit message…

Key things:

1. I've introduced `AbstractModel` and `AbstractModelCollection` to hold methods common to the respective `TwitterRequest` and `Talk` classes.
2. The `AbstractModel` has the concept of sub-resources in additional to default and verbose fields so that I could handle speakers and tracks.
3. The `TalkMapper` still needs to pre-process the results from a database read before passing to the Model. This was done in `transformResults()` which is inherited from `ApiMapper`, so I've created a new method called `processResults()` to do this work.
4. The TalkMapper's `getTalkById()` returns a `TalkModel` rather than a collection containing one item. This makes more more sense as it's used by the `TalkCommentEmailService`, which now uses the 'internal representation' of the talk rather than the output view one. This change also meant that the `TalkModelCollection`'s constructor can accept data that's already hydrated.
