### PR TITLE
Add icon_uri to the event resource

### DIFF
--- a/src/controllers/EmailsController.php
+++ b/src/controllers/EmailsController.php
@@ -7,7 +7,7 @@ class EmailsController extends ApiController
 {
     public function verifications($request, $db)
     {
-        $user_mapper = new UserMapper($db, $request);
+        $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
         $email       = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
         if (empty($email)) {
             throw new Exception("The email address must be supplied", 400);
@@ -31,7 +31,7 @@ class EmailsController extends ApiController
 
     public function usernameReminder($request, $db)
     {
-        $user_mapper = new UserMapper($db, $request);
+        $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
         $email       = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
         if (empty($email)) {
             throw new Exception("The email address must be supplied", 400);
@@ -53,7 +53,7 @@ class EmailsController extends ApiController
 
     public function passwordReset($request, $db)
     {
-        $user_mapper = new UserMapper($db, $request);
+        $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
         $username    = filter_var($request->getParameter("username"), FILTER_SANITIZE_STRING);
         if (empty($username)) {
             throw new Exception("A username must be supplied", 400);

--- a/src/controllers/Event_commentsController.php
+++ b/src/controllers/Event_commentsController.php
@@ -42,7 +42,7 @@ class Event_commentsController extends ApiController
         if (! isset($request->user_id) || empty($request->user_id)) {
             throw new Exception('You must log in to comment');
         }
-        $user_mapper = new UserMapper($db, $request);
+        $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
         $users       = $user_mapper->getUserById($request->user_id);
         $thisUser    = $users['users'][0];
 
@@ -84,7 +84,7 @@ class Event_commentsController extends ApiController
             }
         }
 
-        $event_mapper   = new EventMapper($db, $request);
+        $event_mapper   = new EventMapper($db, $request, $this->config['website_url']);
         $comment_mapper = new EventCommentMapper($db, $request);
 
         // should rating be allowed?
@@ -132,7 +132,7 @@ class Event_commentsController extends ApiController
 
         // notify event admins
         $comment      = $comment_mapper->getCommentById($commentId, true, true);
-        $event_mapper = new EventMapper($db, $request);
+        $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
         $recipients   = $event_mapper->getHostsEmailAddresses($eventId);
         $event        = $event_mapper->getEventById($eventId, true, true);
 

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -40,11 +40,11 @@ class EventsController extends ApiController
                     );
                     break;
                 case 'attendees':
-                    $user_mapper = new UserMapper($db, $request);
+                    $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
                     $list        = $user_mapper->getUsersAttendingEventId($event_id, $resultsperpage, $start, $verbose);
                     break;
                 case 'attending':
-                    $mapper = new EventMapper($db, $request);
+                    $mapper = new EventMapper($db, $request, $this->config['website_url']);
                     $list   = $mapper->getUserAttendance($event_id, $request->user_id);
                     break;
                 case 'tracks':
@@ -56,8 +56,8 @@ class EventsController extends ApiController
                     break;
             }
         } else {
-            $mapper           = new EventMapper($db, $request);
-            $user_mapper      = new UserMapper($db, $request);
+            $mapper           = new EventMapper($db, $request, $this->config['website_url']);
+            $user_mapper      = new UserMapper($db, $request, $this->config['website_url']);
             $isSiteAdmin      = $user_mapper->isSiteAdmin($request->user_id);
             $activeEventsOnly = $isSiteAdmin ? false : true;
 
@@ -80,7 +80,7 @@ class EventsController extends ApiController
                         if (! isset($request->user_id)) {
                             throw new Exception("You must be logged in to view pending events", 400);
                         }
-                        $user_mapper      = new UserMapper($db, $request);
+                        $user_mapper      = new UserMapper($db, $request, $this->config['website_url']);
                         $canApproveEvents = $user_mapper->isSiteAdmin($request->user_id);
                         if (! $canApproveEvents) {
                             throw new Exception("You don't have permission to view pending events", 403);
@@ -156,7 +156,7 @@ class EventsController extends ApiController
                     // the body of this request is completely irrelevant
                     // The logged in user *is* attending the event.  Use DELETE to unattend
                     $event_id     = $this->getItemId($request);
-                    $event_mapper = new EventMapper($db, $request);
+                    $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
                     $event_mapper->setUserAttendance($event_id, $request->user_id);
                     header("Location: " . $request->base . $request->path_info, null, 201);
 
@@ -282,7 +282,7 @@ class EventsController extends ApiController
 
             }
 
-            $event_mapper = new EventMapper($db, $request);
+            $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
 
             // Make sure they only have a maximum of $max_pending_events
             // unapproved event submissions at any time
@@ -302,7 +302,7 @@ class EventsController extends ApiController
             if ($errors) {
                 throw new Exception(implode(". ", $errors), 400);
             } else {
-                $user_mapper  = new UserMapper($db, $request);
+                $user_mapper  = new UserMapper($db, $request, $this->config['website_url']);
 
                 $event_owner           = $user_mapper->getUserById($request->user_id);
                 $event['contact_name'] = $event_owner['users'][0]['full_name'];
@@ -362,7 +362,7 @@ class EventsController extends ApiController
             switch ($request->url_elements[4]) {
                 case 'attending':
                     $event_id     = $this->getItemId($request);
-                    $event_mapper = new EventMapper($db, $request);
+                    $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
                     $event_mapper->setUserNonAttendance($event_id, $request->user_id);
                     header("Location: " . $request->base . $request->path_info, null, 200);
 
@@ -385,7 +385,7 @@ class EventsController extends ApiController
         $event_id = $this->getItemId($request);
         if (! isset($request->url_elements[4])) {
             // Edit an Event
-            $event_mapper   = new EventMapper($db, $request);
+            $event_mapper   = new EventMapper($db, $request, $this->config['website_url']);
             $existing_event = $event_mapper->getEventById($event_id, true);
             if (! $existing_event) {
                 throw new Exception(sprintf(
@@ -539,7 +539,7 @@ class EventsController extends ApiController
         }
 
         $event_id     = $this->getItemId($request);
-        $event_mapper = new EventMapper($db, $request);
+        $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
 
         if (! $event_mapper->thisUserCanApproveEvents()) {
             throw new Exception("You are not allowed to approve this event", 403);
@@ -579,7 +579,7 @@ class EventsController extends ApiController
         }
 
         $event_id     = $this->getItemId($request);
-        $event_mapper = new EventMapper($db, $request);
+        $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
 
         if (! $event_mapper->thisUserCanApproveEvents()) {
             throw new Exception("You are not allowed to reject this event", 403);

--- a/src/controllers/Talk_commentsController.php
+++ b/src/controllers/Talk_commentsController.php
@@ -50,7 +50,7 @@ class Talk_commentsController extends ApiController
 
         // notify event admins
         $comment      = $comment_mapper->getCommentById($commentId, true, true);
-        $event_mapper = new EventMapper($db, $request);
+        $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
         $recipients   = $event_mapper->getHostsEmailAddresses($eventId);
 
         $emailService = new CommentReportedEmailService($this->config, $recipients, $comment);

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -220,7 +220,7 @@ class TalksController extends ApiController
             );
         }
 
-        $event_mapper = new EventMapper($db, $request);
+        $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
         $talk_mapper = new TalkMapper($db, $request);
         $talk_type_mapper = new TalkTypeMapper($db, $request);
 

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -20,11 +20,11 @@ class UsersController extends ApiController
                     $list        = $talk_mapper->getTalksBySpeaker($user_id, $resultsperpage, $start, $verbose);
                     break;
                 case 'hosted':
-                    $event_mapper = new EventMapper($db, $request);
+                    $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
                     $list         = $event_mapper->getEventsHostedByUser($user_id, $resultsperpage, $start, $verbose);
                     break;
                 case 'attended':
-                    $event_mapper = new EventMapper($db, $request);
+                    $event_mapper = new EventMapper($db, $request, $this->config['website_url']);
                     $list         = $event_mapper->getEventsAttendedByUser($user_id, $resultsperpage, $start, $verbose);
                     break;
                 case 'talk_comments':
@@ -41,7 +41,7 @@ class UsersController extends ApiController
                     break;
             }
         } else {
-            $mapper = new UserMapper($db, $request);
+            $mapper = new UserMapper($db, $request, $this->config['website_url']);
             if ($user_id) {
                 $list = $mapper->getUserById($user_id, $verbose);
                 if (count($list['users']) == 0) {
@@ -69,7 +69,7 @@ class UsersController extends ApiController
         if (isset($request->url_elements[3])) {
             switch ($request->url_elements[3]) {
                 case 'verifications':
-                    $user_mapper = new UserMapper($db, $request);
+                    $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
                     $token       = filter_var($request->getParameter("token"), FILTER_SANITIZE_STRING);
                     if (empty($token)) {
                         throw new Exception("Verification token must be supplied", 400);
@@ -91,7 +91,7 @@ class UsersController extends ApiController
             $user   = array();
             $errors = array();
 
-            $user_mapper = new UserMapper($db, $request);
+            $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
 
             // Required Fields
             $user['username'] = filter_var(trim($request->getParameter("username")), FILTER_SANITIZE_STRING);
@@ -187,7 +187,7 @@ class UsersController extends ApiController
 
         $userId = $this->getItemId($request);
 
-        $user_mapper = new UserMapper($db, $request);
+        $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
         if ($user_mapper->thisUserHasAdminOn($userId)) {
             $oauthModel  = $request->getOauthModel($db);
             $accessToken = $request->getAccessToken();
@@ -280,7 +280,7 @@ class UsersController extends ApiController
             throw new Exception("New password must be supplied", 400);
         }
         // now check the password complies with our rules
-        $user_mapper = new UserMapper($db, $request);
+        $user_mapper = new UserMapper($db, $request, $this->config['website_url']);
         $validity    = $user_mapper->checkPasswordValidity($password);
         if (true === $validity) {
             // OK, go ahead

--- a/src/models/ApiMapper.php
+++ b/src/models/ApiMapper.php
@@ -2,15 +2,19 @@
 
 class ApiMapper
 {
+    protected $website_base_uri;
+    
     /**
      * Object constructor, sets up the db and some objects need request too
      *
-     * @param PDO $db The database connection handle
-     * @param Request $request The request object (optional not all objects need it)
+     * @param PDO $db                  The database connection handle
+     * @param Request $request         The request object (optional not all objects need it)
+     * @param string $website_base_uri The base URL of the main website for this instance of the API (optional)
      */
-    public function __construct(PDO $db, Request $request = null)
+    public function __construct(PDO $db, Request $request = null, $website_base_uri = 'https://joind.in')
     {
         $this->_db = $db;
+        $this->website_base_uri = $website_base_uri;
         if (isset($request)) {
             $this->_request = $request;
         }

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -386,10 +386,10 @@ class EventMapper extends ApiMapper
                 if ($row['pending'] == 1 && $thisUserCanApproveEvents) {
                     $list[$key]['approval_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/approval';
                 }
-                $list[$key]['website_uri'] = 'http://joind.in/event/view/' . $row['ID'];
+                $list[$key]['website_uri'] = $this->website_base_uri . '/event/view/' . $row['ID'];
                 // handle the slug
                 if (!empty($row['event_stub'])) {
-                    $list[$key]['humane_website_uri'] = 'http://joind.in/event/' . $row['event_stub'];
+                    $list[$key]['humane_website_uri'] = $this->website_base_uri . '/event/' . $row['event_stub'];
                 }
 
                 if ($verbose) {
@@ -611,7 +611,7 @@ class EventMapper extends ApiMapper
     {
         // do we even have an authenticated user?
         if (isset($this->_request->user_id)) {
-            $user_mapper = new UserMapper($this->_db, $this->_request);
+            $user_mapper = new UserMapper($this->_db, $this->_request, $this->config['website_url']);
 
             // is user site admin?
             $is_site_admin = $user_mapper->isSiteAdmin($this->_request->user_id);
@@ -635,7 +635,7 @@ class EventMapper extends ApiMapper
     {
         // do we even have an authenticated user?
         if (isset($this->_request->user_id)) {
-            $user_mapper = new UserMapper($this->_db, $this->_request);
+            $user_mapper = new UserMapper($this->_db, $this->_request, $this->config['website_url']);
 
             // is user site admin?
             $is_site_admin = $user_mapper->isSiteAdmin($this->_request->user_id);

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -392,6 +392,12 @@ class EventMapper extends ApiMapper
                     $list[$key]['humane_website_uri'] = $this->website_base_uri . '/event/' . $row['event_stub'];
                 }
 
+                // full uri to icon
+                $list[$key]['icon_uri'] = $this->website_base_uri . '/img/event_icons/none.png';
+                if ($row['event_icon']) {
+                    $list[$key]['icon_uri'] = $this->website_base_uri . '/inc/img/event_icons/' . $row['event_icon'];
+                }
+
                 if ($verbose) {
                     $list[$key]['all_talk_comments_uri'] = $base . '/' . $version . '/events/'
                                                            . $row['ID'] . '/talk_comments';

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -595,7 +595,7 @@ class TalkMapper extends ApiMapper
     {
         // do we even have an authenticated user?
         if (isset($this->_request->user_id)) {
-            $user_mapper = new UserMapper($this->_db, $this->_request);
+            $user_mapper = new UserMapper($this->_db, $this->_request, $this->website_base_uri);
 
             // is user site admin?
             $is_site_admin = $user_mapper->isSiteAdmin($this->_request->user_id);

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -197,7 +197,7 @@ class UserMapper extends ApiMapper
                 }
                 $list[$key]['uri']                 = $base . '/' . $version . '/users/' . $row['ID'];
                 $list[$key]['verbose_uri']         = $base . '/' . $version . '/users/' . $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']         = 'http://joind.in/user/view/' . $row['ID'];
+                $list[$key]['website_uri']         = $this->website_base_uri . '/user/view/' . $row['ID'];
                 $list[$key]['talks_uri']           = $base . '/' . $version . '/users/' . $row['ID'] . '/talks/';
                 $list[$key]['attended_events_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '/attended/';
                 $list[$key]['hosted_events_uri']   = $base . '/' . $version . '/users/' . $row['ID'] . '/hosted/';


### PR DESCRIPTION
This provides `icon_ui` which is the fully qualified URL to the event's icon. It assumes that the image is stored in such a way that it can be accessed via `{website uri}/inc/img/event_icons/{icon filename}`.
 
Note that this PR builds on #291 as it needs the same config variable in the mapper.