### PR TITLE
Hotfix/fixtests

### DIFF
--- a/src/inc/Request.php
+++ b/src/inc/Request.php
@@ -134,7 +134,7 @@ class Request
             $header = new Header('X-Forwarded-For', $_SERVER['HTTP_X_FORWARDED_FOR'], ',');
             $header->parseParams();
             $elementArray = $header->buildEntityArray();
-            $ipAddress    = count($elementArray) ? $elementArray[0] : null;
+            $ipAddress    = count($elementArray) ? $elementArray[0][0] : null;
         }
         $this->clientIP        = $ipAddress;
         $this->clientUserAgent = $userAgent;

--- a/tests/inc/RequestTest.php
+++ b/tests/inc/RequestTest.php
@@ -471,7 +471,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         // Please see below for explanation of why we're mocking a "mock" PDO
         // class
-        $db      = $this->createMock(
+        $db      = $this->getMock(
             '\JoindinTest\Inc\mockPDO',
             array('getAvailableDrivers')
         );
@@ -507,7 +507,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function setOauthModelMethodIsFluent()
     {
         /* @var $mockOauth \OAuthModel */
-        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
         $request   = new \Request($this->config, []);
 
         $this->assertSame($request, $request->setOauthModel($mockOauth));
@@ -524,7 +524,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function setOauthModelAllowsSettingOfOauthModel()
     {
         /* @var $mockOauth \OAuthModel */
-        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
         $request   = new \Request($this->config, []);
         $request->setOauthModel($mockOauth);
 
@@ -542,7 +542,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function identifyUserWithOauthTokenTypeSetsUserIdForValidHeader()
     {
         $request   = new \Request($this->config, ['HTTPS' => 'on']);
-        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
             ->with('authPart')
@@ -567,7 +567,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function identifyUserWithBearerTokenTypeSetsUserIdForValidHeader()
     {
         $request   = new \Request($this->config, ['HTTPS' => 'on']);
-        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
             ->with('authPart')

--- a/tests/inc/RequestTest.php
+++ b/tests/inc/RequestTest.php
@@ -754,8 +754,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 'parameters' => array(),
                 'expectedClass' => 'HtmlView',
                 'accepts' => 'text/html,applicaton/json',
-                'view' => null,
-                'skip' => true // Currently we're not applying Accept correctly
+                'view' => new \HtmlView(),
+//                'skip' => true // Currently we're not applying Accept correctly
+// Can @choult check what's the reason for the skip?
             ),
             array( // #8
                 'parameters' => array('format' => 'html'),

--- a/tests/inc/RequestTest.php
+++ b/tests/inc/RequestTest.php
@@ -889,6 +889,47 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new \Request($this->config, $server);
         $this->assertEquals('/v2/one/two', $request->getPathInfo());
     }
+
+    /**
+     * @dataProvider clientIpProvider
+     */
+    public function testGettingClientIp($header)
+    {
+        $_SERVER = array_merge($header, $_SERVER);
+        $request = new \Request($this->config, []);
+        $this->assertEquals('192.168.1.1', $request->getClientIP());
+    }
+
+    public function clientIpProvider()
+    {
+            return [
+                    'remote_addr' => [['REMOTE_ADDR' => '192.168.1.1']],
+                    'x-forwarded-for' => [['HTTP_X_FORWARDED_FOR' => '192.168.1.1']],
+                    'http-forwarded' => [['HTTP_FORWARDED' => 'for=192.168.1.1, for=198.51.100.17']],
+                ];
+    }
+
+    /** @dataProvider gettingClientUserAgentProvider */
+    public function testGettingClientUserAgent($header, $userAgent)
+    {
+        $_SERVER = array_merge($header, $_SERVER);
+        $request = new \Request($this->config, []);
+        $this->assertEquals($userAgent, $request->getClientUserAgent());
+    }
+
+    public function gettingClientUserAgentProvider()
+    {
+        return [
+            [['HTTP_USER_AGENT' => 'Foo'], 'Foo']
+        ];
+    }
+
+    public function testGettingConfigValues()
+    {
+        $request = new \Request(['Foo'=> 'Bar'], []);
+        $this->assertEquals('Bar', $request->getConfigValue('Foo'));
+        $this->assertEquals('Foo', $request->getConfigValue('Bar', 'Foo'));
+    }
 }
 
 /**

--- a/tests/inc/RequestTest.php
+++ b/tests/inc/RequestTest.php
@@ -305,7 +305,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                     'CONTENT_TYPE'      => 'application/json',
                   ];
         /* @var $request \Request */
-        $request = $this->getMock('\Request', array('getRawBody'), array(array(), $server));
+        $request = $this->getMockBuilder('\Request')
+            ->setMethods(array('getRawBody'))
+            ->setConstructorArgs([[], $server])
+            ->getMock();
         $request->expects($this->once())
             ->method('getRawBody')
             ->will($this->returnValue($body));
@@ -468,7 +471,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         // Please see below for explanation of why we're mocking a "mock" PDO
         // class
-        $db      = $this->getMock(
+        $db      = $this->createMock(
             '\JoindinTest\Inc\mockPDO',
             array('getAvailableDrivers')
         );
@@ -504,7 +507,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function setOauthModelMethodIsFluent()
     {
         /* @var $mockOauth \OAuthModel */
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
         $request   = new \Request($this->config, []);
 
         $this->assertSame($request, $request->setOauthModel($mockOauth));
@@ -521,7 +524,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function setOauthModelAllowsSettingOfOauthModel()
     {
         /* @var $mockOauth \OAuthModel */
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
         $request   = new \Request($this->config, []);
         $request->setOauthModel($mockOauth);
 
@@ -539,7 +542,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function identifyUserWithOauthTokenTypeSetsUserIdForValidHeader()
     {
         $request   = new \Request($this->config, ['HTTPS' => 'on']);
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
             ->with('authPart')
@@ -564,7 +567,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function identifyUserWithBearerTokenTypeSetsUserIdForValidHeader()
     {
         $request   = new \Request($this->config, ['HTTPS' => 'on']);
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->createMock('OAuthModel', array(), array(), '', false);
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
             ->with('authPart')

--- a/tests/routers/VersionedRouterTest.php
+++ b/tests/routers/VersionedRouterTest.php
@@ -149,7 +149,8 @@ class VersionedRouterTest extends PHPUnit_Framework_TestCase
      */
     public function testGetRoute($version, array $rules, $url, $method, $expectedController, $expectedAction, array $routeParams = array(), $expectedExceptionCode = false)
     {
-        $router = $this->getMock('VersionedRouter', ['getLegacyRoute'], [$version, [], $rules]);
+        $this->markTestSkipped("can @choult please check whether this test still is needed?");
+        $router = $this->createMock('VersionedRouter', ['getLegacyRoute'], [$version, [], $rules]);
         $router->expects($this->any())
                ->method('getLegacyRoute')
                ->will($this->returnValue('fallen back'));

--- a/tests/routers/VersionedRouterTest.php
+++ b/tests/routers/VersionedRouterTest.php
@@ -149,12 +149,8 @@ class VersionedRouterTest extends PHPUnit_Framework_TestCase
      */
     public function testGetRoute($version, array $rules, $url, $method, $expectedController, $expectedAction, array $routeParams = array(), $expectedExceptionCode = false)
     {
-        $this->markTestSkipped("can @choult please check whether this test still is needed?");
-        $router = $this->createMock('VersionedRouter', ['getLegacyRoute'], [$version, [], $rules]);
-        $router->expects($this->any())
-               ->method('getLegacyRoute')
-               ->will($this->returnValue('fallen back'));
         $request = new Request([], ['REQUEST_URI' => $url, 'REQUEST_METHOD' => $method]);
+        $router = new VersionedRouter($version, [], $rules);
         try {
             $route = $router->getRoute($request);
         } catch (Exception $ex) {


### PR DESCRIPTION
This PR fixes the current testsuite by adapting the calls to phpunits deprecated ```getMock```-methods to either ```createMock``` or to ```getMockObject```

During this process I stumbled over two tests created by @choult that are either obsolete by now or that were working already but have been marked to skip. Can you shed some light there please?