### PR TITLE
"all" filter for events collection

### DIFF
--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -39,7 +39,7 @@ abstract class ApiController
 
     public function getStart($request)
     {
-        return (int) $request->paginationParameters['start'];
+        return $request->paginationParameters['start'];
 
     }
 

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -72,7 +72,7 @@ class EventsController extends ApiController
                 $params = array();
 
                 // collection type filter
-                $filters = array("hot", "upcoming", "past", "cfp", "pending");
+                $filters = array("hot", "upcoming", "past", "cfp", "pending", "all");
                 if (isset($request->parameters['filter']) && in_array($request->parameters['filter'], $filters)) {
                     $params["filter"] = $request->parameters['filter'];
 

--- a/src/inc/Request.php
+++ b/src/inc/Request.php
@@ -366,7 +366,7 @@ class Request
         }
 
         if (! isset($this->paginationParameters['start'])) {
-            $this->paginationParameters['start'] = 0;
+            $this->paginationParameters['start'] = null;
         }
         if (! isset($this->paginationParameters['resultsperpage'])) {
             $this->paginationParameters['resultsperpage'] = 20;

--- a/src/models/ApiMapper.php
+++ b/src/models/ApiMapper.php
@@ -71,6 +71,7 @@ class ApiMapper
             // special case, no limits
             $limit = '';
         } else {
+            $start = (int)$start;
             $limit = ' LIMIT ' . $start . ',' . $resultsperpage;
         }
 

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -151,6 +151,9 @@ class EventMapper extends ApiMapper
         }
         if (array_key_exists("filter", $params)) {
             switch ($params['filter']) {
+                case "all": // current and popular events
+                    $order .= 'events.event_start';
+                    break;
                 case "hot": // current and popular events
                     $order .= "score - ((comment_count + attendee_count + 1) / 5)";
                     break;
@@ -224,6 +227,23 @@ class EventMapper extends ApiMapper
             $data["enddate"] = $params["enddate"];
         }
 
+        // If the "all" filter is selected and a start parameter isn't provided, then
+        // we need to calculate it such that the results returned include the first
+        // upcoming event. This allows client to go backwards and forwards from here.
+        if (array_key_exists("filter", $params) && $params['filter'] == 'all' && $start === null) {
+            // How many events are there up to "now"?
+            $this_sql = $sql . $where . ' and (events.event_start <' . (mktime(0, 0, 0)) . ')';
+            $number_previous_events = $this->getTotalCount($this_sql, $data);
+            
+            // move $start to the $resultsperpage boundary so that the client's
+            // pagination works as they expect
+            $page = floor($number_previous_events / $resultsperpage);
+            $start = $page * $resultsperpage;
+
+            // store back into paginationParameters so that meta is correct
+            $this->_request->paginationParameters['start'] = $start;
+        }
+ 
         // now add all that where clause
         $sql .= $where;
 

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -233,12 +233,7 @@ class EventMapper extends ApiMapper
         if (array_key_exists("filter", $params) && $params['filter'] == 'all' && $start === null) {
             // How many events are there up to "now"?
             $this_sql = $sql . $where . ' and (events.event_start <' . (mktime(0, 0, 0)) . ')';
-            $number_previous_events = $this->getTotalCount($this_sql, $data);
-            
-            // move $start to the $resultsperpage boundary so that the client's
-            // pagination works as they expect
-            $page = floor($number_previous_events / $resultsperpage);
-            $start = $page * $resultsperpage;
+            $start = $this->getTotalCount($this_sql, $data);
 
             // store back into paginationParameters so that meta is correct
             $this->_request->paginationParameters['start'] = $start;


### PR DESCRIPTION
The "all" filter provides all active events in ascending date order. If the "start" parameter is not provided, then the collection will provide the first page where there is an event in the future.

This allows a client to go "backwards" from this point to retrieve past events seamlessly.