### PR TITLE
Post talk speaker endpoint - JOINDIN-639

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -77,7 +77,18 @@
         "action": "deleteAction",
         "verbs": ["DELETE"]
     },
-
+    {
+        "path": "/talks(/[\\d]+)/speakers/?$",
+        "controller": "TalksController",
+        "action": "getSpeakersForTalk",
+        "verbs": ["GET"]
+    },
+    {
+        "path": "/talks(/[\\d]+)/speakers/?$",
+        "controller": "TalksController",
+        "action": "linkUserToTalk",
+        "verbs": ["POST"]
+    },
     {
         "path": "/talks(/[\\d]+)$",
         "controller": "TalksController",

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -86,7 +86,7 @@
     {
         "path": "/talks(/[\\d]+)/speakers/?$",
         "controller": "TalksController",
-        "action": "linkUserToTalk",
+        "action": "setSpeakerForTalk",
         "verbs": ["POST"]
     },
     {

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -503,7 +503,8 @@ class TalksController extends ApiController
                 $speaker = filter_var($speaker, FILTER_SANITIZE_STRING);
                 $speaker = trim($speaker);
                 return $speaker;
-            }, (array) $request->getParameter('speakers')
+            },
+            (array) $request->getParameter('speakers')
         );
 
         return $talk;
