### PR TITLE
Adds a way to retrieve speakers for a talk

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -60,6 +60,12 @@
         "verbs": ["DELETE"]
     },
     {
+        "path": "/talks(/[^/]+)*/speakers/?$",
+        "controller": "Talk_speakersController",
+        "action": "listSpeakersAction",
+        "verbs": ["GET"]
+    },
+    {
         "path": "/talks(/[^/]+)*/?$",
         "controller": "TalksController",
         "action": "getAction",
@@ -77,7 +83,12 @@
         "action": "deleteAction",
         "verbs": ["DELETE"]
     },
-
+    {
+        "path": "/speakers(/[^/]+)*/?$",
+        "controller": "Talk_speakersController",
+        "action": "getSpeakerAction",
+        "verbs" : ["GET"]
+    },
     {
         "path": "/token(/[^/]+)*/?$",
         "controller": "TokenController",

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -61,7 +61,7 @@
     },
     {
         "path": "/talks(/[^/]+)*/speakers/?$",
-        "controller": "Talk_speakersController",
+        "controller": "TalkSpeakersController",
         "action": "listSpeakersAction",
         "verbs": ["GET"]
     },
@@ -85,7 +85,7 @@
     },
     {
         "path": "/speakers(/[^/]+)*/?$",
-        "controller": "Talk_speakersController",
+        "controller": "TalkSpeakersController",
         "action": "getSpeakerAction",
         "verbs" : ["GET"]
     },

--- a/src/controllers/TalkSpeakersController.php
+++ b/src/controllers/TalkSpeakersController.php
@@ -1,6 +1,6 @@
 <?php
 
-class Talk_speakersController extends ApiController
+class TalkSpeakersController extends ApiController
 {
     /**
      * Get a list of Speakers for a given talk
@@ -24,8 +24,12 @@ class Talk_speakersController extends ApiController
 
         $talkSpeakerMapper = new TalkSpeakerMapper($db, $request);
 
-        $list = $talkSpeakerMapper->getSpeakersByTalkId($talk_id,
-            $resultsperpage, $start, $verbose);
+        $list = $talkSpeakerMapper->getSpeakersByTalkId(
+            $talk_id,
+            $resultsperpage,
+            $start,
+            $verbose
+        );
 
         return $list;
     }

--- a/src/controllers/Talk_speakersController.php
+++ b/src/controllers/Talk_speakersController.php
@@ -1,0 +1,54 @@
+<?php
+
+class Talk_speakersController extends ApiController
+{
+    /**
+     * Get a list of Speakers for a given talk
+     *
+     * @param Request $request
+     * @param PDO     $db
+     *
+     * @throws Exception
+     * @return array|bool
+     */
+    public function listSpeakersAction(Request $request, $db)
+    {
+        $talk_id = $this->getItemId($request);
+
+        // verbosity
+        $verbose = $this->getVerbosity($request);
+
+        // pagination settings
+        $start          = $this->getStart($request);
+        $resultsperpage = $this->getResultsPerPage($request);
+
+        $talkSpeakerMapper = new TalkSpeakerMapper($db, $request);
+
+        $list = $talkSpeakerMapper->getSpeakersByTalkId($talk_id,
+            $resultsperpage, $start, $verbose);
+
+        return $list;
+    }
+
+    /**
+     * Handle getting a specific speaker for a talk
+     *
+     * @param Request $request
+     * @param PDO     $db
+     *
+     * @return array;
+     */
+    public function getSpeakerAction($request, $db)
+    {
+        $speaker_id = $this->getItemId($request);
+
+        $verbose = $this->getVerbosity($request);
+
+        $talkSpeakerMapper = new TalkSpeakerMapper($db, $request);
+
+        $list = $talkSpeakerMapper->getSpeakerById($speaker_id, $verbose);
+
+        return $list;
+
+    }
+}

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -236,6 +236,7 @@ class TalkMapper extends ApiMapper
                 } else {
                     $entry['speaker_name'] = $person['speaker_name'];
                 }
+                $entry['uri'] = $base . '/' . $version . '/speakers/' . $person['ID'];
                 $retval[] = $entry;
             }
         }

--- a/src/models/TalkModel.php
+++ b/src/models/TalkModel.php
@@ -84,6 +84,7 @@ class TalkModel extends AbstractModel
         $item['verbose_comments_uri'] = $base . '/' . $version . '/talks/' . $this->ID
                                         . '/comments?verbose=yes';
         $item['event_uri']            = $base . '/' . $version . '/events/' . $this->event_id;
