### PR TITLE
[hotfix] - fix frisby test reponse code

### DIFF
--- a/tests/frisby/api_write_events.js
+++ b/tests/frisby/api_write_events.js
@@ -718,7 +718,7 @@ function testEventTracks(access_token, url) {
                       {},
                       {json: true}
                   )
-                  .expectStatus(403)
+                  .expectStatus(401)
                   .after(function(err, res, body) {
                     frisby.create("Delete track")
                       .delete(


### PR DESCRIPTION
Update frisby test to expect 401 rather then 403 for non-logged in user