### PR TITLE
Fixes issues with newer phpunit-versions

### DIFF
--- a/tests/inc/RequestTest.php
+++ b/tests/inc/RequestTest.php
@@ -3,6 +3,8 @@ namespace JoindinTest\Inc;
 
 require_once __DIR__ . '/../../src/inc/Request.php';
 
+use Request;
+
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -471,10 +473,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         // Please see below for explanation of why we're mocking a "mock" PDO
         // class
-        $db      = $this->getMock(
-            '\JoindinTest\Inc\mockPDO',
-            array('getAvailableDrivers')
-        );
+        $db      = $this->getMockBuilder(
+            '\JoindinTest\Inc\mockPDO')->getMock();
+        $db->method('getAvailableDrivers');
+
         $request = new \Request($this->config, []);
         $result  = $request->getOAuthModel($db);
 
@@ -507,7 +509,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function setOauthModelMethodIsFluent()
     {
         /* @var $mockOauth \OAuthModel */
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMockBuilder('OAuthModel')->disableOriginalConstructor()->getMock();
         $request   = new \Request($this->config, []);
 
         $this->assertSame($request, $request->setOauthModel($mockOauth));
@@ -524,7 +526,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function setOauthModelAllowsSettingOfOauthModel()
     {
         /* @var $mockOauth \OAuthModel */
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMockBuilder('OAuthModel')->disableOriginalConstructor()->getMock();
         $request   = new \Request($this->config, []);
         $request->setOauthModel($mockOauth);
 
@@ -542,7 +544,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function identifyUserWithOauthTokenTypeSetsUserIdForValidHeader()
     {
         $request   = new \Request($this->config, ['HTTPS' => 'on']);
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMockBuilder('OAuthModel')->disableOriginalConstructor()->getMock();
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
             ->with('authPart')
@@ -567,7 +569,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function identifyUserWithBearerTokenTypeSetsUserIdForValidHeader()
     {
         $request   = new \Request($this->config, ['HTTPS' => 'on']);
-        $mockOauth = $this->getMock('OAuthModel', array(), array(), '', false);
+        $mockOauth = $this->getMockBuilder('OAuthModel')->disableOriginalConstructor()->getMock();
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
             ->with('authPart')
@@ -816,14 +818,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array( // #0
-                'expected' => array(\Request::CONTENT_TYPE_JSON,
-                                    \Request::CONTENT_TYPE_HTML),
+                'expected' => array(Request::CONTENT_TYPE_JSON,
+                                    Request::CONTENT_TYPE_HTML),
             ),
             array( // #1
-                'expected' => array(\Request::CONTENT_TYPE_HTML,
-                                    \Request::CONTENT_TYPE_JSON),
-                'choices' => array(\Request::CONTENT_TYPE_HTML,
-                                    \Request::CONTENT_TYPE_JSON),
+                'expected' => array(Request::CONTENT_TYPE_HTML,
+                                    Request::CONTENT_TYPE_JSON),
+                'choices' => array(Request::CONTENT_TYPE_HTML,
+                                    Request::CONTENT_TYPE_JSON),
             ),
             array( // #2
                 'expected' => array('a', 'b'),

--- a/tests/inc/RequestTest.php
+++ b/tests/inc/RequestTest.php
@@ -3,8 +3,6 @@ namespace JoindinTest\Inc;
 
 require_once __DIR__ . '/../../src/inc/Request.php';
 
-use Request;
-
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -818,14 +816,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array( // #0
-                'expected' => array(Request::CONTENT_TYPE_JSON,
-                                    Request::CONTENT_TYPE_HTML),
+                'expected' => array(\Request::CONTENT_TYPE_JSON,
+                                    \Request::CONTENT_TYPE_HTML),
             ),
             array( // #1
-                'expected' => array(Request::CONTENT_TYPE_HTML,
-                                    Request::CONTENT_TYPE_JSON),
-                'choices' => array(Request::CONTENT_TYPE_HTML,
-                                    Request::CONTENT_TYPE_JSON),
+                'expected' => array(\Request::CONTENT_TYPE_HTML,
+                                    \Request::CONTENT_TYPE_JSON),
+                'choices' => array(\Request::CONTENT_TYPE_HTML,
+                                    \Request::CONTENT_TYPE_JSON),
             ),
             array( // #2
                 'expected' => array('a', 'b'),


### PR DESCRIPTION
```getMock``` is deprecated in newer phpunit-versions. THis PR replaces them with calls to ```getMockBuilder()```