### PR TITLE
[Docs] Remove pygments CSS file

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <link href='https://fonts.googleapis.com/css?family=Chivo:900' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/stylesheets/stylesheet.css" media="screen" />
-    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/stylesheets/pygment_trac.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/stylesheets/print.css" media="print" />
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>


### PR DESCRIPTION
GitHub pages has moved to Jekyll 3.0 with the Rouge highlighter. The pygments_trac.css file makes the code unreadable, so while we now do not have any syntax highlighting, at least you can read it!

See http://joindin.github.io/joindin-api/events.html#editing-events for a good example.