### PR TITLE
Allow clearing of event CfP dates on PUT

### DIFF
--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -475,11 +475,14 @@ class EventsController extends ApiController
                 // we got a value, filter and save it
                 $event['cfp_url'] = filter_var($cfp_url, FILTER_VALIDATE_URL);
             }
+
+            $event['cfp_start_date'] = null;
             $cfp_start_date = $request->getParameter("cfp_start_date", false);
             if (false !== $cfp_start_date && strtotime($cfp_start_date)) {
                 $cfp_start_date          = new DateTime($cfp_start_date, $tz);
                 $event['cfp_start_date'] = $cfp_start_date->format('U');
             }
+            $event['cfp_end_date'] = null;
             $cfp_end_date = $request->getParameter("cfp_end_date", false);
             if (false !== $cfp_end_date && strtotime($cfp_end_date)) {
                 $cfp_end_date          = new DateTime($cfp_end_date, $tz);

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -833,7 +833,7 @@ class EventMapper extends ApiMapper
             if (in_array($column_name, ['pending', 'active'])) {
                 continue;
             }
-            if (isset($event[$api_name])) {
+            if (array_key_exists($api_name, $event)) {
                 $pairs[]            = "$column_name = :$api_name";
                 $items[$api_name] = $event[$api_name];
             }


### PR DESCRIPTION
Take advantage of the fact that a PUT should be a complete representation of the resource. As a result, if the cfp dates are invalid, empty or missing, we clear these fields when storing to the database.