### PR TITLE
Event Icons: multiple sizes and upload via API

### DIFF
--- a/db/patch65.sql
+++ b/db/patch65.sql
@@ -1,0 +1,17 @@
+-- table to store the available images for an event
+create table event_images (
+    id int auto_increment primary key,
+    event_id int not null,
+    type varchar(30) not null,
+    url varchar(255) not null,
+    width int,
+    height int,
+    index event_image_type (event_id, type)
+);
+
+-- populate it also with our old-style images
+insert into event_images (event_id, type, url, width, height)
+select ID, "small", CONCAT("https://joind.in/inc/img/event_icons/", event_icon), 90, 90
+from events where (event_icon is not null and event_icon <> "");
+
+INSERT INTO patch_history SET patch_number = 65;

--- a/src/config.php.dist
+++ b/src/config.php.dist
@@ -4,7 +4,7 @@ $config =  array(
     'mode' => 'development',
 
     // the URL of web2 website is used in links within emails
-    'website_url' => 'https://m.joind.in',
+    'website_url' => 'https://joind.in',
 
     'oauth' => array(
         'expirable_client_ids' => array(

--- a/src/config.php.dist
+++ b/src/config.php.dist
@@ -13,6 +13,7 @@ $config =  array(
             'web2',
         ),
     ),
+    'event_image_path' => __DIR__ . '/../../joind.in/src/inc/img/event_icons/',
     'email' => array(
         'contact' => 'feedback@joind.in',
         'from' => 'info@joind.in',

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -36,6 +36,18 @@
         "verbs": ["POST"]
     },
     {
+        "path": "/events(/[\\d]+)/images",
+        "controller": "EventImagesController",
+        "action": "createImage",
+        "verbs": ["POST"]
+    },
+    {
+        "path": "/events(/[\\d]+)/images",
+        "controller": "EventImagesController",
+        "action": "deleteImage",
+        "verbs": ["DELETE"]
+    },
+    {
         "path": "/events(/[\\d]+)/talks",
         "controller": "TalksController",
         "action": "createTalkAction",

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -1,0 +1,115 @@
+<?php
+
+class EventImagesController extends ApiController
+{
+    public function createImage($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in to create data", 400);
+        }
+
+        $event_id = $this->getItemId($request);
+
+        if (!isset($_FILES['image'])) {
+            throw new Exception("Image was not supplied", 400);
+        }
+
+        if ($_FILES['image']['error'] != 0) {
+            throw new Exception("Image upload failed (Code: " . $FILES['image']['error'] . ")", 400);
+        }
+
+        // check the file meets our expectations
+        $uploaded_name = $_FILES['image']['tmp_name'];
+
+        list($width, $height, $filetype) = getimagesize($uploaded_name);
+
+        // must be square
+        if ($width != $height) {
+            throw new Exception("Supplied image must be square", 400);
+        }
+
+        // 140px min, 1440px max
+        if ($width < 140) {
+            throw new Exception("Supplied image must be at least 140px square", 400);
+        }
+        if ($width > 1440) {
+            throw new Exception("Supplied image must be no more than 1440px square", 400);
+        }
+
+        // save the file
+        $filename = $_FILES['image']['name'];
+        $event_image_path = $request->getConfigValue('event_image_path');
+        $savedFilename = $this->moveFile($uploaded_name, $filename, $event_image_path);
+
+        if (false === $savedFilename) {
+            throw new Exception("The file could not be saved");
+        }
+
+        // remove old images; record that we saved the file (this is the orig size)
+        $event_mapper = new EventMapper($db, $request);
+        $event_mapper->removeImages($event_id);
+        $event_mapper->saveNewImage($event_id, $savedFilename, $width, $height, "orig");
+
+        // small is 140px square
+        $orig_image = imagecreatefromstring(file_get_contents($event_image_path . $savedFilename));
+        $small_width = 140;
+        $small_height = 140;
+
+        $small_image = imagecreatetruecolor($small_width, $small_height);
+        imagecopyresampled($small_image, $orig_image, 0, 0, 0, 0, $small_width, $small_height, $width, $height);
+
+        $small_filename = str_replace('orig', 'small', $savedFilename);
+
+        if ($filetype == IMG_JPG) {
+            imagejpeg($small_image, $event_image_path . $small_filename);
+        } elseif ($filetype == IMG_GIF) {
+            imagegif($small_image, $event_image_path . $small_filename);
+        } else {
+            imagepng($small_image, $event_image_path . $small_filename);
+        }
+
+        $event_mapper->saveNewImage($event_id, $small_filename, $small_width, $small_height, "small");
+
+        $location = $request->base . '/' . $request->version . '/events/' . $event_id;
+        header('Location: ' . $location, null, 201);
+    }
+
+    protected function moveFile($uploaded_name, $filename, $path)
+    {
+        $filename_pieces = explode(".", $filename);
+        $newfilename = $filename_pieces[0] . "-orig." . $filename_pieces[1];
+
+        // check if the file exists before moving
+        if (!file_exists($path . $newfilename)) {
+            move_uploaded_file($uploaded_name, $path . $newfilename);
+            return $newfilename;
+        } else {
+            // we need to avoid a collision
+            // try appending numbers but give up after 10
+            for ($i = 0; $i < 10; $i++) {
+                $newfilename = $filename_pieces[0] . $i . "-orig." . $filename_pieces[1];
+
+                if (!file_exists($path . $newfilename)) {
+                    move_uploaded_file($uploaded_name, $path . $newfilename);
+                    return $newfilename;
+                }
+            }
+            // at this point, we have given up
+            return false;
+        }
+    }
+
+    public function createImage($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in to create data", 400);
+        }
+
+        $event_id = $this->getItemId($request);
+        $event_mapper = new EventMapper($db, $request);
+        $event_mapper->removeImages($event_id);
+
+        $location = $request->base . '/' . $request->version . '/events/' . $event_id;
+        header('Location: ' . $location, null, 204);
+    }
+}

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -12,7 +12,7 @@ class EventImagesController extends ApiController
 
         $event_mapper = new EventMapper($db, $request);
 
-        if(!$event_mapper->thisUserHasAdminOn($event_id)) {
+        if (!$event_mapper->thisUserHasAdminOn($event_id)) {
             throw new Exception("You don't have permission to do that", 403);
         }
 

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -99,7 +99,7 @@ class EventImagesController extends ApiController
         }
     }
 
