### PR TITLE
Hotfix/header

### DIFF
--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -73,7 +73,9 @@ class ContactController extends ApiController
         $emailService = new ContactEmailService($this->config);
         $emailService->sendEmail($data);
 
-        header("Content-Length: 0", null, 202);
-        exit;
+        $view = $request->getView();
+
+        $view->setResponseCode(202);
+        $view->setHeader('Content-Length', 0);
     }
 }

--- a/src/controllers/EmailsController.php
+++ b/src/controllers/EmailsController.php
@@ -22,8 +22,10 @@ class EmailsController extends ApiController
                 $emailService = new UserRegistrationEmailService($this->config, $recipients, $token);
                 $emailService->sendEmail();
 
-                header("Content-Length: 0", null, 202);
-                exit;
+                $view = $request->getView();
+                $view->setHeader('Content-Length', 0);
+                $view->setResponseCode(202);
+                return;
             }
             throw new Exception("Can't find that email address", 400);
         }
@@ -44,8 +46,10 @@ class EmailsController extends ApiController
                 $emailService = new UserUsernameReminderEmailService($this->config, $recipients, $user);
                 $emailService->sendEmail();
 
-                header("Content-Length: 0", null, 202);
-                exit;
+                $view = $request->getView();
+                $view->setHeader('Content-Length', 0);
+                $view->setResponseCode(202);
+                return;
             }
             throw new Exception("Can't find that email address", 400);
         }
@@ -76,8 +80,10 @@ class EmailsController extends ApiController
                 $emailService = new UserPasswordResetEmailService($this->config, $recipients, $user, $token);
                 $emailService->sendEmail();
 
-                header("Content-Length: 0", null, 202);
-                exit;
+                $view = $request->getView();
+                $view->setHeader('Content-Length', 0);
+                $view->setResponseCode(202);
+                return;
             }
             throw new Exception("Can't find that user", 400);
         }

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -94,7 +94,12 @@ class EventImagesController extends ApiController
         $event_mapper->saveNewImage($event_id, $small_filename, $small_width, $small_height, "small");
 
         $location = $request->base . '/' . $request->version . '/events/' . $event_id;
-        header('Location: ' . $location, null, 201);
+
+        $view = $request->getView();
+        $view->setHeader('Location', $location);
+        $view->setResponseCode(201);
+        return;
+
     }
 
     public function deleteImage($request, $db)
@@ -108,7 +113,11 @@ class EventImagesController extends ApiController
         $event_mapper->removeImages($event_id);
 
         $location = $request->base . '/' . $request->version . '/events/' . $event_id;
-        header('Location: ' . $location, null, 204);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $location);
+        $view->setResponseCode(204);
+        return;
+
     }
 }

--- a/src/controllers/EventImagesController.php
+++ b/src/controllers/EventImagesController.php
@@ -98,8 +98,6 @@ class EventImagesController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $location);
         $view->setResponseCode(201);
-        return;
-
     }
 
     public function deleteImage($request, $db)
@@ -117,7 +115,5 @@ class EventImagesController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $location);
         $view->setResponseCode(204);
-        return;
-
     }
 }

--- a/src/controllers/Event_commentsController.php
+++ b/src/controllers/Event_commentsController.php
@@ -132,8 +132,12 @@ class Event_commentsController extends ApiController
         $event_mapper->cacheCommentCount($comment['event_id']);
 
         $uri = $request->base . '/' . $request->version . '/event_comments/' . $new_id;
-        header("Location: " . $uri, null, 201);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(201);
+        return;
+
     }
 
     public function reportComment($request, $db)
@@ -166,8 +170,12 @@ class Event_commentsController extends ApiController
 
         // send them to the comments collection
         $uri = $request->base . '/' . $request->version . '/events/' . $eventId . "/comments";
