### PR TITLE
Fix escaped single and double quotes in Talk-Informations

### DIFF
--- a/db/patch67.sql
+++ b/db/patch67.sql
@@ -1,0 +1,11 @@
+-- Replace &#39; with a single quote in all talk-text-fields
+UPDATE talks SET
+  talk_title = replace(talk_title, '&#39;', "'"),
+  talk_desc = replace(talk_title, '&#39;', "'");
+
+-- Replace &#34; with a double quote in all talk-text-fields
+UPDATE talks SET
+  talk_title = replace(talk_title, '&#34;', '"'),
+  talk_desc = replace(talk_title, '&#34;', '"');
+
+INSERT INTO patch_history SET patch_number = 67;

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -31,7 +31,7 @@ class TalksController extends ApiController
                 $collection = new TalkModelCollection([$talk], 1);
                 $list = $collection->getOutputView($request, $verbose);
             } elseif (isset($request->parameters['title'])) {
-                $keyword = filter_var($request->parameters['title'], FILTER_SANITIZE_STRING);
+                $keyword = filter_var($request->parameters['title'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
 
                 $mapper = new TalkMapper($db, $request);
                 $talks = $mapper->getTalksByTitleSearch($keyword, $resultsperpage, $start);
@@ -430,7 +430,8 @@ class TalksController extends ApiController
 
         $talk['title'] = filter_var(
             $request->getParameter('talk_title'),
-            FILTER_SANITIZE_STRING
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
         );
         if (empty($talk['title'])) {
             throw new Exception("The talk title field is required", 400);
@@ -438,7 +439,8 @@ class TalksController extends ApiController
 
         $talk['description'] = filter_var(
             $request->getParameter('talk_description'),
-            FILTER_SANITIZE_STRING
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
         );
         if (empty($talk['description'])) {
             throw new Exception("The talk description field is required", 400);
@@ -446,7 +448,8 @@ class TalksController extends ApiController
 
         $talk['type'] = filter_var(
             $request->getParameter('type', 'Talk'),
-            FILTER_SANITIZE_STRING
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
         );
 
         $talk_type_mapper = new TalkTypeMapper($db, $request);
@@ -458,7 +461,8 @@ class TalksController extends ApiController
 
         $start_date = filter_var(
             $request->getParameter('start_date'),
-            FILTER_SANITIZE_STRING
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
         );
         if (empty($start_date)) {
             throw new Exception("Please give the date and time of the talk", 400);
@@ -474,7 +478,8 @@ class TalksController extends ApiController
 
         $talk['language'] = filter_var(
             $request->getParameter('language'),
-            FILTER_SANITIZE_STRING
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
         );
         if (empty($talk['language'])) {
             // default to UK English
@@ -501,7 +506,7 @@ class TalksController extends ApiController
 
         $talk['speakers'] = array_map(
             function ($speaker) {
-                $speaker = filter_var($speaker, FILTER_SANITIZE_STRING);
+                $speaker = filter_var($speaker, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
                 $speaker = trim($speaker);
                 return $speaker;
             },

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -31,7 +31,11 @@ class TalksController extends ApiController
                 $collection = new TalkModelCollection([$talk], 1);
                 $list = $collection->getOutputView($request, $verbose);
             } elseif (isset($request->parameters['title'])) {
-                $keyword = filter_var($request->parameters['title'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+                $keyword = filter_var(
+                    $request->parameters['title'],
+                    FILTER_SANITIZE_STRING,
+                    FILTER_FLAG_NO_ENCODE_QUOTES
+                );
 
                 $mapper = new TalkMapper($db, $request);
                 $talks = $mapper->getTalksByTitleSearch($keyword, $resultsperpage, $start);

--- a/tests/frisby/api_write_talks.js
+++ b/tests/frisby/api_write_talks.js
@@ -82,4 +82,32 @@ function testCreateTalkFailsWithIncorrectData(access_token, talks_uri) {
         .expectStatus(201)
         .expectHeaderContains('Location', '/talks/')
         .toss();
+
+    frisby.create('Create talk with Escaped title')
+        .post(
+            talks_uri,
+            {
+                "talk_title" : "Frisby \"test ' Ölrücklaufstoßdämpfer",
+                "talk_description" : "'Ölrücklaufstoßdämpfer\"",
+                "start_date" : (new Date()).toISOString(),
+            },
+            {json: true, headers: {json: true, 'Authorization' : 'oauth ' + access_token, 'Content-type': 'application/json'}}
+        )
+        .expectStatus(201) // Created as it is automatically approved
+        .expectHeaderContains("Location", "/talks/")
+        .after(function(err, res, body) {
+            if(res.statusCode == 201) {
+                // We have an event, we can test it!
+                var event_uri = res.headers.location;
+                frisby.create('Get Talkwith EscapedTitle')
+                    .get(event_uri)
+                    .expectStatus(200) // Created as it is automatically approved
+                    .expectJSON("talks.?", {
+                        "talk_title" : "Frisby \"test ' Ölrücklaufstoßdämpfer",
+                        "talk_description" : "'Ölrücklaufstoßdämpfer\""
+                    })
+                    .toss();
+            }
+        })
+        .toss();
 }


### PR DESCRIPTION
This is a test to verify that the API is not doing any stranfge escaping stuff and returns items as it receives them.

References https://github.com/joindin/joindin-web2/issues/378 and https://github.com/joindin/joindin-web2/issues/366