-    public function createImage($request, $db)
+    public function deleteImage($request, $db)
     {
         if (! isset($request->user_id)) {
             throw new Exception("You must be logged in to create data", 400);
@@ -111,5 +111,6 @@ class EventImagesController extends ApiController
 
         $location = $request->base . '/' . $request->version . '/events/' . $event_id;
         header('Location: ' . $location, null, 204);
+        exit;
     }
 }

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -35,6 +35,11 @@ class EventImagesController extends ApiController
 
         list($width, $height, $filetype) = getimagesize($uploaded_name);
 
+        // must be gif, jpg or png
+        if (!in_array($filetype, [IMAGETYPE_JPEG, IMAGETYPE_GIF, IMAGETYPE_PNG], true)) {
+            throw new Exception("Supplied image must be a PNG, JPG or GIF", 400);
+        }
+
         // must be square
         if ($width != $height) {
             throw new Exception("Supplied image must be square", 400);

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -12,6 +12,12 @@ class EventImagesController extends ApiController
 
         $event_mapper = new EventMapper($db, $request);
 
+        // ensure event exists
+        $existing_event = $event_mapper->getEventById($event_id, false, true);
+        if ($existing_event['meta']['count'] == 0) {
+            throw new Exception('There is no event with ID ' . $event_id);
+        }
+
         if (!$event_mapper->thisUserHasAdminOn($event_id)) {
             throw new Exception("You don't have permission to do that", 403);
         }

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -10,6 +10,12 @@ class EventImagesController extends ApiController
 
         $event_id = $this->getItemId($request);
 
+        $event_mapper = new EventMapper($db, $request);
+
+        if(!$event_mapper->thisUserHasAdminOn($event_id)) {
+            throw new Exception("You don't have permission to do that", 403);
+        }
+
         if (!isset($_FILES['image'])) {
             throw new Exception("Image was not supplied", 400);
         }
@@ -46,7 +52,6 @@ class EventImagesController extends ApiController
         }
 
         // remove old images; record that we saved the file (this is the orig size)
-        $event_mapper = new EventMapper($db, $request);
         $event_mapper->removeImages($event_id);
         $event_mapper->saveNewImage($event_id, $savedFilename, $width, $height, "orig");
 

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -382,13 +382,15 @@ class EventMapper extends ApiMapper
                 if ($verbose) {
                     $list[$key]['talk_comments_count'] = $this->getTalkCommentCount($row['ID']);
                 }
-                $list[$key]['tags'] = $this->getTags($row['ID']);
+                $list[$key]['images']        = $this->getImages($row['ID']);
+                $list[$key]['tags']          = $this->getTags($row['ID']);
                 $list[$key]['uri']           = $base . '/' . $version . '/events/' . $row['ID'];
