### PR TITLE
Remove a host from an event

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -9,6 +9,11 @@
         "action": "addHost",
         "verbs": ["POST"]
     },
+    {   "path": "/events/[\\d]+/hosts/[\\d]+",
+        "controller": "Event_hostsController",
+        "action": "removeHostFromEvent",
+        "verbs": ["DELETE"]
+    },
     {
         "path": "/events(/[^/]+)*/comments/reported",
         "controller": "Event_commentsController",

--- a/src/controllers/Event_hostsController.php
+++ b/src/controllers/Event_hostsController.php
@@ -130,7 +130,7 @@ class Event_hostsController extends ApiController
 
         $isAdmin = $eventMapper->thisUserHasAdminOn($event_id);
         if (!$isAdmin) {
-            throw new Exception("You do not have permission to add hosts to this event", 403);
+            throw new Exception("You do not have permission to remove hosts from this event", 403);
         }
 
         $userMapper = $this->getUserMapper($request, $db);

--- a/src/controllers/Event_hostsController.php
+++ b/src/controllers/Event_hostsController.php
@@ -106,6 +106,65 @@ class Event_hostsController extends ApiController
      * @param Request $request
      * @param PDO     $db
      *
+     * @throws Exception
+     * @return bool
+     */
+    public function removeHostFromEvent(Request $request, PDO $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in to create data", 401);
+        }
+
+        $user_id = $request->url_elements[5];
+        if ($user_id === $request->user_id) {
+            throw new Exception('You are not allowed to remove yourself from the host-list', 403);
+        }
+
+        $event_id = $this->getItemId($request);
+
+        $eventMapper = $this->getEventMapper($request, $db);
+        $event = $eventMapper->getEventById($event_id);
+        if (false === $event) {
+            throw new Exception('Event not found', 404);
+        }
+
+        $isAdmin = $eventMapper->thisUserHasAdminOn($event_id);
+        if (!$isAdmin) {
+            throw new Exception("You do not have permission to add hosts to this event", 403);
+        }
+
+        $userMapper = $this->getUserMapper($request, $db);
+        $user = $userMapper->getUserById($user_id);
+        if (false === $user) {
+            throw new Exception('No User found', 404);
+        }
+
+        $mapper = $this->getEventHostMapper($request, $db);
+
+        $uid = $mapper->removeHostFromEvent($user_id, $event_id);
+        if (false === $uid) {
+            throw new Exception('Something went wrong', 400);
+        }
+
+        $uri = sprintf(
+            '%1$s/%2$s/events/%3$s/hosts',
+            $request->base,
+            $request->version,
+            $event_id
+        );
+
+        $request->getView()->setHeader('Location', $uri);
+        $request->getView()->setResponseCode(204);
+        $request->getView()->setNoRender(true);
+
+        return;
+
+    }
+
+    /**
+     * @param Request $request
+     * @param PDO     $db
+     *
      * @return EventHostMapper
      */
     public function getEventHostMapper(Request $request, PDO $db)

--- a/src/controllers/Event_hostsController.php
+++ b/src/controllers/Event_hostsController.php
@@ -112,7 +112,7 @@ class Event_hostsController extends ApiController
     public function removeHostFromEvent(Request $request, PDO $db)
     {
         if (! isset($request->user_id)) {
-            throw new Exception("You must be logged in to create data", 401);
+            throw new Exception("You must be logged in to remove data", 401);
         }
 
         $user_id = $request->url_elements[5];

--- a/src/models/EventHostMapper.php
+++ b/src/models/EventHostMapper.php
@@ -56,6 +56,18 @@ class EventHostMapper extends ApiMapper
         return $this->_db->lastInsertId();
     }
 
