### PR TITLE
Sorts CfP-List by CfP-End-Date

### DIFF
--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -164,7 +164,7 @@ class EventMapper extends ApiMapper
                     break;
                 case "cfp": // events with open CfPs, soonest closing first
                     $where .= ' and events.event_cfp_url IS NOT NULL AND events.event_cfp_end >= ' . mktime(0, 0, 0);
-                    $order .= 'events.event_start';
+                    $order .= 'events.event_cfp_end';
                     break;
                 case "pending": // events to be approved
                     $order .= 'events.event_start';


### PR DESCRIPTION
Currently the CfP-List is sorted by the start-date of the event. But much more interesting for most people is the date the CfP closes so sorting by that date might make much more sense.

That way the CfPs that will close next will be shown in the joind.in-Web-interface.