-                $list[ $key ]['verbose_uri']   = $base . '/' . $version . '/events/' . $row['ID'] . '?verbose=yes';
+                $list[ $key ]['verbose_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '?verbose=yes';
                 $list[$key]['comments_uri']  = $base . '/' . $version . '/events/' . $row['ID'] . '/comments';
                 $list[$key]['talks_uri']     = $base . '/' . $version . '/events/' . $row['ID'] . '/talks';
-                $list[ $key]['tracks_uri']    = $base . '/' . $version . '/events/' . $row['ID'] . '/tracks';
+                $list[ $key]['tracks_uri']   = $base . '/' . $version . '/events/' . $row['ID'] . '/tracks';
                 $list[$key]['attending_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/attending';
+
                 if ($row['pending'] == 1 && $thisUserCanApproveEvents) {
                     $list[$key]['approval_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/approval';
                 }
@@ -1105,4 +1107,24 @@ class EventMapper extends ApiMapper
 
         return $stmt->execute(["event_id" => $event_id, "reviewing_user_id" => $reviewing_user_id]);
     }
+
+    /**
+     * Fetch the available images for this event
+     *
+     * @param int $event_id
+     *
+     * @return array The images including metadata
+     */
+    protected function getImages($event_id)
+    {
+        $image_sql = 'select i.type, i.url, i.width, i.height'
+                    . ' from event_images i '
+                    . ' where i.event_id = :event_id';
+        $image_stmt = $this->_db->prepare($image_sql);
+        $image_stmt->execute(array("event_id" => $event_id));
+        $images  = $image_stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $images;
+    }
+
 }

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -390,6 +390,7 @@ class EventMapper extends ApiMapper
                 $list[$key]['talks_uri']     = $base . '/' . $version . '/events/' . $row['ID'] . '/talks';
                 $list[ $key]['tracks_uri']   = $base . '/' . $version . '/events/' . $row['ID'] . '/tracks';
                 $list[$key]['attending_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/attending';
+                $list[$key]['images_uri']    = $base . '/' . $version . '/events/' . $row['ID'] . '/images';
 
                 if ($row['pending'] == 1 && $thisUserCanApproveEvents) {
                     $list[$key]['approval_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/approval';

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -1124,7 +1124,14 @@ class EventMapper extends ApiMapper
         $image_stmt->execute(array("event_id" => $event_id));
         $images  = $image_stmt->fetchAll(PDO::FETCH_ASSOC);
 
-        return $images;
+        // add named keys so we can easily refer to these results
+        $collection = [];
+        if($images && is_array($images)) {
+            foreach($images as $row) {
+                $collection[$row['type']] = $row;
+            }
+        }
+        return $collection;
     }
 
     /**

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -1169,7 +1169,7 @@ class EventMapper extends ApiMapper
             "type" => $type,
             "width" => $width,
             "height" => $height,
-            "url" => "https://joind.in/inc/img/event_icons/" . $filename,
+            "url" => $this->website_url . "/inc/img/event_icons/" . $filename,
         ]);
 
         // for small images, update the old table too

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -1127,8 +1127,8 @@ class EventMapper extends ApiMapper
 
         // add named keys so we can easily refer to these results
         $collection = [];
-        if($images && is_array($images)) {
-            foreach($images as $row) {
+        if ($images && is_array($images)) {
+            foreach ($images as $row) {
                 $collection[$row['type']] = $row;
             }
         }
@@ -1158,8 +1158,8 @@ class EventMapper extends ApiMapper
      * For legacy reasons, we'll add a "small" image to the events table also
      *
      * @param int $event_id the event to add an image to
-     * @param string $filename the filename we saved the image as (the rest of 
-     *      the URL is hardcoded here for now because images don't work the 
+     * @param string $filename the filename we saved the image as (the rest of
+     *      the URL is hardcoded here for now because images don't work the
      *      same way on dev as they do on live)
      * @param int $width the width of the image
      * @param int $height the height of the image


### PR DESCRIPTION
Following on from https://github.com/joindin/joindin-api/pull/289 and the discussions we had there:

Accept an image (>=140px <=1440px) and store both the original size and a 140px size so it'll look nice on our usual 70px size on web2.  Include information about all known images in the event resource by default - this includes a full URL that can be used in an img tag.  Allow removal of images.  Require user to have rights on this event.

This change includes a database patch that considers all our existing icons as "images" and creates records for them in the new structure.  Also, when a new image is added to an event, the filename is added to the old event table so that web1 and the "icon" field that already exists in the API will continue to work.

Note that this endpoint requires a form post of files (docs incoming which include a curl request example if that helps).

I'm closing the previous pull request that offered this functionality.