### PR TITLE
Add ability to upload an event icon

### DIFF
--- a/src/config.php.dist
+++ b/src/config.php.dist
@@ -6,6 +6,9 @@ $config =  array(
     // the URL of web2 website is used in links within emails
     'website_url' => 'https://m.joind.in',
 
+    // The directory where event icons are stored
+    'event_icon_path' => __DIR__ . '/../../joind.in/src/inc/img/event_icons/',
+
     'oauth' => array(
         'expirable_client_ids' => array(
             // some clients, (e.g. web2) do not hold onto their token after the

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -12,6 +12,12 @@
         "verbs": ["GET"]
     },
     {
+        "path": "/events(/[\\d]+)/icon$",
+        "controller": "EventsController",
+        "action": "updateIconAction",
+        "verbs": ["PUT"]
+    },
+    {
         "path": "/events(/[^/]+)*/?$",
         "controller": "EventsController",
         "action": "getAction",

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -551,68 +551,9 @@ class EventsController extends ApiController
             throw new Exception('Missing type parameter', 400);
         }
 
-        // is this a valid image file?
-        $imageData = base64_decode($imageData);
-        $image = @imagecreatefromstring($imageData);
-        if ($image === false) {
-            throw new Exception('Unrecognised image', 400);
-        }
-
-        // is it square?
-        $width = imagesx($image);
-        $height = imagesy($image);
-
-        if ($width !== $height) {
-            imagedestroy($image);
-            throw new Exception('Image is not square', 400);
-        }
-
-        // determine filename and path
-        switch ($type) {
-            case 'image/png':
-                $filename = "event-logo-$event_id.png";
-                break;
-
-            default:
-                // jpeg
-                $filename = "event-logo-$event_id.jpg";
-        }
-        $path = $this->config['event_icon_path'] . $filename;
-
-        // Resize image
-        $newLogoWidth = 1440;
-        if ($width < $newLogoWidth) {
-            // image is too small to resize - just save it to avoid degradation
-            file_put_contents($path, $imageData);
-            imagedestroy($image);
-        } else {
-            // resize and save
-            $newLogo = imagecreatetruecolor($newLogoWidth, $newLogoWidth);
-            imagecopyresampled($newLogo, $image, 0, 0, 0, 0, $newLogoWidth, $newLogoWidth, $width, $width);
-
-            // save
-            switch ($type) {
-                case 'image/png':
-                    $saved = imagepng($newLogo, $path, 0);
-                    break;
-
-                default:
-                    // jpeg
-                    $saved = imagejpeg($newLogo, $path, 90);
-            }
-            imagedestroy($newLogo);
-            imagedestroy($image);
-            if (!$saved) {
-                throw new Exception('Failed to save image', 400);
-            }
-        }
-
-        // save filename to event record in database
-        $event_mapper = new EventMapper($db, $request);
-        $saved = $event_mapper->setIconFilename($event_id, $filename);
-        if (!$saved) {
-            throw new Exception('Failed to update event with icon information', 400);
-        }
+        // Store to disk and into database record
+        $icon = new EventIconModel(new EventMapper($db, $request), $this->config['event_icon_path']);
+        $icon->createFromData($type, $imageData, $event_id);
 
         http_response_code(204);
         exit;

--- a/src/models/EventIconModel.php
+++ b/src/models/EventIconModel.php
@@ -1,0 +1,114 @@
+<?php
+
+class EventIconModel
+{
+    private $eventMapper;
+    private $imageDirectory;
+
+    public function __construct(EventMapper $eventMapper, $imageDirectory)
+    {
+        $this->eventMapper = $eventMapper;
+        $this->imageDirectory = $imageDirectory;
+    }
+
+    /**
+     * create icon from uploaded image data
+     *
+     * @param string $type       image mime type
+     * @param string $imageData  image data
+     * @param string $event_id   event id
+     *
+     * @throws Exception on failure
+     */
+    public function createFromData($type, $imageData, $event_id)
+    {
+        // is this a valid image file?
+        $imageData = base64_decode($imageData);
+        $image = @imagecreatefromstring($imageData);
+        if ($image === false) {
+            throw new Exception('Unrecognised image', 400);
+        }
+
+        // is it square?
+        $width = imagesx($image);
+        $height = imagesy($image);
+
+        if ($width !== $height) {
+            imagedestroy($image);
+            throw new Exception('Image is not square', 400);
+        }
+
+        // determine extension
+        switch ($type) {
+            case 'image/png':
+                $extension = 'png';
+                break;
+
+            case 'image/jpeg':
+            case 'image/pjpeg':
+                $extension = 'jpg';
+                break;
+
+            default:
+                throw new Exception('Unrecognised image type. Only jpg or png is acceptable.', 400);
+        }
+
+        // create large image
+        $filename = "event-logo-$event_id-large.$extension";
+        $this->createImageOfSize($filename, 1440, $type, $imageData, $image);
+
+        // create small image
+        $filename = "event-logo-$event_id.$extension";
+        $this->createImageOfSize($filename, 140, $type, $imageData, $image);
+
+        imagedestroy($image);
+
+        // save filename to event record in database
+        $saved = $this->eventMapper->setIconFilename($event_id, $filename);
+        if (!$saved) {
+            throw new Exception('Failed to update event with icon information', 400);
+        }
+    }
+
+
+    /**
+     * Create image on disk of a particular size. Note event icons are square,
+     * so we only need the width.
+     *
+     * @param mixed $filename   Filename to store image
+     * @param mixed $width      Width of image
+     * @param mixed $type       Mime type of image data
+     * @param mixed $imageData  Image data
+     * @param mixed $image      Image resource
+     *
+     * @throws Exception on failure
+     */
+    protected function createImageOfSize($filename, $width, $type, $imageData, $image)
+    {
+        $path = $this->imageDirectory . $filename;
+        $currentWidth = imagesx($image);
+        if ($currentWidth < $width) {
+            // image is too small to resize - just save it to avoid degradation
+            file_put_contents($path, $imageData);
+        } else {
+            // resize and save
+            $newLogo = imagecreatetruecolor($width, $width);
+            imagecopyresampled($newLogo, $image, 0, 0, 0, 0, $width, $width, $currentWidth, $currentWidth);
+
+            // save
+            switch ($type) {
+                case 'image/png':
+                    $saved = imagepng($newLogo, $path, 0);
+                    break;
+
+                default:
+                    // jpeg
+                    $saved = imagejpeg($newLogo, $path, 90);
+            }
+            imagedestroy($newLogo);
+            if (!$saved) {
+                throw new Exception('Failed to save image', 400);
+            }
+        }
+    }
+}

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -869,6 +869,26 @@ class EventMapper extends ApiMapper
     }
 
     /**
+     * Set the the filename set for this event
+     *
+     * @param  integer $event_id
+     * @param  string $icon_filename
+     */
+    public function setIconFilename($event_id, $icon_filename)
+    {
+        $sql  = "UPDATE events SET event_icon = :icon_filename WHERE ID = :event_id";
+        $stmt = $this->_db->prepare($sql);
+
+        try {
+            $result = $stmt->execute(['icon_filename' => $icon_filename, 'event_id' => $event_id]);
+        } catch (Exception $e) {
+            // @todo: logging goes here when we get it
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Add a user as an admin on an event
      */
     public function addUserAsHost($event_id, $user_id)

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -385,6 +385,9 @@ class EventMapper extends ApiMapper
                 $list[$key]['tags'] = $this->getTags($row['ID']);
                 $list[$key]['uri']           = $base . '/' . $version . '/events/' . $row['ID'];
                 $list[ $key ]['verbose_uri']   = $base . '/' . $version . '/events/' . $row['ID'] . '?verbose=yes';
+                if ($verbose && $this->thisUserHasAdminOn($row['ID'])) {
+                    $list[$key]['icon_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/icon';
+                }
                 $list[$key]['comments_uri']  = $base . '/' . $version . '/events/' . $row['ID'] . '/comments';
                 $list[$key]['talks_uri']     = $base . '/' . $version . '/events/' . $row['ID'] . '/talks';
                 $list[ $key]['tracks_uri']    = $base . '/' . $version . '/events/' . $row['ID'] . '/tracks';


### PR DESCRIPTION
Implement a new endpoint of /events/{id}/icon which accepts a PUT request to set the icon for that event. The icon must be square and if it one side is larger than 1440 pixels, then it is resized to 1440px.

Also add the event's `icon_uri` to its verbose output.

This is the API part of [JOINDIN-530](https://joindin.jira.com/browse/JOINDIN-530).