### PR TITLE
Update the phing config to get the reports to work again on the VM

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -73,6 +73,7 @@
               <exclude name="**/database.php" />
           </patternset>
         </fileset>
+        <formatter type="full" usefile="false" />
     </phpcodesniffer>
 </target>
 


### PR DESCRIPTION
When running `phing phpcs-human` on the VM to check my phpcs compliance, I got the error

`ERROR: Report type "default" not known`

By adding some phing config to specify the report type, this now works.