### PR TITLE
Add link to reported comments page

### DIFF
--- a/src/services/EventCommentReportedEmailService.php
+++ b/src/services/EventCommentReportedEmailService.php
@@ -59,7 +59,8 @@ class EventCommentReportedEmailService extends EmailBaseService
 
     private function linkToReportedCommentsForEvent($name)
     {
-        return '<a href="' . $this->website_url . '/event/' . strtolower($name) 
+          return '<a href="' . $this->website_url
+                . '/event/' . strtolower($name)
                 . '/reported-comments' . '">' . $this->event['name'] . '</a>';
     }
 }

--- a/src/services/EventCommentReportedEmailService.php
+++ b/src/services/EventCommentReportedEmailService.php
@@ -59,6 +59,7 @@ class EventCommentReportedEmailService extends EmailBaseService
 
     private function linkToReportedCommentsForEvent($name)
     {
-        return '<a href="' . $this->website_url . '/event/' . strtolower($name) . '/reported-comments' . '">' . $this->event['name'] . '</a>';
+        return '<a href="' . $this->website_url . '/event/' . strtolower($name) 
+                . '/reported-comments' . '">' . $this->event['name'] . '</a>';
     }
 }

--- a/src/services/EventCommentReportedEmailService.php
+++ b/src/services/EventCommentReportedEmailService.php
@@ -5,6 +5,7 @@ class EventCommentReportedEmailService extends EmailBaseService
 
     protected $comment;
     protected $event;
+    protected $website_url;
 
     public function __construct($config, $recipients, $comment, $event)
     {
@@ -14,6 +15,7 @@ class EventCommentReportedEmailService extends EmailBaseService
         // this email needs comment info
         $this->comment = $comment['comments'][0];
         $this->event = $event['events'][0];
+        $this->website_url = $config['website_url'];
     }
 
     public function sendEmail()
@@ -40,7 +42,7 @@ class EventCommentReportedEmailService extends EmailBaseService
         }
 
         $replacements = array(
-            "name"   => $this->event['name'],
+            "name"    => $this->linkToReportedCommentsForEvent($this->event['name']),
             "rating"  => $rating,
             "comment" => $this->comment['comment'],
             "byline"  => $byLine
@@ -53,5 +55,10 @@ class EventCommentReportedEmailService extends EmailBaseService
         $this->setHtmlBody($messageHTML);
 
         $this->dispatchEmail();
+    }
+
+    private function linkToReportedCommentsForEvent($name)
+    {
+        return '<a href="' . $this->website_url . '/event/' . strtolower($name) . '/reported-comments' . '">' . $this->event['name'] . '</a>';
     }
 }

--- a/src/services/EventCommentReportedEmailService.php
+++ b/src/services/EventCommentReportedEmailService.php
@@ -42,10 +42,11 @@ class EventCommentReportedEmailService extends EmailBaseService
         }
 
         $replacements = array(
-            "name"    => $this->linkToReportedCommentsForEvent($this->event['name']),
+            "name"    => $this->event['name'],
             "rating"  => $rating,
             "comment" => $this->comment['comment'],
-            "byline"  => $byLine
+            "byline"  => $byLine,
+            "link"    => $this->linkToReportedCommentsForEvent($this->event['name'])
         );
 
         $messageBody = $this->parseEmail("eventCommentReported.md", $replacements);
@@ -59,8 +60,8 @@ class EventCommentReportedEmailService extends EmailBaseService
 
     private function linkToReportedCommentsForEvent($name)
     {
-          return '<a href="' . $this->website_url
+        return '<' . $this->website_url
                 . '/event/' . strtolower($name)
-                . '/reported-comments' . '">' . $this->event['name'] . '</a>';
+                . '/reported-comments' . '>';
     }
 }

--- a/src/views/emails/eventCommentReported.md
+++ b/src/views/emails/eventCommentReported.md
@@ -6,5 +6,7 @@ A comment on your event has been reported.  It will be hidden until you moderate
 
 **Comment:** [comment]
 
+**Moderate:** [link]
+
 *A reported comment usually indicates a comment that is inappropriate, offensive, or considered to be spam.  Please visit the event dashboard to moderate this comment.*
 


### PR DESCRIPTION
I added a function which will wrap the passed in event name with a link to the reported comments page, and changed the code that was simply displaying the name of the event so that it calls that function. 