-        header("Location: " . $uri, true, 202);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(202);
+        return;
+
     }
 
     /**
@@ -211,7 +219,11 @@ class Event_commentsController extends ApiController
         $comment_mapper->moderateReportedComment($decision, $commentId, $request->user_id);
 
         $uri = $request->base  . '/' . $request->version . '/events/' . $event_id . "/comments";
-        header("Location: $uri", true, 204);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(204);
+        return;
+
     }
 }

--- a/src/controllers/Event_commentsController.php
+++ b/src/controllers/Event_commentsController.php
@@ -136,8 +136,6 @@ class Event_commentsController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $uri);
         $view->setResponseCode(201);
-        return;
-
     }
 
     public function reportComment($request, $db)
@@ -174,8 +172,6 @@ class Event_commentsController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $uri);
         $view->setResponseCode(202);
-        return;
-
     }
 
     /**
@@ -223,7 +219,5 @@ class Event_commentsController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $uri);
         $view->setResponseCode(204);
-        return;
-
     }
 }

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -632,8 +632,6 @@ class EventsController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $uri);
         $view->setResponseCode(201);
-        return;
-
     }
 
     /**
@@ -678,7 +676,6 @@ class EventsController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $location);
         $view->setResponseCode(204);
-        return;
     }
 
     /**

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -159,9 +159,12 @@ class EventsController extends ApiController
                     $event_id     = $this->getItemId($request);
                     $event_mapper = new EventMapper($db, $request);
                     $event_mapper->setUserAttendance($event_id, $request->user_id);
-                    header("Location: " . $request->base . $request->path_info, null, 201);
 
+                    $view = $request->getView();
+                    $view->setHeader('Location', $request->base . $request->path_info);
+                    $view->setResponseCode(201);
                     return;
+
                 default:
                     throw new Exception("Operation not supported, sorry", 404);
             }
@@ -328,12 +331,17 @@ class EventsController extends ApiController
                     $event_id = $event_mapper->createEvent($event, true);
 
                     // redirect to event listing
-                    header("Location: " . $request->base . $request->path_info . '/' . $event_id, null, 201);
+                    $view = $request->getView();
+                    $view->setHeader('Location', $request->base . $request->path_info . '/' . $event_id);
+                    $view->setResponseCode(201);
+
                 } else {
                     $event_id = $event_mapper->createEvent($event);
 
                     // set status to accepted; a pending event won't be visible
-                    header("Location: " . $request->base . $request->path_info, null, 202);
+                    $view = $request->getView();
+                    $view->setHeader('Location', $request->base . $request->path_info);
+                    $view->setResponseCode(202);
                 }
 
                 // now set the current user as host and attending
@@ -351,7 +359,7 @@ class EventsController extends ApiController
                     $emailService = new EventSubmissionEmailService($this->config, $recipients, $event, $count);
                     $emailService->sendEmail();
                 }
-                exit;
+                return;
             }
         }
     }
@@ -367,9 +375,12 @@ class EventsController extends ApiController
                     $event_id     = $this->getItemId($request);
                     $event_mapper = new EventMapper($db, $request);
                     $event_mapper->setUserNonAttendance($event_id, $request->user_id);
-                    header("Location: " . $request->base . $request->path_info, null, 200);
 
+                    $view = $request->getView();
+                    $view->setHeader('Location', $request->base . $request->path_info);
+                    $view->setResponseCode(200);
                     return;
+
                     break;
                 default:
                     throw new Exception("Operation not supported, sorry", 404);
@@ -524,8 +535,11 @@ class EventsController extends ApiController
                 $event_mapper->setTags($event_id, $tags);
             }
 
-            header("Location: " . $request->base . $request->path_info, null, 204);
-            exit;
+            $view = $request->getView();
+            $view->setHeader('Location', $request->base . $request->path_info);
+            $view->setResponseCode(204);
+            return;
+
         }
     }
 
@@ -614,8 +628,12 @@ class EventsController extends ApiController
         $track_id = $track_mapper->createEventTrack($track, $event_id);
 
         $uri = $request->base  . '/' . $request->version . '/tracks/' . $track_id;
-        header("Location: " . $uri, null, 201);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(201);
+        return;
+
     }
 
     /**
@@ -656,8 +674,10 @@ class EventsController extends ApiController
         }
 
         $location = $request->base . '/' . $request->version . '/events/' . $event_id;
-        header('Location: ' . $location, null, 204);
 
+        $view = $request->getView();
+        $view->setHeader('Location', $location);
+        $view->setResponseCode(204);
         return;
     }
 
@@ -687,9 +707,9 @@ class EventsController extends ApiController
             throw new Exception("This event cannot be rejected", 400);
         }
 
-        header("Content-Length: 0", null, 204);
-
-        return;
+        $view = $request->getView();
+        $view->setHeader('Content-Length', 0);
+        $view->setResponseCode(204);
     }
 
 

--- a/src/controllers/Talk_commentsController.php
+++ b/src/controllers/Talk_commentsController.php
@@ -81,8 +81,10 @@ class Talk_commentsController extends ApiController
 
         // send them to the comments collection
         $uri = $request->base . '/' . $request->version . '/talks/' . $talkId . "/comments";
-        header("Location: " . $uri, true, 202);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(202);
     }
 
     /**
@@ -127,8 +129,10 @@ class Talk_commentsController extends ApiController
 
         $talk_id  = $commentInfo['talk_id'];
         $uri = $request->base  . '/' . $request->version . '/talks/' . $talk_id . "/comments";
-        header("Location: $uri", true, 204);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(204);
     }
 
     public function updateComment($request, $db)

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -258,8 +258,6 @@ class TalksController extends ApiController
         $view = $request->getView();
         $view->setHeader('Location', $uri);
         $view->setResponseCode(201);
-        return;
-
     }
 
     /**

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -130,8 +130,12 @@ class TalksController extends ApiController
                         $emailService = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
                         $emailService->sendEmail();
                         $uri = $request->base . '/' . $request->version . '/talk_comments/' . $new_id;
-                        header("Location: " . $uri, true, 201);
-                        exit;
+
+                        $view = $request->getView();
+                        $view->setHeader('Location', $uri);
+                        $view->setResponseCode(201);
+                        return;
+
                     } else {
                         throw new Exception("The comment could not be stored", 400);
                     }
@@ -141,8 +145,11 @@ class TalksController extends ApiController
                     // The logged in user *is* attending the talk.  Use DELETE to unattend
                     $talk_mapper = new TalkMapper($db, $request);
                     $talk_mapper->setUserStarred($talk_id, $request->user_id);
-                    header("Location: " . $request->base . $request->path_info, null, 201);
-                    exit;
+
+                    $view = $request->getView();
+                    $view->setHeader('Location', $request->base . $request->path_info);
+                    $view->setResponseCode(201);
+                    return;
                 default:
                     throw new Exception("Operation not supported, sorry", 404);
             }
@@ -162,8 +169,12 @@ class TalksController extends ApiController
                     $talk_id     = $this->getItemId($request);
                     $talk_mapper = new TalkMapper($db, $request);
                     $talk_mapper->setUserNonStarred($talk_id, $request->user_id);
-                    header("Location: " . $request->base . $request->path_info, null, 200);
-                    exit;
+
+                    $view = $request->getView();
+                    $view->setHeader('Location', $request->base . $request->path_info);
+                    $view->setResponseCode(200);
+                    return;
+
                 default:
                     throw new Exception("Operation not supported, sorry", 404);
             }
@@ -176,8 +187,10 @@ class TalksController extends ApiController
             $talk = $talk_mapper->getTalkById($talk_id);
             if (false === $talk) {
                 // talk isn't there so it's as good as deleted
-                header("Content-Length: 0", null, 204);
-                exit; // no more content
+                $view = $request->getView();
+                $view->setHeader('Content-Length', 0);
+                $view->setResponseCode(204);
+                return;
             }
 
             $is_admin = $talk_mapper->thisUserHasAdminOn($talk_id);
@@ -186,8 +199,10 @@ class TalksController extends ApiController
             }
 
             $talk_mapper->delete($talk_id);
-            header("Content-Length: 0", null, 204);
-            exit; // no more content
+            $view = $request->getView();
+            $view->setHeader('Content-Length', 0);
+            $view->setResponseCode(204);
+            return;
         }
     }
 
@@ -239,8 +254,12 @@ class TalksController extends ApiController
         $talk_mapper->addTalkToTrack($talk_id, $track_id);
 
         $uri = $request->base . '/' . $request->version . '/talks/' . $talk_id;
-        header('Location: ' . $uri, null, 201);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(201);
+        return;
+
     }
 
     /**
@@ -285,8 +304,10 @@ class TalksController extends ApiController
         $talk_mapper->removeTrackFromTalk($talk_id, $track_id);
 
         $uri = $request->base . '/' . $request->version . '/talks/' . $talk_id;
-        header('Location: ' . $uri, null, 204);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(204);
     }
 
     /**
@@ -405,8 +426,9 @@ class TalksController extends ApiController
         // edit the talk
         $talk_mapper->editTalk($data, $talk_id);
 
-        header("Location: " . $request->base . $request->path_info, null, 204);
-        exit;
+        $view = $request->getView();
+        $view->setHeader('Location', $request->base . $request->path_info);
+        $view->setResponseCode(204);
     }
 
     /**
@@ -631,13 +653,9 @@ class TalksController extends ApiController
             }
         }
 
-        //If we are unit testing, then we can't exit or send headers!
-        if (defined('UNIT_TEST')) {
-            return true;
-        }
-
-        header("Location: " . $request->base . $request->path_info, null, 204);
-        exit;
+        $view = $request->getView();
+        $view->setHeader('Location', $request->base . $request->path_info);
+        $view->setResponseCode(204);
     }
 
     private function getLinkUserDataFromRequest(Request $request)
@@ -735,7 +753,9 @@ class TalksController extends ApiController
         $talk_mapper->removeApprovedSpeakerFromTalk($talk_id, $speaker_id);
 
         $uri = $request->base . '/' . $request->version . '/talks/' . $talk_id;
-        header('Location: ' . $uri, null, 204);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(204);
     }
 }

--- a/src/controllers/TracksController.php
+++ b/src/controllers/TracksController.php
@@ -73,8 +73,10 @@ class TracksController extends ApiController
         $track_mapper->editEventTrack($track, $track_id);
 
         $uri = $request->base  . '/' . $request->version . '/tracks/' . $track_id;
-        header("Location: $uri", true, 204);
-        exit;
+
+        $view = $request->getView();
+        $view->setHeader('Location', $uri);
+        $view->setResponseCode(204);
     }
 
     public function deleteTrack($request, $db)
@@ -104,7 +106,8 @@ class TracksController extends ApiController
 
         $track_mapper->deleteEventTrack($track_id);
 
-        header("Content-Length: 0", null, 204);
-        exit;
+        $view = $request->getView();
+        $view->setHeader('Content-Length', 0);
+        $view->setResponseCode(204);
     }
 }

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -80,8 +80,11 @@ class UsersController extends ApiController
                     } else {
                         $success = $user_mapper->verifyUser($token);
                         if ($success) {
-                            header("Content-Length: 0", null, 204);
-                            exit; // no more content
+                            $view = $request->getView();
+                            $view->setHeader('Content-Length', 0);
+                            $view->setResponseCode(204);
+                            return;
+
                         } else {
                             throw new Exception("Verification failed", 400);
                         }
@@ -151,7 +154,9 @@ class UsersController extends ApiController
                 throw new Exception(implode(". ", $errors), 400);
             } else {
                 $user_id = $user_mapper->createUser($user);
-                header("Location: " . $request->base . $request->path_info . '/' . $user_id, null, 201);
+                $view = $request->getView();
+                $view->setHeader('Location', $request->base . $request->path_info . '/' . $user_id);
+                $view->setResponseCode(201);
 
                 // autoverify for test platforms
                 if (isset($this->config['features']['allow_auto_verify_users'])
@@ -170,7 +175,8 @@ class UsersController extends ApiController
                 $recipients   = array($user['email']);
                 $emailService = new UserRegistrationEmailService($this->config, $recipients, $token);
                 $emailService->sendEmail();
-                exit;
+
+                return;
             }
         }
     }
@@ -280,8 +286,11 @@ class UsersController extends ApiController
                 }
 
                 // we're good!
-                header("Content-Length: 0", null, 204);
-                exit; // no more content
+                $view = $request->getView();
+                $view->setHeader('Content-Length', 0);
+                $view->setResponseCode(204);
+                return;
+
             }
         }
         throw new Exception("Could not update user", 400);
@@ -305,8 +314,10 @@ class UsersController extends ApiController
             // OK, go ahead
             $success = $user_mapper->resetPassword($token, $password);
             if ($success) {
-                header("Content-Length: 0", null, 204);
-                exit; // no more content
+                $view = $request->getView();
+                $view->setHeader('Content-Length', 0);
+                $view->setResponseCode(204);
+                return;
             } else {
                 throw new Exception("Password could not be reset", 400);
             }
@@ -336,14 +347,10 @@ class UsersController extends ApiController
         if (! $user_mapper->delete($user_id)) {
             throw new Exception("There was a problem trying to delete the user", 400);
         }
-        //If we are unit testing, then we can't exit or send headers!
-        if (defined('UNIT_TEST')) {
-            return true;
-        }
 
-        header("Content-Length: 0", null, 204);
-        exit; // no more content
-
+        $view = $request->getView();
+        $view->setHeader('Content-Length', 0);
+        $view->setResponseCode(204);
     }
 
     public function setUserMapper(UserMapper $user_mapper)

--- a/src/views/ApiView.php
+++ b/src/views/ApiView.php
@@ -45,7 +45,9 @@ class ApiView
         if ($content && $this->noRender === false) {
             $body = $this->buildOutput($content);
         }
-
+        if (200 == $this->responseCode) {
+            $this->responseCode = http_response_code();
+        }
         http_response_code($this->responseCode);
         foreach ($this->headers as $key => $value) {
             header($key . ': ' . $value, true);

--- a/src/views/ApiView.php
+++ b/src/views/ApiView.php
@@ -48,10 +48,10 @@ class ApiView
         if (200 == $this->responseCode) {
             $this->responseCode = http_response_code();
         }
-        http_response_code($this->responseCode);
         foreach ($this->headers as $key => $value) {
             header($key . ': ' . $value, true);
         }
+        http_response_code($this->responseCode);
 
         echo $body;
 

--- a/tests/controllers/TalksControllerTest.php
+++ b/tests/controllers/TalksControllerTest.php
@@ -382,7 +382,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $event_mapper = $this->createEventMapper($db, $request);
         $talks_controller->setEventMapper($event_mapper);
 
-        $this->assertTrue($talks_controller->setSpeakerForTalk($request, $db));
+        $this->assertNull($talks_controller->setSpeakerForTalk($request, $db));
 
     }
 
@@ -445,7 +445,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $event_mapper = $this->createEventMapper($db, $request);
         $talks_controller->setEventMapper($event_mapper);
 
-        $this->assertTrue($talks_controller->setSpeakerForTalk($request, $db));
+        $this->assertNull($talks_controller->setSpeakerForTalk($request, $db));
 
     }
 
@@ -629,7 +629,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $event_mapper = $this->createEventMapper($db, $request);
         $talks_controller->setEventMapper($event_mapper);
 
-        $this->assertTrue($talks_controller->setSpeakerForTalk($request, $db));
+        $this->assertNull($talks_controller->setSpeakerForTalk($request, $db));
 
     }
 
@@ -698,7 +698,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
         $event_mapper = $this->createEventMapper($db, $request);
         $talks_controller->setEventMapper($event_mapper);
 
-        $this->assertTrue($talks_controller->setSpeakerForTalk($request, $db));
+        $this->assertNull($talks_controller->setSpeakerForTalk($request, $db));
 
     }
 

--- a/tests/controllers/UsersControllerTest.php
+++ b/tests/controllers/UsersControllerTest.php
@@ -129,7 +129,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $usersController->setUserMapper($userMapper);
-        $this->assertTrue($usersController->deleteUser($request, $db));
+        $this->assertNull($usersController->deleteUser($request, $db));
 
     }
 

--- a/tests/views/ApiViewTest.php
+++ b/tests/views/ApiViewTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @covers ApiView
+ */
+class ApiViewTest extends PHPUnit_Framework_TestCase
+{
+    /** @runInSeparateProcess */
+    public function testThatAReturnCodeSetViaHeaderIsReturnedWhenNoOtherReturnCodeIsSet()
+    {
+        $view = new ApiView();
+
+        header('Foo: bar', false, 201);
+
+        ob_start();
+        $view->render('');
+        $this->assertEquals('', ob_get_contents());
+        ob_end_clean();
+
+        $this->assertEquals(201, http_response_code());
+    }
+
+    /** @runInSeparateProcess */
+    public function testThatAReturnCodeSetViaSetHeaderIsReturnedEvenThoughAHeaderCodeIsSet()
+    {
+        $view = new ApiView();
+
+        $view->setResponseCode(202);
+        header('Foo: bar', false, 201);
+
+        ob_start();
+        $view->render('');
+        $this->assertEquals('', ob_get_contents());
+        ob_end_clean();
+
+        $this->assertEquals(202, http_response_code());
+    }
+
+
+    /** @runInSeparateProcess */
+    public function testThatHeadersAreSet()
+    {
+        $view = new ApiView();
+
+        $view->setResponseCode(202);
+        header('Foo: bar', false, 201);
+
+        ob_start();
+        $view->render('');
+        $this->assertEquals('', ob_get_contents());
+        ob_end_clean();
+
+        $expectedHeaders = [
+            'Foo: bar',
+        ];
+        $this->assertEquals($expectedHeaders, xdebug_get_headers());
+    }
+
+    /** @runInSeparateProcess */
+    public function testThatHeadersAreSetViaSetHeaders()
+    {
+        $view = new ApiView();
+
+        $view->setHeader('Bar', 'Foo');
+
+        $view->render('');
+
+        $expectedHeaders = [
+            'Bar: Foo',
+        ];
+        $this->assertEquals($expectedHeaders, xdebug_get_headers());
+    }
+}

