### PR TITLE
Average rating persists when rating is removed

### DIFF
--- a/db/patch66.sql
+++ b/db/patch66.sql
@@ -1,0 +1,35 @@
+-- Drop the function if it exists
+DROP FUNCTION IF EXISTS get_talk_rating;
+
+
+-- Create get_talk_rating function that takes into account ratings that should not be added (speaker ratings, private)
+-- + IFNULL() fix for making sure this works on non-claimed talks (jthijssen)
+-- + Not using ratings=0, since they didn't rate at all (jthijssen)
+DELIMITER //
+
+CREATE FUNCTION get_talk_rating(talk_id INT) RETURNS int
+	READS SQL DATA
+BEGIN
+	DECLARE rating_out INT;
+	DECLARE EXIT HANDLER FOR NOT FOUND RETURN NULL;
+
+	SELECT IFNULL(ROUND(AVG(rating)), 0) INTO rating_out
+	FROM talk_comments tc
+	WHERE
+		tc.talk_id = talk_id AND
+		tc.rating != 0 AND
+		tc.private = 0 AND
+		tc.active = 1 AND
+		tc.user_id NOT IN
+		(
+			SELECT IFNULL(ts.speaker_id,0) FROM talk_speaker ts WHERE ts.talk_id = talk_id
+			UNION
+			SELECT 0
+		);
+
+	RETURN rating_out;
+END//
+
+
+-- Increase patch count
+INSERT INTO patch_history SET patch_number = 66;


### PR DESCRIPTION
In relation to [JOINDIN-687](https://joindin.jira.com/browse/JOINDIN-687)

The get_talk_rating mysql function now checks the active flag in the talk_comments so
the average comment rating doesn't include removed/reported comments.