### PR TITLE
Fixes frisby tests

### DIFF
--- a/tests/frisby/api_write.js
+++ b/tests/frisby/api_write.js
@@ -82,7 +82,7 @@ function testUserByUrl(url) {
 }
 
 function testUnverifiedUserFailsLogin(username, password) {
-  frisby.create('Log in')
+  frisby.create('Log in 1')
     .post(baseURL + "/v2.1/token", {
       "grant_type": "password",
       "username": username,
@@ -96,7 +96,7 @@ function testUnverifiedUserFailsLogin(username, password) {
 }
 
 function testUserLogin(username, password) {
-  frisby.create('Log in')
+  frisby.create('Log in 2')
     .post(baseURL + "/v2.1/token", {
       "grant_type": "password",
       "username": username,

--- a/tests/frisby/api_write_events.js
+++ b/tests/frisby/api_write_events.js
@@ -819,30 +819,39 @@ function testAddHostToEvent(access_token, url) {
         )
         .expectStatus(404)
         .toss();
-    frisby.create('Add new host')
-        .post(
-            url + "/hosts",
-            {
-                "host_name" : "acole"
-            },
-            {json : true,
-                headers : {'Authorization' : 'Bearer ' + access_token}
-            }
+    frisby.create('Retrieve a random User from the DB')
+        .get(
+            baseURL + '/v2.1/users/12'
         )
-        .expectStatus(201)
-        .after(function(err, res, body) {
-            var track_uri = res.headers.location;
-            frisby.create('Check Hosts for the event')
-                .get(track_uri)
-                .expectStatus(200)
-                .expectJSON('hosts',[
-                    {"host_name" : "A test user for events"},
-                    {"host_name" : "Angela Cole", "host_uri" : "http://api.dev.joind.in/v2.1/users/9"}
-                ])
+        .afterJSON(function(result) {
+            var hostToAdd = result['users'][0];
+            frisby.create('Add new host')
+                .post(
+                    url + "/hosts",
+                    {
+                        "host_name" : hostToAdd.username
+                    },
+                    {
+                        json    : true,
+                        headers : {'Authorization' : 'Bearer ' + access_token}
+                    }
+                )
+                .expectStatus(201)
+                .after(function (err, res, body) {
+                    var track_uri = res.headers.location;
+                    frisby.create('Check Hosts for the event')
+                        .get(track_uri)
+                        .expectStatus(200)
+                        .expectJSON('hosts', [
+                            {"host_name" : "A test user for events"},
+                            {"host_name"   : hostToAdd.full_name,
+                                "host_uri" : hostToAdd.uri
+                            }
+                        ])
+                        .toss();
+                })
                 .toss();
-        })
-        .toss();
-
+        }).toss();
 }
 
 


### PR DESCRIPTION
Due to database-differences between local and test-databases a user
isn't necessarily available in the database. So instead of assuming there
is a user this PR adds a database-retrieval of a user (with a random ID
though)

This issue popped up on merging the fix for the headers and should now
be resolved. There wasn't a ticket available