### PR TITLE
Update the website URLs to match new site

### DIFF
--- a/src/inc/Request.php
+++ b/src/inc/Request.php
@@ -641,4 +641,24 @@ class Request
     {
         return $this->clientUserAgent;
     }
+
+    /**
+     * Fetch a config value by named key.  If the value doesn't exist then
+     * return the default value
+     *
+     * @param string $param Parameter to retrieve
+     * @param string $default Default to return if parameter doesn't exist
+     *
+     * @return string
+     */
+    public function getConfigValue($key, $default = '')
+    {
+        $value = $default;
+        if (array_key_exists($key, $this->config)) {
+            $value = $this->config[$key];
+        }
+
+        return $value;
+    }
+
 }

--- a/src/inc/Request.php
+++ b/src/inc/Request.php
@@ -660,5 +660,4 @@ class Request
 
         return $value;
     }
-
 }

--- a/src/models/ApiMapper.php
+++ b/src/models/ApiMapper.php
@@ -13,6 +13,7 @@ class ApiMapper
         $this->_db = $db;
         if (isset($request)) {
             $this->_request = $request;
+            $this->website_url = $request->getConfigValue('website_url');
         }
 
         return true;

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -386,13 +386,13 @@ class EventMapper extends ApiMapper
                 if ($row['pending'] == 1 && $thisUserCanApproveEvents) {
                     $list[$key]['approval_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/approval';
                 }
-                $list[$key]['website_uri'] = 
-                    $this->_request->getConfigValue('website_url') 
+                $list[$key]['website_uri'] =
+                    $this->_request->getConfigValue('website_url')
                     . '/event/' . $row['url_friendly_name'];
                 // handle the slug
                 if (!empty($row['event_stub'])) {
-                    $list[$key]['humane_website_uri'] = 
-                        $this->_request->getConfigValue('website_url') 
+                    $list[$key]['humane_website_uri'] =
+                        $this->_request->getConfigValue('website_url')
                         . '/e/' . $row['event_stub'];
                 }
 

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -386,14 +386,10 @@ class EventMapper extends ApiMapper
                 if ($row['pending'] == 1 && $thisUserCanApproveEvents) {
                     $list[$key]['approval_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/approval';
                 }
-                $list[$key]['website_uri'] =
-                    $this->_request->getConfigValue('website_url')
-                    . '/event/' . $row['url_friendly_name'];
+                $list[$key]['website_uri'] = $this->website_url . '/event/' . $row['url_friendly_name'];
                 // handle the slug
                 if (!empty($row['event_stub'])) {
-                    $list[$key]['humane_website_uri'] =
-                        $this->_request->getConfigValue('website_url')
-                        . '/e/' . $row['event_stub'];
+                    $list[$key]['humane_website_uri'] = $this->website_url . '/e/' . $row['event_stub'];
                 }
 
                 if ($verbose) {

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -386,10 +386,14 @@ class EventMapper extends ApiMapper
                 if ($row['pending'] == 1 && $thisUserCanApproveEvents) {
                     $list[$key]['approval_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/approval';
                 }
-                $list[$key]['website_uri'] = 'http://joind.in/event/view/' . $row['ID'];
+                $list[$key]['website_uri'] = 
+                    $this->_request->getConfigValue('website_url') 
+                    . '/event/' . $row['url_friendly_name'];
                 // handle the slug
                 if (!empty($row['event_stub'])) {
-                    $list[$key]['humane_website_uri'] = 'http://joind.in/event/' . $row['event_stub'];
+                    $list[$key]['humane_website_uri'] = 
+                        $this->_request->getConfigValue('website_url') 
+                        . '/e/' . $row['event_stub'];
                 }
 
                 if ($verbose) {

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -102,8 +102,7 @@ class TalkMapper extends ApiMapper
                 $list[$key]['uri']                  = $base . '/' . $version . '/talks/' . $row['ID'];
                 $list[$key]['verbose_uri']          = $base . '/' . $version . '/talks/' .
                                                         $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']          = $this->_request->getConfigValue('website_url')
-                    . '/talk/' . $row['stub'];
+                $list[$key]['website_uri']          = $this->website_url . '/talk/' . $row['stub'];
                 $list[$key]['comments_uri']         = $base . '/' . $version . '/talks/' . $row['ID'] . '/comments';
                 $list[$key]['starred_uri']          = $base . '/' . $version . '/talks/' . $row['ID'] . '/starred';
                 $list[$key]['verbose_comments_uri'] = $base . '/' . $version . '/talks/' . $row['ID'] .

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -102,7 +102,7 @@ class TalkMapper extends ApiMapper
                 $list[$key]['uri']                  = $base . '/' . $version . '/talks/' . $row['ID'];
                 $list[$key]['verbose_uri']          = $base . '/' . $version . '/talks/' .
                                                         $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']          = $this->_request->getConfigValue('website_url') 
+                $list[$key]['website_uri']          = $this->_request->getConfigValue('website_url')
                     . '/talk/' . $row['stub'];
                 $list[$key]['comments_uri']         = $base . '/' . $version . '/talks/' . $row['ID'] . '/comments';
                 $list[$key]['starred_uri']          = $base . '/' . $version . '/talks/' . $row['ID'] . '/starred';

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -102,7 +102,8 @@ class TalkMapper extends ApiMapper
                 $list[$key]['uri']                  = $base . '/' . $version . '/talks/' . $row['ID'];
                 $list[$key]['verbose_uri']          = $base . '/' . $version . '/talks/' .
                                                         $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']          = 'http://joind.in/talk/view/' . $row['ID'];
+                $list[$key]['website_uri']          = $this->_request->getConfigValue('website_url') 
+                    . '/talk/' . $row['stub'];
                 $list[$key]['comments_uri']         = $base . '/' . $version . '/talks/' . $row['ID'] . '/comments';
                 $list[$key]['starred_uri']          = $base . '/' . $version . '/talks/' . $row['ID'] . '/starred';
                 $list[$key]['verbose_comments_uri'] = $base . '/' . $version . '/talks/' . $row['ID'] .

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -197,8 +197,7 @@ class UserMapper extends ApiMapper
                 }
                 $list[$key]['uri']                 = $base . '/' . $version . '/users/' . $row['ID'];
                 $list[$key]['verbose_uri']         = $base . '/' . $version . '/users/' . $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']         = $this->_request->getConfigValue('website_url')
-                    . '/user/' . $row['username'];
+                $list[$key]['website_uri']         = $this->website_url . '/user/' . $row['username'];
                 $list[$key]['talks_uri']           = $base . '/' . $version . '/users/' . $row['ID'] . '/talks/';
                 $list[$key]['attended_events_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '/attended/';
                 $list[$key]['hosted_events_uri']   = $base . '/' . $version . '/users/' . $row['ID'] . '/hosted/';

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -197,7 +197,8 @@ class UserMapper extends ApiMapper
                 }
                 $list[$key]['uri']                 = $base . '/' . $version . '/users/' . $row['ID'];
                 $list[$key]['verbose_uri']         = $base . '/' . $version . '/users/' . $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']         = 'http://joind.in/user/view/' . $row['ID'];
+                $list[$key]['website_uri']         = $this->_request->getConfigValue('website_url') 
+                    . '/user/' . $row['username'];
                 $list[$key]['talks_uri']           = $base . '/' . $version . '/users/' . $row['ID'] . '/talks/';
                 $list[$key]['attended_events_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '/attended/';
                 $list[$key]['hosted_events_uri']   = $base . '/' . $version . '/users/' . $row['ID'] . '/hosted/';

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -197,7 +197,7 @@ class UserMapper extends ApiMapper
                 }
                 $list[$key]['uri']                 = $base . '/' . $version . '/users/' . $row['ID'];
                 $list[$key]['verbose_uri']         = $base . '/' . $version . '/users/' . $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']         = $this->_request->getConfigValue('website_url') 
+                $list[$key]['website_uri']         = $this->_request->getConfigValue('website_url')
                     . '/user/' . $row['username'];
                 $list[$key]['talks_uri']           = $base . '/' . $version . '/users/' . $row['ID'] . '/talks/';
                 $list[$key]['attended_events_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '/attended/';

--- a/src/services/EventSubmissionEmailService.php
+++ b/src/services/EventSubmissionEmailService.php
@@ -12,6 +12,7 @@ class EventSubmissionEmailService extends EmailBaseService
 
         // this email needs event info
         $this->event = $event;
+        $this->website_url = $config['website_url'];
 
         $this->count = $count;
     }
@@ -27,6 +28,7 @@ class EventSubmissionEmailService extends EmailBaseService
             "description"  => $this->event['description'],
             "date"         => $date->format('jS M, Y'),
             "contact_name" => $this->event['contact_name'],
+            "website_url"  => $this->website_url,
         );
 
         if ($this->count) {

--- a/src/views/emails/eventSubmission.md
+++ b/src/views/emails/eventSubmission.md
@@ -8,6 +8,6 @@ Please review a new event submission to joind.in:
 
 *Description:* [description]
 
-View all pending submissions here: [https://m.joind.in/event/pending](https://m.joind.in/event/pending)
+View all pending submissions here: [[website_url]/event/pending]([website_url]/event/pending)
 [count]
 


### PR DESCRIPTION
This PR does two main things:
 - updates the website URLs returned by the API to be the preferred URL structure for the web2 site
 - uses the configurable location of that URL so that the links also work on other platforms (to get the config, I added a getter into the request object as it's in scope and contains the config)