### PR TITLE
Add talk to track

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -115,6 +115,12 @@
         "action": "deleteTrack",
         "verbs": ["DELETE"]
     },
+    {
+        "path": "/tracks(/[\\d]+)$",
+        "controller": "TracksController",
+        "action": "addTalkToTrack",
+        "verbs": ["POST"]
+    },
 
     {
         "path": "/users/passwords$",

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -109,6 +109,12 @@
         "action": "editTrack",
         "verbs": ["PUT"]
     },
+    {
+        "path": "/tracks(/[\\d]+)/?$",
+        "controller": "TracksController",
+        "action": "deleteTrack",
+        "verbs": ["DELETE"]
+    },
 
     {
         "path": "/users/passwords$",

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -103,6 +103,12 @@
         "action": "getAction",
         "verbs": ["GET"]
     },
+    {
+        "path": "/tracks(/[\\d]+)/?$",
+        "controller": "TracksController",
+        "action": "editTrack",
+        "verbs": ["PUT"]
+    },
 
     {
         "path": "/users/passwords$",

--- a/src/controllers/TracksController.php
+++ b/src/controllers/TracksController.php
@@ -97,4 +97,44 @@ class TracksController extends ApiController
         header("Content-Length: 0", null, 204);
         exit;
     }
+
+    public function addTalkToTrack($request, $db)
+    {
+        $track_id = $this->getItemId($request);
+        $track_mapper = new TrackMapper($db, $request);
+        $tracks = $track_mapper->getTrackById($track_id, true);
+        if (!$tracks) {
+            throw new Exception("Track not found", 404);
+        }
+        $event_mapper = new EventMapper($db, $request);
+        $events = $event_mapper->getEventByTrackId($track_id, true, false, false);
+        if (!$events || !$events[0]['ID']) {
+            throw new Exception("Associated event not found", 400);
+        }
+        $event_id = $events[0]['ID'];
+        if (!$event_mapper->thisUserHasAdminOn($event_id)) {
+            throw new Exception('You do not have permission to edit this track', 403);
+        }
+        // get the talk
+        $talk_uri = $request->getParameter("talk_uri");
+        $pattern ='@^' . $request->base  . '/' . $request->version . '/talks/([\d]+)$@';
+        if (!preg_match($pattern, $talk_uri, $matches)) {
+            throw new Exception('Invalid talk_uri', 400);
+        }
+        $talk_id = $matches[1];
+        // ensure talk belongs to this event
+        $talk_mapper = new TalkMapper($db, $request);
+        $talk = $talk_mapper->getTalkById($talk_id);
+        if (!$talk) {
+            throw new Exception("Talk not found", 400);
+        }
+        if ($event_id != $talk->event_id) {
+            throw new Exception("This talk cannot be added to this track", 400);
+        }
+        $talk_track_id = $track_mapper->addTalkToTrack($track_id, $talk_id);
+     
+        $uri = $request->base  . '/' . $request->version . '/talks/' . $talk_id;
+        header("Location: " . $uri, null, 201);
+        exit;
+    }
 }

--- a/src/controllers/TracksController.php
+++ b/src/controllers/TracksController.php
@@ -22,4 +22,54 @@ class TracksController extends ApiController
 
         return $list;
     }
+
+    public function editTrack($request, $db)
+    {
+        $track_id = $this->getItemId($request);
+
+        $track_mapper = new TrackMapper($db, $request);
+        $tracks = $track_mapper->getTrackById($track_id, true);
+        if (!$tracks) {
+            throw new Exception("Track not found", 404);
+        }
+
+        $event_mapper = new EventMapper($db, $request);
+        $events = $event_mapper->getEventByTrackId($track_id, true, false, false);
+        if (!$events || !$events[0]['ID']) {
+            throw new Exception("Associated event not found", 404);
+        }
+        $event_id = $events[0]['ID'];
+        if (!$event_mapper->thisUserHasAdminOn($event_id)) {
+            throw new Exception('You do not have permission to edit this track', 403);
+        }
+
+        // validate fields
+        $errors = [];
+        $track['track_name'] = filter_var(
+            $request->getParameter("track_name"),
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
+        );
+        if (empty($track['track_name'])) {
+            $errors[] = "'track_name' is a required field";
+        }
+        $track['track_description'] = filter_var(
+            $request->getParameter("track_description"),
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
+        );
+        if (empty($track['track_description'])) {
+            $errors[] = "'track_description' is a required field";
+        }
+        if ($errors) {
+            throw new Exception(implode(". ", $errors), 400);
+        }
+
+
+        $track_mapper->editEventTrack($track, $track_id);
+
+        $uri = $request->base  . '/' . $request->version . '/tracks/' . $track_id;
+        header("Location: $uri", true, 204);
+        exit;
+    }
 }

--- a/src/controllers/TracksController.php
+++ b/src/controllers/TracksController.php
@@ -65,11 +65,36 @@ class TracksController extends ApiController
             throw new Exception(implode(". ", $errors), 400);
         }
 
-
         $track_mapper->editEventTrack($track, $track_id);
 
         $uri = $request->base  . '/' . $request->version . '/tracks/' . $track_id;
         header("Location: $uri", true, 204);
+        exit;
+    }
+
+    public function deleteTrack($request, $db)
+    {
+        $track_id = $this->getItemId($request);
+
+        $track_mapper = new TrackMapper($db, $request);
+        $tracks = $track_mapper->getTrackById($track_id, true);
+        if (!$tracks) {
+            throw new Exception("Track not found", 404);
+        }
+
+        $event_mapper = new EventMapper($db, $request);
+        $events = $event_mapper->getEventByTrackId($track_id, true, false, false);
+        if (!$events || !$events[0]['ID']) {
+            throw new Exception("Associated event not found", 404);
+        }
+        $event_id = $events[0]['ID'];
+        if (!$event_mapper->thisUserHasAdminOn($event_id)) {
+            throw new Exception('You do not have permission to delete this track', 403);
+        }
+
+        $track_mapper->deleteEventTrack($track_id);
+
+        header("Content-Length: 0", null, 204);
         exit;
     }
 }

