### PR TITLE
Feature/ease unit testing

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -353,7 +353,8 @@ class TalksController extends ApiController
         $event_mapper->cacheTalkCount($event_id);
 
         $uri = $request->base . '/' . $request->version . '/talks/' . $new_id;
-        header("Location: " . $uri, true, 201);
+        $request->getView()->setResponseCode(201);
+        $request->getView()->setHeader('Location', $uri);
 
         $new_talk = $this->getTalkById($db, $request, $new_id);
         $collection = new TalkModelCollection([$new_talk], 1);

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -14,10 +14,10 @@ function handle_exception($e)
     global $request, $config;
     $status_code = $e->getCode() ?: 400;
     $status_code = is_numeric($status_code) ? $status_code : 500;
-    header("Status: " . $status_code, false, $status_code);
+    $request->getView()->setResponseCode($status_code);
 
     if ($status_code === 401) {
-        header('WWW-Authenticate: Bearer realm="api.joind.in"');
+        $request->getView()->setHeader('WWW-Authenticate', 'Bearer realm="api.joind.in');
     }
 
     $message = $e->getMessage();

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -72,7 +72,7 @@ $router = new ApiRouter($config, $routers, ['2']);
 $route = $router->getRoute($request);
 $return_data = $route->dispatch($request, $ji_db, $config);
 
-if (isset($request->user_id)) {
+if ($return_data && isset($request->user_id)) {
     $return_data['meta']['user_uri'] = $request->base . '/' . $request->version . '/users/' . $request->user_id;
 }
 

--- a/src/views/ApiView.php
+++ b/src/views/ApiView.php
@@ -1,7 +1,13 @@
 <?php
 
-class ApiView
+abstract class ApiView
 {
+    protected $headers = [];
+
+    protected $responseCode = 200;
+
+    protected $noRender = false;
+
     protected function addCount($content)
     {
         if (is_array($content)) {
@@ -17,4 +23,38 @@ class ApiView
 
         return $content;
     }
+
+    public function setHeader($header, $value)
+    {
+        $this->headers[$header] = $value;
+    }
+
+    public function setResponseCode($code)
+    {
+        $this->responseCode = $code;
+    }
+
+    public function setNoRender($noRender)
+    {
+        $this->noRender = $noRender;
+    }
+
+    public function render($content)
+    {
+        $body = '';
+        if ($content && $this->noRender === false) {
+            $body = $this->buildOutput($content);
+        }
+
+        http_response_code($this->responseCode);
+        foreach ($this->headers as $key => $value) {
+            header($key . ': ' . $value, true);
+        }
+
+        echo $body;
+
+        return true;
+    }
+
+    abstract public function buildOutput($content);
 }

--- a/src/views/ApiView.php
+++ b/src/views/ApiView.php
@@ -1,6 +1,6 @@
 <?php
 
-abstract class ApiView
+class ApiView
 {
     protected $headers = [];
 
@@ -56,5 +56,8 @@ abstract class ApiView
         return true;
     }
 
-    abstract public function buildOutput($content);
+    public function buildOutput($content)
+    {
+        return null;
+    }
 }

--- a/src/views/HtmlView.php
+++ b/src/views/HtmlView.php
@@ -11,6 +11,13 @@
  */
 class HtmlView extends ApiView
 {
+
+    public function render($content)
+    {
+        $this->setHeader('Content-Type', 'text/html; charset=utf8');
+
+        return parent::render($content);
+    }
     /**
      * Render the view
      *
@@ -18,11 +25,10 @@ class HtmlView extends ApiView
      *
      * @return bool
      */
-    public function render($content)
+    public function buildOutput($content)
     {
         $content = $this->addCount($content);
 
-        header('Content-Type: text/html; charset=utf8');
         $this->layoutStart();
         if (is_array($content)) {
             $this->printArray($content);

--- a/src/views/JsonPView.php
+++ b/src/views/JsonPView.php
@@ -9,10 +9,13 @@ class JsonPView extends JsonView
 
     public function render($content)
     {
-        header('Content-Type: text/javascript; charset=utf8');
-        $retval = $this->_callback . '(' . $this->buildOutput($content) . ');';
-        echo $retval;
+        $this->setHeader('Content-Type', 'text/javascript; charset=utf8');
 
-        return true;
+        return parent::render($content);
+    }
+
+    public function buildOutput($content)
+    {
+        return $this->_callback . '(' . parent::buildOutput($content) . ');';
     }
 }

--- a/src/views/JsonView.php
+++ b/src/views/JsonView.php
@@ -4,10 +4,9 @@ class JsonView extends ApiView
 {
     public function render($content)
     {
-        header('Content-Type: application/json; charset=utf8');
-        echo $this->buildOutput($content);
+        $this->setHeader('Content-Type', 'application/json; charset=utf8');
 
-        return true;
+        return parent::render($content);
     }
 
     /**


### PR DESCRIPTION
This change adds ways to omit the current calls to "header" and "exit" in the controllers to send certain headers or to circumvent the output of data to the client.

This change only renders output when content is provided, so when a controller-action returns "null" no output is rendered.

Additionally headers can now be set using a "setHeader"-method on the view, so direct calls to "header" aren't necessary any more

This addresses https://joindin.jira.com/browse/JOINDIN-700