+        $item['speakers_uri']         = $base . '/' . $version . '/talks/' . $this->ID . '/speakers';
 
         return $item;
     }

--- a/src/models/TalkSpeakerMapper.php
+++ b/src/models/TalkSpeakerMapper.php
@@ -1,0 +1,161 @@
+<?php
+
+class TalkSpeakerMapper extends ApiMapper
+{
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultFields() {
+        $fields = array(
+            "username" => "speaker_name",
+            "full_name" => "full_name",
+            "twitter_username" => "twitter_username"
+        );
+        return $fields;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getVerboseFields() {
+        $fields = array(
+            "username" => "speaker_name",
+            "full_name" => "full_name",
+            "twitter_username" => "twitter_username"
+        );
+        return $fields;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function transformResults($results, $verbose)
+    {
+        $total = $results['total'];
+        unset($results['total']);
+        $list = parent::transformResults($results, $verbose);
+
+        $base = $this->_request->base;
+        $version = $this->_request->version;
+        if(is_array($list) && count($list)) {
+            foreach($results as $key => $row) {
+                // add speakers
+                $list[$key]['uri'] = $base . '/' . $version . '/speakers/' . $row['speaker_id'] ;
+                $list[$key]['verbose_uri'] = $base . '/' . $version . '/speakers/' . $row['speaker_id'] . '?verbose=yes';
+                $list[$key]['talk_uri'] = $base . '/' . $version . '/talks/' . $row['talk_id'];
+                if (isset($row['user_id'])) {
+                    $list[$key]['user_uri'] = $base . '/' . $version . '/users/' . $row['user_id'];
+                }
+            }
+        }
+
+        $retval = array();
+        $retval['speakers'] = $list;
+        $retval['meta'] = $this->getPaginationLinks($list, $total);
+
+        return $retval;
+
+    }
+
+    /**
+     * Get a list of ALL speakers of a talk (confirmed AND unconfirmed)
+     *
+     * @param int  $talk_id
+     * @param int  $resultsperpage
+     * @param int  $start
+     * @param bool $verbose
+     *
+     * @return array|false
+     */
+    public function getSpeakersByTalkId($talk_id, $resultsperpage, $start, $verbose = false)
+    {
+        $results = $this->getUsers(
+            $resultsperpage,
+            $start,
+            'speaker.talk_id= :talk_id',
+            null,
+            array('talk_id' => $talk_id)
+        );
+
+        if ($results && $results['total'] > 0) {
+            $retval = $this->transformResults($results, $verbose);
+            return $retval;
+        }
+        return false;
+    }
+
+    /**
+     * Get users for a given talk
+     *
+     * @param int    $resultsperpage
+     * @param int    $start
+     * @param string $where
+     * @param string $order
+     *
+     * @return array|bool
+     */
+    protected function getUsers($resultsperpage, $start, $where = null, $order = null, $parameters = array())
+    {
+        $sql = 'select speaker.ID as speaker_id, speaker.speaker_name, speaker.talk_id, user.ID as user_id, user.email, '
+               . 'user.full_name, user.twitter_username '
+               . 'from talk_speaker as speaker '
+               . 'left join user on (speaker.speaker_id = user.ID) '
+               . 'where speaker.speaker_name <> "" ';
+
+        // where
+        if ($where) {
+            $sql .= ' and ' . $where;
+        }
+
+        // group by because of adding the user_attend join
+        $sql .= ' group by speaker.ID ';
+
+        // order by
+        if ($order) {
+            $sql .= ' order by ' . $order;
+        }
+
+        $countStmt = $this->_db->prepare($sql);
+
+        // limit clause
+        $sql .= $this->buildLimit($resultsperpage, $start);
+
+        $stmt = $this->_db->prepare($sql);
+
+        $response = $stmt->execute($parameters);
+        if ($response) {
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results['total'] = $this->getTotalCount($sql, $parameters);
+            return $results;
+        }
+        return false;
+    }
+
+    /**
+     * Get informations about a speaker identified by its speaker-id
+     *
+     * @param int  $speaker_id The ID of the speaker to fetch
+     * @param bool $verbose    Whether to return verbose information or not
+     *
+     * @return array|bool
+     */
+    public function getSpeakerById($speaker_id, $verbose = false)
+    {
+        $result = $this->getUsers(
+            1,
+            0,
+            'speaker.ID= :speaker_id',
+            null,
+            array(
+                'speaker_id' => $speaker_id,
+            )
+        );
+
+        if ($result) {
+            $retVal = $this->transformResults($result, $verbose);
+            return $retVal;
+        }
+
+        return false;
+    }
+}

--- a/src/models/TalkSpeakerMapper.php
+++ b/src/models/TalkSpeakerMapper.php
@@ -5,7 +5,8 @@ class TalkSpeakerMapper extends ApiMapper
     /**
      * @inheritdoc
      */
-    public function getDefaultFields() {
+    public function getDefaultFields()
+    {
         $fields = array(
             "username" => "speaker_name",
             "full_name" => "full_name",
@@ -17,7 +18,8 @@ class TalkSpeakerMapper extends ApiMapper
     /**
      * @inheritdoc
      */
-    public function getVerboseFields() {
+    public function getVerboseFields()
+    {
         $fields = array(
             "username" => "speaker_name",
             "full_name" => "full_name",
@@ -37,11 +39,12 @@ class TalkSpeakerMapper extends ApiMapper
 
         $base = $this->_request->base;
         $version = $this->_request->version;
-        if(is_array($list) && count($list)) {
-            foreach($results as $key => $row) {
+        if (is_array($list) && count($list)) {
+            foreach ($results as $key => $row) {
                 // add speakers
                 $list[$key]['uri'] = $base . '/' . $version . '/speakers/' . $row['speaker_id'] ;
-                $list[$key]['verbose_uri'] = $base . '/' . $version . '/speakers/' . $row['speaker_id'] . '?verbose=yes';
+                $list[$key]['verbose_uri'] = $base . '/' . $version . '/speakers/'
+                                           . $row['speaker_id'] . '?verbose=yes';
                 $list[$key]['talk_uri'] = $base . '/' . $version . '/talks/' . $row['talk_id'];
                 if (isset($row['user_id'])) {
                     $list[$key]['user_uri'] = $base . '/' . $version . '/users/' . $row['user_id'];
@@ -96,7 +99,8 @@ class TalkSpeakerMapper extends ApiMapper
      */
     protected function getUsers($resultsperpage, $start, $where = null, $order = null, $parameters = array())
     {
-        $sql = 'select speaker.ID as speaker_id, speaker.speaker_name, speaker.talk_id, user.ID as user_id, user.email, '
+        $sql = 'select speaker.ID as speaker_id, speaker.speaker_name, speaker.talk_id, '
+               . 'user.ID as user_id, user.email, '
                . 'user.full_name, user.twitter_username '
                . 'from talk_speaker as speaker '
                . 'left join user on (speaker.speaker_id = user.ID) '

--- a/tests/models/TalkSpeakerMapperTest.php
+++ b/tests/models/TalkSpeakerMapperTest.php
@@ -1,0 +1,87 @@
+<?php
+
+class TalkSpeakerMapperTest extends PHPUnit_Extensions_Database_TestCase
+{
+    protected $pdo = null;
+
+    /**
+     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+     */
+    public function getConnection()
+    {
+        if (null === $this->pdo) {
+            $this->pdo = new PDO('sqlite::memory:');
+            $this->pdo->exec('create table talk_speaker(talk_id int, speaker_name, ID int, speaker_id int, status)');
+            $this->pdo->exec('create table user(username, password, email, lastlogin int, ID int, admin int, full_name, active int, twitter_username, request_code)');
+
+        }
+        return $this->createDefaultDBConnection($this->pdo, ':memory:');
+    }
+
+    /**
+     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+     */
+    public function getDataSet()
+    {
+        return $this->createXMLDataSet(__DIR__ . '/_files/talk_user_seed.xml');
+    }
+
+    public function testGetUsers()
+    {
+        $request = new Request([],[]);
+        $talkSpeakerMapper = new TalkSpeakerMapper($this->getConnection()->getConnection(), $request);
+
+        $this->assertEquals([
+            'speakers' => [
+                [
+                    'uri' => 'http:////speakers/1',
+                    'verbose_uri' => 'http:////speakers/1?verbose=yes',
+                    'talk_uri' => 'http:////talks/44',
+                    'user_uri' => 'http:////users/12',
+                    'username' => 'Karl Napp',
+                    'full_name' => 'Karl Napp',
+                    'twitter_username' => 'karlnapp' ,
+                ],
+                [
+                    'uri' => 'http:////speakers/2',
+                    'verbose_uri' => 'http:////speakers/2?verbose=yes',
+                    'talk_uri' => 'http:////talks/44',
+                    'username' => 'Foo Bar',
+                    'full_name' => null,
+                    'twitter_username' => null,
+                ],
+                [
+                    'uri' => 'http:////speakers/3',
+                    'verbose_uri' => 'http:////speakers/3?verbose=yes',
+                    'talk_uri' => 'http:////talks/44',
+                    'user_uri' => 'http:////users/13',
+                    'username' => 'Bar Foo',
+                    'full_name' => 'Bar Foo',
+                    'twitter_username' => 'barfoo',
+                ],
+                [
+                    'uri' => 'http:////speakers/4',
+                    'verbose_uri' => 'http:////speakers/4?verbose=yes',
+                    'talk_uri' => 'http:////talks/44',
+                    'user_uri' => 'http:////users/22',
+                    'username' => 'barBaz',
+                    'full_name' => 'barBaz',
+                    'twitter_username' => 'barbaz',
+                ],
+            ],
+            'meta' => [
+                'count' => 4,
+                'total' => 4,
+                'this_page' => 'http://?start=0&resultsperpage=20',
+            ],
+        ], $talkSpeakerMapper->getSpeakersByTalkId(44, 10, 0));
+    }
+
+    public function testGettingUsersForNonexistentEvent()
+    {
+        $request = new Request([],[]);
+        $talkSpeakerMapper = new TalkSpeakerMapper($this->getConnection()->getConnection(), $request);
+
+        $this->assertfalse( $talkSpeakerMapper->getSpeakersByTalkId('', 10, 0));
+    }
+}

--- a/tests/models/_files/talk_user_seed.xml
+++ b/tests/models/_files/talk_user_seed.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <table name="talk_speaker">
+        <column>talk_id</column>
+        <column>speaker_name</column>
+        <column>ID</column>
+        <column>speaker_id</column>
+        <column>status</column>
+        <row>
+            <value>44</value>
+            <value>Karl Napp</value>
+            <value>1</value>
+            <value>12</value>
+            <value></value>
+        </row>
+        <row>
+            <value>44</value>
+            <value>Foo Bar</value>
+            <value>2</value>
+            <value></value>
+            <value></value>
+        </row>
+        <row>
+            <value>44</value>
+            <value>Bar Foo</value>
+            <value>3</value>
+            <value>13</value>
+            <value>foo</value>
+        </row>
+        <row>
+            <value>44</value>
+            <value>barBaz</value>
+            <value>4</value>
+            <value>22</value>
+            <value>bar</value>
+        </row>
+        <row>
+            <value>45</value>
+            <value>barBaz</value>
+            <value>5</value>
+            <value>22</value>
+            <value></value>
+        </row>
+    </table>
+    <table name="user">
+        <column>username</column>
+        <column>password</column>
+        <column>email</column>
+        <column>lastlogin</column>
+        <column>ID</column>
+        <column>admin</column>
+        <column>full_name</column>
+        <column>active</column>
+        <column>twitter_username</column>
+        <column>request_code</column>
+        <row>
+            <value>karlnapp</value>
+            <value>passwd</value>
+            <value>karlnapp@example.org</value>
+            <value>1</value>
+            <value>12</value>
+            <value>1</value>
+            <value>Karl Napp</value>
+            <value>0</value>
+            <value>karlnapp</value>
+            <value>1</value>
+        </row>
+        <row>
+            <value>barfoo</value>
+            <value>passwd</value>
+            <value>barfoo@example.org</value>
+            <value>1</value>
+            <value>13</value>
+            <value>1</value>
+            <value>Bar Foo</value>
+            <value>0</value>
+            <value>barfoo</value>
+            <value>1</value>
+        </row>
+        <row>
+            <value>barbaz</value>
+            <value>passwd</value>
+            <value>barbaz@example.org</value>
+            <value>1</value>
+            <value>22</value>
+            <value>1</value>
+            <value>barBaz</value>
+            <value>0</value>
+            <value>barbaz</value>
+            <value>1</value>
+        </row>
+    </table>
+</dataset>


### PR DESCRIPTION
This PR adds a way to get the speaker(s) for a talk via the API. That way a list of speakers can be retrieved for a single talk without having to fetch the complete talk informations.

It is also a prerequisite to add, edit or delete speakers for a talk which in turn is a prerequisite to edit talks.

This commit introduces two new API-Endpoints:

* /talks(/[^/]+)*/speakers/?$ to get a list of all the speakers for a single talk and
* /speakers(/[^/]+)*/?$ to get information about a single speaker. This endpoint currently returns an array always containing a single entry. That's the same behaviour as the /talks(/[^/]+)*$-endpoint shows.

A speaker can be either a name if the speaker didn't claim the talk or a user when the speaker did claim the talk. So there might be a user-URI on a speaker-entry but that depends on whether the user claimed the talk or not. And a speaker is unique to the talk. So one user doing two talks can be found with two different speaker-entries.

There currently aren't frisby-tests. I'll add them in a follow-up PR later.