--- a/src/models/EventMapper.php
+++ b/src/models/EventMapper.php
@@ -100,6 +100,32 @@ class EventMapper extends ApiMapper
     }
 
     /**
+     * Find an event from its track id
+     *
+     * Optionally return the non-transformed data.
+     *
+     * @param int  $track_id
+     * @param bool $verbose
+     * @param bool $activeEventsOnly
+     * @param bool $transform
+     *
+     * @return array the event detail
+     */
+    public function getEventByTrackId($track_id, $verbose = false, $activeEventsOnly = true, $transform = true)
+    {
+        $results = $this->getEvents(1, 0, array("track_id" => $track_id, 'active' => $activeEventsOnly));
+        if (!$results) {
+            return false;
+        }
+        
+        if ($transform) {
+            return $this->transformResults($results, $verbose);
+        }
+
+        return $results;
+    }
+
+    /**
      * Internal function called by other event-fetching code, with changeable SQL
      *
      * @param int $resultsperpage how many records to return
@@ -136,6 +162,11 @@ class EventMapper extends ApiMapper
         if (array_key_exists("tags", $params)) {
             $sql .= "left join tags_events on tags_events.event_id = events.ID 
                 left join tags on tags.ID = tags_events.tag_id ";
+        }
+
+        if (array_key_exists("track_id", $params)) {
+            $sql .= "right join event_track on event_track.event_id = events.ID and event_track.ID = :track_id";
+            $data['track_id'] = $params['track_id'];
         }
 
         $sql .= ' where (events.private <> "y" OR events.private IS NULL) ';

--- a/src/models/TrackMapper.php
+++ b/src/models/TrackMapper.php
@@ -153,4 +153,22 @@ class TrackMapper extends ApiMapper
 
         return $track_id;
     }
+
+    /**
+     * Delete track and talk associations
+     *
+     * @param  int $track_id
+     */
+    public function deleteEventTrack($track_id)
+    {
+        // delete talk associations
+        $sql = "delete from event_track where ID = :track_id";
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute(['track_id' => $track_id]);
+
+        // delete track
+        $sql = "delete from talk_track where track_id = :track_id";
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute(['track_id' => $track_id]);
+    }
 }

--- a/src/models/TrackMapper.php
+++ b/src/models/TrackMapper.php
@@ -171,4 +171,34 @@ class TrackMapper extends ApiMapper
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['track_id' => $track_id]);
     }
+
+    /**
+     * Add a talk to a track
+     *
+     * @param int $track_id
+     * @param int $talk_id
+     *
+     * @return int
+     */
+    public function addTalkToTrack($track_id, $talk_id)
+    {
+        $params = [
+            'track_id' => $track_id,
+            'talk_id' => $talk_id,
+        ];
+        // is this link in the database already?
+        $sql = 'select ID from talk_track where track_id = :track_id and talk_id = :talk_id';
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute($params);
+        $talk_track_id = $stmt->fetchColumn();
+        if ($talk_track_id === false) {
+            // insert new row as not in database
+            $sql = 'insert into talk_track (track_id, talk_id) values (:track_id, :talk_id)';
+            $stmt = $this->_db->prepare($sql);
+            $stmt->execute($params);
+        
+            $talk_track_id = $this->_db->lastInsertId();
+        }
+        return $talk_track_id;
+    }
 }

--- a/src/models/TrackMapper.php
+++ b/src/models/TrackMapper.php
@@ -100,4 +100,57 @@ class TrackMapper extends ApiMapper
 
         return $sql;
     }
+
+    /**
+     * Edit event track
+     *
+     * @param  array $data
+     * @param  int   $track_id
+     * @return int
+     */
+    public function editEventTrack($data, $track_id)
+    {
+        // Sanity check: ensure all mandatory fields are present.
+        $mandatory_fields = [
+            'track_name',
+            'track_description',
+        ];
+        $contains_mandatory_fields = !array_diff($mandatory_fields, array_keys($data));
+        if (!$contains_mandatory_fields) {
+            throw new Exception("Missing mandatory fields");
+        }
+
+        $sql = "UPDATE event_track SET %s WHERE ID = :track_id";
+
+        // get the list of column to API field name for all valid fields
+        $fields = $this->getVerboseFields();
+        $items  = array();
+
+        foreach ($fields as $api_name => $column_name) {
+            // We don't change any activation stuff here!!
+            if (in_array($column_name, ['pending', 'active'])) {
+                continue;
+            }
+            if (array_key_exists($api_name, $data)) {
+                $pairs[] = "$column_name = :$api_name";
+                $items[$api_name] = $data[$api_name];
+            }
+        }
+
+        $items['track_id'] = $track_id;
+
+        $stmt = $this->_db->prepare(sprintf($sql, implode(', ', $pairs)));
+
+        try {
+            $stmt->execute($items);
+        } catch (Exception $e) {
+            throw new Exception(sprintf(
+                'executing "%s" resulted in an error: %s',
+                $stmt->queryString,
+                implode(' :: ', $stmt->errorInfo())
+            ));
+        }
+
+        return $track_id;
+    }
 }


### PR DESCRIPTION
POST to the track URI with a `talk_uri` in the body will add this talk to the track. Checks are in place to ensure that the talk and track both belong to the same event.
 
Note that this PR builds on #321 (Edit track) as it uses the `getEventByTrackId()` method from that PR.