+    public function removeHostfromEvent($host_id, $event_id)
+    {
+        $sql = 'DELETE FROM user_admin WHERE uid = :user_id AND rid = :event_id AND rtype = :type';
+        $stmt = $this->_db->prepare($sql);
+
+        return $stmt->execute([
+            ':host_id'  => $host_id,
+            ':event_id' => $event_id,
+            ':type'     => 'event',
+        ]);
+    }
+
     /**
      * SQL for fetching event hosts, so it can be used in multiple places
      *

--- a/src/models/EventHostMapper.php
+++ b/src/models/EventHostMapper.php
@@ -62,7 +62,7 @@ class EventHostMapper extends ApiMapper
         $stmt = $this->_db->prepare($sql);
 
         return $stmt->execute([
-            ':host_id'  => $host_id,
+            ':user_id'  => $host_id,
             ':event_id' => $event_id,
             ':type'     => 'event',
         ]);

--- a/tests/controllers/Event_hostsControllerTest.php
+++ b/tests/controllers/Event_hostsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace JoindinTest\Controller;
 
+use Mockery as M;
 
 class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,9 +16,25 @@ class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
         $controller = new \Event_hostsController();
 
         $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
-        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+        $db      = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
 
         $controller->addHost($request, $db);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionCode 401
+     * @expectedExceptionMessage You must be logged in to remove data
+     */
+    public function testThatRemovingHostWithoutLoginFails()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->user_id = null;
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+
+        $constructor = new \Event_hostsController();
+        $constructor->removeHostFromEvent($request, $db);
     }
 
     /**
@@ -34,13 +51,55 @@ class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
 
         $controller->setEventMapper($em);
 
-        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request               = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
         $request->url_elements = [3 => 'foo'];
-        $request->user_id = 2;
+        $request->user_id      = 2;
 
         $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
 
         $controller->addHost($request, $db);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage You are not allowed to remove yourself from the host-list
+     */
+    public function testThatRemovingOneselfThrowsException()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->user_id = 1;
+        $request->url_elements = [5 => 1];
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+
+        $constructor = new \Event_hostsController();
+        $constructor->removeHostFromEvent($request, $db);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionCode 404
+     * @expectedExceptionMessage Event not found
+     */
+    public function testThatInvalidEventThrowsException()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->user_id = 1;
+        $request->url_elements = [
+            3 => 4,
+            5 => 2,
+        ];
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+
+        $eventMapper = $this->getMockBuilder('\EventMapper')->disableOriginalConstructor()->getMock();
+        $eventMapper->method('getEventById')->willReturn(false);
+
+        $constructor = new \Event_hostsController();
+        $constructor->setEventMapper($eventMapper);
+
+        $constructor->removeHostFromEvent($request, $db);
     }
 
     /**
@@ -65,6 +124,32 @@ class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
         $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
 
         $controller->addHost($request, $db);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage You do not have permission to add hosts to this event
+     */
+    public function testThatUserThatIsNotAdminOnEventWillThrowException()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->user_id = 1;
+        $request->url_elements = [
+            3 => 4,
+            5 => 2,
+        ];
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+
+        $eventMapper = $this->getMockBuilder('\EventMapper')->disableOriginalConstructor()->getMock();
+        $eventMapper->method('getEventById')->willReturn(true);
+        $eventMapper->method('thisUserHasAdminOn')->willReturn(false);
+
+        $constructor = new \Event_hostsController();
+        $constructor->setEventMapper($eventMapper);
+
+        $constructor->removeHostFromEvent($request, $db);
     }
 
     /**
@@ -95,6 +180,36 @@ class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
         $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
 
         $controller->addHost($request, $db);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionCode 404
+     * @expectedExceptionMessage No User found
+     */
+    public function testThatSettingUnknownUserWillThrowException()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->user_id = 1;
+        $request->url_elements = [
+            3 => 4,
+            5 => 2,
+        ];
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+
+        $eventMapper = $this->getMockBuilder('\EventMapper')->disableOriginalConstructor()->getMock();
+        $eventMapper->method('getEventById')->willReturn(true);
+        $eventMapper->method('thisUserHasAdminOn')->willReturn(true);
+
+        $userMapper = $this->getMockBuilder('\UserMapper')->disableOriginalConstructor()->getMock();
+        $userMapper->method('getUserById')->willReturn(false);
+
+        $constructor = new \Event_hostsController();
+        $constructor->setEventMapper($eventMapper);
+        $constructor->setUserMapper($userMapper);
+
+        $constructor->removeHostFromEvent($request, $db);
     }
 
     /**
@@ -160,6 +275,8 @@ class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
         $view->expects($this->once())->method('setResponseCode')->with($this->equalTo(201));
         $view->expects($this->once())->method('setNoRender')->with($this->equalTo(true));
 
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+
         $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
         $request->url_elements = [3 => 12];
         $request->user_id = 2;
@@ -167,8 +284,123 @@ class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
         $request->method('getParameter')->willReturn('myhostname');
         $request->method('getView')->willReturn($view);
 
+        $controller->addHost($request, $db);
+    }
+
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionCode 400
+     * @expectedExceptionMessage Something went wrong
+     */
+    public function testThatFailureWhileRemovingUserAsHostWillThrowException()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->user_id = 1;
+        $request->url_elements = [
+            3 => 4,
+            5 => 2,
+        ];
+
         $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
 
