### PR TITLE
Removes CfPs that have not yet started

### DIFF
--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -166,8 +166,9 @@ class EventMapper extends ApiMapper
                     $where .= sprintf(
                         ' AND events.event_cfp_url IS NOT NULL' .
                         ' AND events.event_cfp_end >= %1$d' .
-                        ' AND events.event_cfp_start <= %1$s',
-                        mktime(0, 0, 0)
+                        ' AND events.event_cfp_start <= %2$s',
+                        mktime(0, 0, 0),
+                        mktime(0, 0, 0) + (7 * 86400)
                     );
                     $order .= 'events.event_start';
                     break;

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -163,7 +163,12 @@ class EventMapper extends ApiMapper
                     $order .= 'events.event_start desc';
                     break;
                 case "cfp": // events with open CfPs, soonest closing first
-                    $where .= ' and events.event_cfp_url IS NOT NULL AND events.event_cfp_end >= ' . mktime(0, 0, 0);
+                    $where .= sprintf(
+                        ' AND events.event_cfp_url IS NOT NULL' .
+                        ' AND events.event_cfp_end >= %1$d' .
+                        ' AND events.event_cfp_start <= %1$s',
+                        mktime(0, 0, 0)
+                    );
                     $order .= 'events.event_start';
                     break;
                 case "pending": // events to be approved


### PR DESCRIPTION
Currently CfPs that have not yet started will be shown in the CfP-list. This PR fixes that by removing CfPs with start-date greater than the current date from the list. That's the same behaviour as removing CfPs that are already closed from the CfP-List