### PR TITLE
Add icon_uri to the event resource

### DIFF
--- a/src/config.php.dist
+++ b/src/config.php.dist
@@ -6,6 +6,9 @@ $config =  array(
     // the URL of web2 website is used in links within emails
     'website_url' => 'https://m.joind.in',
 
+    // the fully qualified URL to where event icons are stored (excluding trailing slash)
+    'event_icon_url' => 'http://dev.joind.in/inc/img/event_icons',
+
     'oauth' => array(
         'expirable_client_ids' => array(
             // some clients, (e.g. web2) do not hold onto their token after the

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -8,6 +8,16 @@
  */
 class EventMapper extends ApiMapper
 {
+    protected $event_icon_url;
+
+    public function __construct(PDO $db, Request $request = null)
+    {
+        parent::__construct($db, $request);
+
+        if (isset($request)) {
+            $this->event_icon_url = $request->getConfigValue('event_icon_url');
+        }
+    }
 
     /**
      * Default mapping for column names to API field names
@@ -396,6 +406,12 @@ class EventMapper extends ApiMapper
                 // handle the slug
                 if (!empty($row['event_stub'])) {
                     $list[$key]['humane_website_uri'] = $this->website_url . '/e/' . $row['event_stub'];
+                }
+
+                // event icon
+                $list[$key]['icon_uri'] = $this->website_url . '/img/event_icons/none.png';
+                if (!empty($row['event_icon'])) {
+                    $list[$key]['icon_uri'] = $this->event_icon_url . '/' . $row['event_icon'];
                 }
 
                 if ($verbose) {


### PR DESCRIPTION
This provides `icon_ui` which is the fully qualified URL to the event's icon. The URL to the icon image is a config variable `event_icon_url` so that we can support changing it at a later date.

(This PR will probably conflict in config.php.dist after #289 is merged…)