### PR TITLE
Exclude private events from pending events count

### DIFF
--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -972,7 +972,7 @@ class EventMapper extends ApiMapper
     {
         $sql = 'select count(*) as count '
                . 'from events '
-               . 'where pending = 1';
+               . 'where pending = 1 and private = 0';
 
         $stmt     = $this->_db->prepare($sql);
         $response = $stmt->execute();


### PR DESCRIPTION
The email notifications show an inaccurate count of events pending
because they weren't excluding the private events, which we won't
approve anyway