-        $controller->addHost($request, $db);
+        $eventMapper = $this->getMockBuilder('\EventMapper')->disableOriginalConstructor()->getMock();
+        $eventMapper->method('getEventById')->willReturn(true);
+        $eventMapper->method('thisUserHasAdminOn')->willReturn(true);
+
+        $userMapper = $this->getMockBuilder('\UserMapper')->disableOriginalConstructor()->getMock();
+        $userMapper->method('getUserById')->willReturn(true);
+
+        $eventHostMapper = $this->getMockBuilder('\EventHostMapper')->disableOriginalConstructor()->getMock();
+        $eventHostMapper->method('removeHostFromEvent')->willReturn(false);
+
+        $constructor = new \Event_hostsController();
+        $constructor->setEventMapper($eventMapper);
+        $constructor->setUserMapper($userMapper);
+        $constructor->setEventHostMapper($eventHostMapper);
+
+        $constructor->removeHostFromEvent($request, $db);
+    }
+
+    public function testThatRemovingUserAsHostSetsCorrectValues()
+    {
+        $view = $this->getMockBuilder('\ApiView')->getMock();
+        $view->method('setHeader')->with('Location', 'base/version/events/4/hosts');
+        $view->method('setResponseCode')->with(204);
+        $view->method('setNoRender')->with(true);
+
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->user_id = 1;
+        $request->url_elements = [
+            3 => 4,
+            5 => 2,
+        ];
+        $request->base = 'base';
+        $request->version = 'version';
+        $request->method('getView')->willReturn($view);
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+
+        $eventMapper = $this->getMockBuilder('\EventMapper')->disableOriginalConstructor()->getMock();
+        $eventMapper->method('getEventById')->willReturn(true);
+        $eventMapper->method('thisUserHasAdminOn')->willReturn(true);
+
+        $userMapper = $this->getMockBuilder('\UserMapper')->disableOriginalConstructor()->getMock();
+        $userMapper->method('getUserById')->willReturn(true);
+
+        $eventHostMapper = $this->getMockBuilder('\EventHostMapper')->disableOriginalConstructor()->getMock();
+        $eventHostMapper->method('removeHostFromEvent')->willReturn(true);
+
+        $constructor = new \Event_hostsController();
+        $constructor->setEventMapper($eventMapper);
+        $constructor->setUserMapper($userMapper);
+        $constructor->setEventHostMapper($eventHostMapper);
+
+        $this->assertNull($constructor->removeHostFromEvent($request, $db));
+    }
+
+    public function testThatGetingEventHostWapperMithoutSettingFirstWorksAsExpected()
+    {
+        $controller = new \Event_hostsController();
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+
+
+        $this->assertAttributeEquals(null, 'eventHostMapper', $controller);
+        $automatedEventHostMapper = $controller->getEventHostMapper($request, $db);
+        $this->assertInstanceOf('EventHostMapper', $automatedEventHostMapper);
+        $this->assertAttributeSame($automatedEventHostMapper, 'eventHostMapper', $controller);
+        $this->assertSame($automatedEventHostMapper, $controller->getEventHostMapper($request, $db));
+    }
+
+    public function testThatGetingUserMapperWithoutSettingFirstWorksAsExpected()
+    {
+        $controller = new \Event_hostsController();
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+
+
+        $this->assertAttributeEquals(null, 'userMapper', $controller);
+        $automatedUserMapper = $controller->getUserMapper($request, $db);
+        $this->assertInstanceOf('UserMapper', $automatedUserMapper);
+        $this->assertAttributeSame($automatedUserMapper, 'userMapper', $controller);
+        $this->assertSame($automatedUserMapper, $controller->getUserMapper($request, $db));
+    }
+
+    public function testThatGetingEventMapperWithoutSettingFirstWorksAsExpected()
+    {
+        $controller = new \Event_hostsController();
+
+        $db = $this->getMockBuilder('\PDO')->disableOriginalConstructor()->getMock();
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+
+
+        $this->assertAttributeEquals(null, 'eventMapper', $controller);
+        $automatedEventMapper = $controller->getEventMapper($request, $db);
+        $this->assertInstanceOf('EventMapper', $automatedEventMapper);
+        $this->assertAttributeSame($automatedEventMapper, 'eventMapper', $controller);
+        $this->assertSame($automatedEventMapper, $controller->getEventMapper($request, $db));
     }
 }