@@ -538,7 +539,7 @@ class TalksController extends ApiController
         $data = $this->getLinkUserDataFromRequest($request);
 
         if ($data['display_name'] == '' || $data['username'] == '') {
-            throw new Exception("You must provide a display name and a username",400);
+            throw new Exception("You must provide a display name and a username", 400);
         }
 
         //Get the speaker record based on the display name - check if this is already claimed,

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -519,7 +519,6 @@ class TalksController extends ApiController
 
     public function setSpeakerForTalk(Request $request, PDO $db)
     {
-        //We must be logged in
         if (!isset($request->user_id)) {
             throw new Exception("You must be logged in to create data", 401);
         }
@@ -537,7 +536,7 @@ class TalksController extends ApiController
 
         $data = $this->getLinkUserDataFromRequest($request);
 
-        if ($data['display_name'] == '' || $data['username'] == '') {
+        if ($data['display_name'] === '' || $data['username'] === '') {
             throw new Exception("You must provide a display name and a username", 400);
         }
 
@@ -546,11 +545,9 @@ class TalksController extends ApiController
 
         $claim = $talk_mapper->getSpeakerFromTalk($talk_id, $data['display_name']);
 
-        if (! $claim) {
+        if ($claim === false) {
             throw new Exception("No speaker matching that name found", 422);
-        }
-
-        if ($claim && $claim['speaker_id'] != null) {
+        } elseif ($claim['speaker_id'] != null) {
             throw new Exception("Talk already claimed", 422);
         }
 
@@ -575,7 +572,7 @@ class TalksController extends ApiController
         exit;
     }
 
-    protected function getLinkUserDataFromRequest(Request $request)
+    private function getLinkUserDataFromRequest(Request $request)
     {
         $talk = [];
         $talk['display_name'] = trim($request->getParameter('display_name', ''));

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -521,7 +521,7 @@ class TalksController extends ApiController
     {
         //We must be logged in
         if (!isset($request->user_id)) {
-            throw new Exception("You must be logged in to create data", 400);
+            throw new Exception("You must be logged in to create data", 401);
         }
 
         $talk_id = $this->getItemId($request);
@@ -547,11 +547,11 @@ class TalksController extends ApiController
         $claim = $talk_mapper->getSpeakerFromTalk($talk_id, $data['display_name']);
 
         if (! $claim) {
-            throw new Exception("No speaker matching that name found", 400);
+            throw new Exception("No speaker matching that name found", 422);
         }
 
         if ($claim && $claim['speaker_id'] != null) {
-            throw new Exception("Talk already claimed", 400);
+            throw new Exception("Talk already claimed", 422);
         }
 
         $pending_talk_claim_mapper = new PendingTalkClaimMapper($db, $request);
@@ -563,12 +563,12 @@ class TalksController extends ApiController
         } elseif ($talk_mapper->thisUserHasAdminOn($talk_id)) {
             $speaker_id = $user_mapper->getUserIdFromUsername($data['username']);
             if (! $speaker_id) {
-                throw new Exception("Specified user not found");
+                throw new Exception("Specified user not found", 404);
             }
             $pending_talk_claim_mapper->assignTalkAsHost($talk_id, $speaker_id, $claim['ID'], $user_id);
             //We need to send an email to the speaker asking for confirmation
         } else {
-            throw new Exception("You must be the speaker or event admin to link a user to a talk", 400);
+            throw new Exception("You must be the speaker or event admin to link a user to a talk", 401);
         }
 
         header("Location: " . $request->base . $request->path_info, null, 204);

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -514,11 +514,10 @@ class TalksController extends ApiController
     {
         $talk_id = $this->getItemId($request);
         $talk = $this->getTalkById($db, $request, $talk_id);
-        $collection = new TalkModelCollection([$talk], 1);
-        return $collection->getTalks()[0]->speakers;
+        return $talk->speakers;
     }
 
-    public function linkUserToTalk(Request $request, PDO $db)
+    public function setSpeakerForTalk(Request $request, PDO $db)
     {
         //We must be logged in
         if (!isset($request->user_id)) {

--- a/src/models/PendingTalkClaimMapper.php
+++ b/src/models/PendingTalkClaimMapper.php
@@ -45,16 +45,26 @@ class PendingTalkClaimMapper extends ApiMapper
         return $fields;
     }
 
-    public function claimTalkAsSpeaker($talk_id){
+    public function claimTalkAsSpeaker($talk_id,$speaker_id,$claim_id)
+    {
         $sql  = 'insert into pending_talk_claims 
                     (talk_id,submitted_by,speaker_id,date_added,claim_id,user_approved_at) 
                   values
-                    (:talk_id,:submitted_by,:speaker_id,NOW(),:claim_id,NOW())
+                    (:talk_id,:submitted_by,:speaker_id,UNIX_TIMESTAMP(),:claim_id,NOW())
                  ';
         $stmt = $this->_db->prepare($sql);
-        $stmt->execute(array('uid' => $user_id, 'tid' => $talk_id));
+        return $stmt->execute(array('talk_id' => $talk_id, 'submitted_by' => $speaker_id, 'speaker_id' => $speaker_id, 'claim_id' => $claim_id));
+    }
 
-        return true;
+    public function assignTalkAsHost($talk_id,$speaker_id,$claim_id,$user_id)
+    {
+        $sql  = 'insert into pending_talk_claims 
+                    (talk_id,submitted_by,speaker_id,date_added,claim_id,host_approved_at) 
+                  values
+                    (:talk_id,:submitted_by,:speaker_id,UNIX_TIMESTAMP(),:claim_id,NOW())
+                 ';
+        $stmt = $this->_db->prepare($sql);
+        return $stmt->execute(array('talk_id' => $talk_id, 'submitted_by' => $user_id, 'speaker_id' => $speaker_id, 'claim_id' => $claim_id));
     }
 
 

--- a/src/models/PendingTalkClaimMapper.php
+++ b/src/models/PendingTalkClaimMapper.php
@@ -45,6 +45,15 @@ class PendingTalkClaimMapper extends ApiMapper
         return $fields;
     }
 
+    /**
+     * Propose a talk relationship by the speaker
+     *
+     * @param int $talk_id    The ID of the talk to claim
+     * @param int $speaker_id The ID of the speaker claiming the talk
+     * @param int $claim_id   The ID from the talk_speaker table relating to the talk and display_name
+     *
+     * @return bool
+     */
     public function claimTalkAsSpeaker($talk_id,$speaker_id,$claim_id)
     {
         $sql  = 'insert into pending_talk_claims 
@@ -56,6 +65,16 @@ class PendingTalkClaimMapper extends ApiMapper
         return $stmt->execute(array('talk_id' => $talk_id, 'submitted_by' => $speaker_id, 'speaker_id' => $speaker_id, 'claim_id' => $claim_id));
     }
 
+    /**
+     * Propose a talk relationship by the host
+     *
+     * @param int $talk_id    The ID of the talk to claim
+     * @param int $speaker_id The ID of the speaker who owns the talk
+     * @param int $claim_id   The ID from the talk_speaker table relating to the talk and display_name
+     * @param int $user_id    The ID of the user proposing the relationship
+     *
+     * @return bool
+     */
     public function assignTalkAsHost($talk_id,$speaker_id,$claim_id,$user_id)
     {
         $sql  = 'insert into pending_talk_claims 

--- a/src/models/PendingTalkClaimMapper.php
+++ b/src/models/PendingTalkClaimMapper.php
@@ -16,10 +16,10 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function getDefaultFields()
     {
-        $fields = array(
+        $fields = [
             "talk_id"           => "username",
             "speaker_id"        => "full_name",
-        );
+        ];
 
         return $fields;
     }
@@ -33,14 +33,14 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function getVerboseFields()
     {
-        $fields = array(
+        $fields = [
             "talk_id"           => "username",
             "speaker_id"        => "full_name",
             "date_added"        => "date_added",
             "claim_id"          => "claim_id",
             "user_approved_at"  => "user_approved_at",
             "host_approved_at"  => "host_approved_at",
-        );
+        ];
 
         return $fields;
     }
@@ -63,12 +63,12 @@ class PendingTalkClaimMapper extends ApiMapper
                  ';
         $stmt = $this->_db->prepare($sql);
         return $stmt->execute(
-            array(
+            [
                 'talk_id'       => $talk_id,
                 'submitted_by'  => $speaker_id,
                 'speaker_id'    => $speaker_id,
                 'claim_id'      => $claim_id
-            )
+            ]
         );
     }
 
@@ -91,12 +91,12 @@ class PendingTalkClaimMapper extends ApiMapper
                  ';
         $stmt = $this->_db->prepare($sql);
         return $stmt->execute(
-            array(
+            [
                 'talk_id'       => $talk_id,
                 'submitted_by'  => $user_id,
                 'speaker_id'    => $speaker_id,
                 'claim_id'      => $claim_id
-            )
+            ]
         );
     }
 }

--- a/src/models/PendingTalkClaimMapper.php
+++ b/src/models/PendingTalkClaimMapper.php
@@ -54,7 +54,7 @@ class PendingTalkClaimMapper extends ApiMapper
      *
      * @return bool
      */
-    public function claimTalkAsSpeaker($talk_id,$speaker_id,$claim_id)
+    public function claimTalkAsSpeaker($talk_id, $speaker_id, $claim_id)
     {
         $sql  = 'insert into pending_talk_claims 
                     (talk_id,submitted_by,speaker_id,date_added,claim_id,user_approved_at) 
@@ -62,7 +62,14 @@ class PendingTalkClaimMapper extends ApiMapper
                     (:talk_id,:submitted_by,:speaker_id,UNIX_TIMESTAMP(),:claim_id,NOW())
                  ';
         $stmt = $this->_db->prepare($sql);
-        return $stmt->execute(array('talk_id' => $talk_id, 'submitted_by' => $speaker_id, 'speaker_id' => $speaker_id, 'claim_id' => $claim_id));
+        return $stmt->execute(
+            array(
+                'talk_id'       => $talk_id,
+                'submitted_by'  => $speaker_id,
+                'speaker_id'    => $speaker_id,
+                'claim_id'      => $claim_id
+            )
+        );
     }
 
     /**
@@ -75,7 +82,7 @@ class PendingTalkClaimMapper extends ApiMapper
      *
      * @return bool
      */
-    public function assignTalkAsHost($talk_id,$speaker_id,$claim_id,$user_id)
+    public function assignTalkAsHost($talk_id, $speaker_id, $claim_id, $user_id)
     {
         $sql  = 'insert into pending_talk_claims 
                     (talk_id,submitted_by,speaker_id,date_added,claim_id,host_approved_at) 
@@ -83,8 +90,13 @@ class PendingTalkClaimMapper extends ApiMapper
                     (:talk_id,:submitted_by,:speaker_id,UNIX_TIMESTAMP(),:claim_id,NOW())
                  ';
         $stmt = $this->_db->prepare($sql);
-        return $stmt->execute(array('talk_id' => $talk_id, 'submitted_by' => $user_id, 'speaker_id' => $speaker_id, 'claim_id' => $claim_id));
+        return $stmt->execute(
+            array(
+                'talk_id'       => $talk_id,
+                'submitted_by'  => $user_id,
+                'speaker_id'    => $speaker_id,
+                'claim_id'      => $claim_id
+            )
+        );
     }
-
-
 }

--- a/src/models/PendingTalkClaimMapper.php
+++ b/src/models/PendingTalkClaimMapper.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * PendingTalkClaimMapper
+ *
+ * @uses ApiModel
+ * @package API
+ */
+class PendingTalkClaimMapper extends ApiMapper
+{
+
+    /**
+     * Default mapping for column names to API field names
+     *
+     * @return array with keys as API fields and values as db columns
+     */
+    public function getDefaultFields()
+    {
+        $fields = array(
+            "talk_id"           => "username",
+            "speaker_id"        => "full_name",
+        );
+
+        return $fields;
+    }
+
+    /**
+     * Field/column name mappings for the verbose version
+     *
+     * This should contain everything above and then more in most cases
+     *
+     * @return array with keys as API fields and values as db columns
+     */
+    public function getVerboseFields()
+    {
+        $fields = array(
+            "talk_id"           => "username",
+            "speaker_id"        => "full_name",
+            "date_added"        => "date_added",
+            "claim_id"          => "claim_id",
+            "user_approved_at"  => "user_approved_at",
+            "host_approved_at"  => "host_approved_at",
+        );
+
+        return $fields;
+    }
+
+    public function claimTalkAsSpeaker($talk_id){
+        $sql  = 'insert into pending_talk_claims 
+                    (talk_id,submitted_by,speaker_id,date_added,claim_id,user_approved_at) 
+                  values
+                    (:talk_id,:submitted_by,:speaker_id,NOW(),:claim_id,NOW())
+                 ';
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute(array('uid' => $user_id, 'tid' => $talk_id));
+
+        return true;
+    }
+
+
+}

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -773,7 +773,7 @@ class TalkMapper extends ApiMapper
         return true;
     }
 
