### PR TITLE
SQL for the API write tests

### DIFF
--- a/db/init_api_tests.sql
+++ b/db/init_api_tests.sql
@@ -1,0 +1,7 @@
+-- SQL for API write tests
+--
+-- These aren't safe to run on a live platform, but are very valuable in testing. Before they can be run,
+-- this query needs to be run against the database:
+
+insert into oauth_consumers (consumer_key, consumer_secret, user_id, enable_password_grant)
+    values ('0000', '1111', '1', '1');


### PR DESCRIPTION
In order to run the API's write tests we need a record in the `oauth_consumers` table. This PR creates a file with the relevant SQL in it that can then be used by the Vagrant provisioning scripts to seed the development environment.