--- a/tests/controllers/Event_hostsControllerTest.php
+++ b/tests/controllers/Event_hostsControllerTest.php
@@ -129,7 +129,7 @@ class Event_hostsControllerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Exception
      * @expectedExceptionCode 403
-     * @expectedExceptionMessage You do not have permission to add hosts to this event
+     * @expectedExceptionMessage You do not have permission to remove hosts from this event
      */
     public function testThatUserThatIsNotAdminOnEventWillThrowException()
     {

--- a/tests/models/EventHostMapperTest.php
+++ b/tests/models/EventHostMapperTest.php
@@ -117,4 +117,28 @@ class EventHostMapperTest extends PHPUnit_Framework_TestCase
             ]
         ], $mapper->getHostsByEventId(12, 10, 0));
     }
+
+    public function testThatRemovingAHostFromAnEventCallsTheExpectedMethods()
+    {
+        $stmt1 = $this->getMockBuilder('PDOStatement')->disableOriginalConstructor()->getMock();
+        $stmt1->method('execute')
+              ->with([
+                  ':user_id'  => 12,
+                  ':event_id' => 14,
+                  ':type'     => 'event',
+              ])
+              ->willReturn(true);
+
+        $pdo = $this->getMockBuilder('PDO')->disableOriginalConstructor()->getMock();
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->with('DELETE FROM user_admin WHERE uid = :user_id AND rid = :event_id AND rtype = :type')
+            ->willReturn($stmt1);
+
+        $request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
+
+        $mapper = new EventHostMapper($pdo, $request);
+        $this->assertTrue($mapper->removeHostfromEvent(12, 14));
+
+    }
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -21,7 +21,7 @@
     </logging>
 
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+        <whitelist processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">../src/controllers</directory>
             <directory suffix=".php">../src/inc</directory>
             <directory suffix=".php">../src/models</directory>


### PR DESCRIPTION
This PR adds functionality to remove a host from an event. For that it implements the API-Endpoint ```DELETE api/v2.1/events/[event-id]/hosts/[user-id]```.

This PR is based on #371 and should be rebased onto master after that PR has been merged.