-    public function getSpeakerFromTalk($talk_id,$display_name)
+    public function getSpeakerFromTalk($talk_id, $display_name)
     {
         $speaker_sql  = 'select ts.* from talk_speaker ts '
             . 'where ts.talk_id = :talk_id and ts.speaker_name = :display_name';

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -772,4 +772,16 @@ class TalkMapper extends ApiMapper
 
         return true;
     }
+
+    public function getSpeakerFromTalk($talk_id,$display_name)
+    {
+        $speaker_sql  = 'select ts.* from talk_speaker ts '
+            . 'where ts.talk_id = :talk_id and ts.speaker_name = :display_name';
+        $speaker_stmt = $this->_db->prepare($speaker_sql);
+        $speaker_stmt->execute(array("talk_id" => $talk_id, "display_name" => $display_name));
+        $speakers = $speaker_stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return count($speakers) > 0 ? $speakers[0] : false;
+
+    }
 }

--- a/src/models/TalkModel.php
+++ b/src/models/TalkModel.php
@@ -85,6 +85,7 @@ class TalkModel extends AbstractModel
         $item['verbose_comments_uri'] = $base . '/' . $version . '/talks/' . $this->ID
                                         . '/comments?verbose=yes';
         $item['event_uri']            = $base . '/' . $version . '/events/' . $this->event_id;