--- a/tests/views/ApiViewTest.php
+++ b/tests/views/ApiViewTest.php
@@ -5,7 +5,10 @@
  */
 class ApiViewTest extends PHPUnit_Framework_TestCase
 {
-    /** @runInSeparateProcess */
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testThatAReturnCodeSetViaHeaderIsReturnedWhenNoOtherReturnCodeIsSet()
     {
         $view = new ApiView();
@@ -20,7 +23,10 @@ class ApiViewTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(201, http_response_code());
     }
 
-    /** @runInSeparateProcess */
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testThatAReturnCodeSetViaSetHeaderIsReturnedEvenThoughAHeaderCodeIsSet()
     {
         $view = new ApiView();
@@ -36,8 +42,10 @@ class ApiViewTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(202, http_response_code());
     }
 
-
-    /** @runInSeparateProcess */
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testThatHeadersAreSet()
     {
         $view = new ApiView();
@@ -56,7 +64,10 @@ class ApiViewTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedHeaders, xdebug_get_headers());
     }
 
-    /** @runInSeparateProcess */
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testThatHeadersAreSetViaSetHeaders()
     {
         $view = new ApiView();


### PR DESCRIPTION
This PR alters the way the HTTP-Status-code is set. It also replaces all the calls to ```header``` and ```exit``` with calls to ```ApiView::setHeader()```, ```ApiView::setResponseCode()```  and ```return```.

That makes way to easier testing.