### PR TITLE
JOINDIN-600 Dont email author their own comments

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -124,11 +124,17 @@ class TalksController extends ApiController
                         $comment    = $comment_mapper->getCommentById($new_id);
                         $speakers   = $talk_mapper->getSpeakerEmailsByTalkId($talk_id);
                         $recipients = array();
+                        $commentAuthorEmail = $comments[0]['email'];
                         foreach ($speakers as $person) {
+                            if ($commentAuthorEmail == $person['email']) {
+                                continue;
+                            }
                             $recipients[] = $person['email'];
                         }
-                        $emailService = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
-                        $emailService->sendEmail();
+                        if (count($recipients) > 0) {
+                            $emailService = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
+                            $emailService->sendEmail();
+                        }
                         $uri = $request->base . '/' . $request->version . '/talk_comments/' . $new_id;
                         header("Location: " . $uri, true, 201);
                         exit;

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -124,17 +124,16 @@ class TalksController extends ApiController
                         $comment    = $comment_mapper->getCommentById($new_id);
                         $speakers   = $talk_mapper->getSpeakerEmailsByTalkId($talk_id);
                         $recipients = array();
-                        $commentAuthorEmail = $comments[0]['email'];
+                        $commentAuthorEmail = $comment[0]['email'];
                         foreach ($speakers as $person) {
                             if ($commentAuthorEmail == $person['email']) {
                                 continue;
                             }
                             $recipients[] = $person['email'];
                         }
-                        if (count($recipients) > 0) {
-                            $emailService = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
-                            $emailService->sendEmail();
-                        }
+
+                        $emailService = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
+                        $emailService->sendEmail();
                         $uri = $request->base . '/' . $request->version . '/talk_comments/' . $new_id;
                         header("Location: " . $uri, true, 201);
                         exit;

--- a/src/services/TalkCommentEmailService.php
+++ b/src/services/TalkCommentEmailService.php
@@ -23,6 +23,10 @@ class TalkCommentEmailService extends EmailBaseService
 
     public function sendEmail()
     {
+        if (empty($this->recipients)) {
+            return false;
+        }
+
         $this->setSubject("New feedback on " . $this->talk->talk_title);
 
         $byLine = '';

--- a/src/services/TalkCommentEmailService.php
+++ b/src/services/TalkCommentEmailService.php
@@ -23,10 +23,6 @@ class TalkCommentEmailService extends EmailBaseService
 
     public function sendEmail()
     {
-        if (empty($this->recipients)) {
-            return false;
-        }
-
         $this->setSubject("New feedback on " . $this->talk->talk_title);
 
         $byLine = '';


### PR DESCRIPTION
This ensures that speakers do not get an email telling them they have
just replied.

The method is currently un tested, happy to add some but the function is
a mess too so would probably need refactoring. Another ticket ?