+        $item['speakers_uri']          = $base . '/' . $version . '/talks/' . $this->ID . '/speakers';
 
         return $item;
     }

--- a/src/models/TalkModel.php
+++ b/src/models/TalkModel.php
@@ -85,7 +85,7 @@ class TalkModel extends AbstractModel
         $item['verbose_comments_uri'] = $base . '/' . $version . '/talks/' . $this->ID
                                         . '/comments?verbose=yes';
         $item['event_uri']            = $base . '/' . $version . '/events/' . $this->event_id;
-        $item['speakers_uri']          = $base . '/' . $version . '/talks/' . $this->ID . '/speakers';
+        $item['speakers_uri']         = $base . '/' . $version . '/talks/' . $this->ID . '/speakers';
 
         return $item;
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,28 @@
 <?php
 // Load and register autoloader
 require_once __DIR__ . '/../src/inc/Autoloader.php';
+
+//We are unit testing
+define('UNIT_TEST', 1);
+
+/**
+ * Class to allow for mocking PDO to send to the OAuthModel
+ */
+class mockPDO extends \PDO
+{
+    /**
+     * Constructor that does nothing but helps us test with fake database
+     * adapters
+     */
+    public function __construct()
+    {
+        // We need to do this crap because PDO has final on the __sleep and
+        // __wakeup methods. PDO requires a parameter in the constructor but we don't
+        // want to create a real DB adapter. If you tell getMock to not call the
+        // original constructor, it fakes stuff out by unserializing a fake
+        // serialized string. This way, we've got a "PDO" object but we don't need
+        // PHPUnit to fake it by unserializing a made-up string. We've neutered
+        // the constructor in mockPDO.
+    }
+
+}

