### PR TITLE
Fixing issue where speaker_id = 0

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -548,7 +548,7 @@ class TalksController extends ApiController
 
         if ($claim === false) {
             throw new Exception("No speaker matching that name found", 422);
-        } elseif ($claim['speaker_id'] != null) {
+        } elseif ($claim['speaker_id'] != null && $claim['speaker_id'] != 0) {
             throw new Exception("Talk already claimed", 422);
         }
 


### PR DESCRIPTION
There was an issue where (at least in the test data) a speaker_id of 0 was sometimes used instead of NULL in the talk_speaker table. Because there was only a check for null, the API was reporting that these talks were claimed when that wasn't the case.