### PR TITLE
Fixes failing frisby-test

### DIFF
--- a/tests/frisby/api_write_events.js
+++ b/tests/frisby/api_write_events.js
@@ -639,7 +639,7 @@ function testEventComments(access_token, url) {
 
   frisby.create('Get reported event comments (event host)')
     .get(url + '/comments/reported',
-      {json: true, headers: {'Authorization' : 'Bearer ' + access_token}})
+      {headers: {'Authorization' : 'Bearer ' + access_token}})
     .expectStatus(200)
     .toss();
 


### PR DESCRIPTION
The test for reported Event-comments for event-hosts failed due to the underlying frisby trying to do some JSON-Magic. As we only check the return-code I removed the JSON-Parameter from the options and everything works as expected.

Note that for the frisby-tests to run there are some requirements:

1. Be sure that you have an entry in your ```oauth_consumers```- table with ```consumer_key = 0000``` and ```consumer_secret = 1111```.
2. Check that your src/config.php contains the following entries:

```php
    'features' => [
        'allow_auto_verify_users' => true,
        'allow_auto_approve_events' => true,
    ],
```

3. Frisby needs to be installed either on the VM (AFAIK it currently isn't) or on your local machine. On your local machine you'd want phing to be installed as well for easier calling the test.

When all these prerequisites are met you can run the destructive frisby tests using ```phing frisby-write```. Without phing you'd use ```cd tests/frisby && jasmine-node --nocolor --junitreport --output ../../build/logs/frisby/  api_write_spec.js``` instead.