--- a/tests/controllers/TalksControllerTest.php
+++ b/tests/controllers/TalksControllerTest.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace JoindinTest\Controller;
+
+
+class TalksControllerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called and no user_id is set,
+     * an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage You must be logged in to create data
+     */
+    public function testClaimTalkWithNoUserIdThrowsException()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/326/speakers", 'REQUEST_METHOD' => 'POST']);
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called on a non-existent talk,
+     * an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage Talk not found
+     */
+    public function testClaimNonExistantTalkThrowsException()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+
+        $talk_mapper = $this->getMockBuilder('\TalkMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getTalkById')
+            ->will($this->returnValue(false));
+
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+
+
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called without a username,
+     * an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage You must provide a display name and a username
+     */
+    public function testClaimTalkWithoutUsernameThrowsException()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'display_name'  => 'Jane Bloggs'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $talks_controller->setUserMapper($user_mapper);
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called without a display_name,
+     * an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage You must provide a display name and a username
+     */
+    public function testClaimTalkWithoutDisplayNameThrowsException()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'username'  => 'janebloggs'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $talks_controller->setUserMapper($user_mapper);
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called with a
+     * display_name that doesn't match a talk speaker, an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage No speaker matching that name found
+     */
+    public function testClaimTalkWithInvalidSpeakerThrowsException()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'username'      => 'janebloggs',
+            'display_name'  =>  'P Sherman'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getSpeakerFromTalk')
+            ->will(
+                $this->returnValue(false)
+            );
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $talks_controller->setUserMapper($user_mapper);
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called against a display_name
+     * that has been claimed already, and Exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage Talk already claimed
+     */
+    public function testClaimTalkAlreadyClaimedThrowsException(){
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'username'      => 'janebloggs',
+            'display_name'  => 'P Sherman'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getSpeakerFromTalk')
+            ->will(
+                $this->returnValue(
+                    [
+                        'speaker_id'  => 1,
+                        'ID'          => 1
+                    ]
+                )
+            );
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $talks_controller->setUserMapper($user_mapper);
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called against a username
+     * that is different to the logged in user, an Exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage You must be the speaker or event admin to link a user to a talk
+     */
+    public function testClaimTalkForSomeoneElseThrowsException(){
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'username'      => 'psherman',
+            'display_name'  => 'P Sherman'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getSpeakerFromTalk')
+            ->will(
+                $this->returnValue(
+                    [
+                        'speaker_id'  => null,
+                        'ID'          => 1
+                    ]
+                )
+            );
+        $talk_mapper
+            ->expects($this->once())
+            ->method('thisUserHasAdminOn')
+            ->will($this->returnValue(false));
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $talks_controller->setUserMapper($user_mapper);
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called as a host against a username
+     * that doesn't exist, an Exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage Specified user not found
+     */
+    public function testAssignTalkAsHostToNonExistentUserThrowsException(){
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'username'      => 'psherman',
+            'display_name'  => 'P Sherman'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getSpeakerFromTalk')
+            ->will(
+                $this->returnValue(
+                    [
+                        'speaker_id'  => null,
+                        'ID'          => 1
+                    ]
+                )
+            );
+        $talk_mapper
+            ->expects($this->once())
+            ->method('thisUserHasAdminOn')
+            ->will($this->returnValue(true));
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $user_mapper
+            ->expects($this->once())
+            ->method('getUserIdFromUsername')
+            ->will($this->returnValue(false));
+        $talks_controller->setUserMapper($user_mapper);
+
+        $talks_controller->setSpeakerForTalk($request, $db);
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called and user_id is not an admin
+     * then as long as they are claiming for themselves, the method succeeds
+     *
+     * @return void
+     */
+    public function testClaimTalkAsUserIsSuccessful()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'username'      => 'janebloggs',
+            'display_name'  => 'Jane Bloggs'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getSpeakerFromTalk')
+            ->will(
+                $this->returnValue(
+                    [
+                        'speaker_id'  => null,
+                        'ID'          => 1
+                    ]
+                )
+            );
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $talks_controller->setUserMapper($user_mapper);
+
+        $pending_talk_claim_mapper = $this->getMockBuilder('\PendingTalkClaimMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+        
+        $pending_talk_claim_mapper
+            ->expects($this->once())
+            ->method('claimTalkAsSpeaker')
+            ->will($this->returnValue(true));
+        $talks_controller->setPendingTalkClaimMapper($pending_talk_claim_mapper);
+
+        $this->assertTrue($talks_controller->setSpeakerForTalk($request, $db));
+
+    }
+
+    /**
+     * Ensures that if the setSpeakerForTalk method is called and user_id is a host
+     * then as long as the username exists, the method succeeds
+     *
+     * @return void
+     */
+    public function testAssignTalkAsHostIsSuccessful()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $request->parameters = [
+            'username'      => 'psherman',
+            'display_name'  => 'P Sherman'
+        ];
+
+        $talks_controller = new \TalksController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $talk_mapper = $this->createTalkMapper($db, $request);
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getSpeakerFromTalk')
+            ->will(
+                $this->returnValue(
+                    [
+                        'speaker_id'  => null,
+                        'ID'          => 1
+                    ]
+                )
+            );
+        $talk_mapper
+            ->expects($this->once())
+            ->method('thisUserHasAdminOn')
+            ->will($this->returnValue(true));
+        $talks_controller->setTalkMapper($talk_mapper);
+
+        $user_mapper = $this->createUserMapper($db, $request);
+        $user_mapper
+            ->expects($this->once())
+            ->method('getUserIdFromUsername')
+            ->will($this->returnValue(1));
+        $talks_controller->setUserMapper($user_mapper);
+
+        $pending_talk_claim_mapper = $this->getMockBuilder('\PendingTalkClaimMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $pending_talk_claim_mapper
+            ->expects($this->once())
+            ->method('assignTalkAsHost')
+            ->will($this->returnValue(true));
+        $talks_controller->setPendingTalkClaimMapper($pending_talk_claim_mapper);
+
+        $this->assertTrue($talks_controller->setSpeakerForTalk($request, $db));
+
+    }
+
+
+    private function createTalkMapper($db, $request)
+    {
+        $talk_mapper = $this->getMockBuilder('\TalkMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $talk_mapper
+            ->expects($this->once())
+            ->method('getTalkById')
+            ->will(
+                $this->returnValue(
+                    new \TalkModel(
+                        [
+                            'talk_title'              => 'talk_title',
+                            'url_friendly_talk_title' => 'url_friendly_talk_title',
+                            'talk_description'        => 'talk_desc',
+                            'type'                    => 'talk_type',
+                            'start_date'              => 'date_given',
+                            'duration'                => 'duration',
+                            'stub'                    => 'stub',
+                            'average_rating'          => 'avg_rating',
+                            'comments_enabled'        => 'comments_enabled',
+                            'comment_count'           => 'comment_count',
+                            'starred'                 => 'starred',
+                            'starred_count'           => 'starred_count',
+                        ]
+                    )
+                )
+            );
+
+        return $talk_mapper;
+    }
+
+    private function createUserMapper($db, $request)
+    {
+        $user_mapper = $this->getMockBuilder('\UserMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $user_mapper
+            ->expects($this->once())
+            ->method('getUserById')
+            ->will(
+                $this->returnValue(
+                    [
+                        'users' => [
+                            [
+                                'username'  => 'janebloggs'
+                            ]
+                        ]
+                    ]
+                )
+            );
+
+        return $user_mapper;
+    }
+}
+

--- a/tests/controllers/UsersControllerTest.php
+++ b/tests/controllers/UsersControllerTest.php
@@ -107,7 +107,6 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDeleteUserWithAdminAccessDeletesSuccesfully()
     {
-        define('UNIT_TEST', 1);
         $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/users/3", 'REQUEST_METHOD' => 'DELETE']);
         $request->user_id = 1;
         $usersController = new \UsersController();
@@ -136,26 +135,3 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
 
 }
 
-
-
-/**
- * Class to allow for mocking PDO to send to the OAuthModel
- */
-class mockPDO extends \PDO
-{
-    /**
-     * Constructor that does nothing but helps us test with fake database
-     * adapters
-     */
-    public function __construct()
-    {
-        // We need to do this crap because PDO has final on the __sleep and
-        // __wakeup methods. PDO requires a parameter in the constructor but we don't
-        // want to create a real DB adapter. If you tell getMock to not call the
-        // original constructor, it fakes stuff out by unserializing a fake
-        // serialized string. This way, we've got a "PDO" object but we don't need
-        // PHPUnit to fake it by unserializing a made-up string. We've neutered
-        // the constructor in mockPDO.
-    }
-
-}


### PR DESCRIPTION
This creates the API endpoint required in https://joindin.jira.com/browse/JOINDIN-639

It's complete, except the sending emails (as the emails need a link, which requires the work to be done in web-2 as well), but before I moved on any further, I largely wanted a more in-depth review, as I've not really done any 'big' things on the API side before!

Functionally it all works, but there might be better ways to juggle the mappers etc.

In short, consider this a request for a code review :-)