### PR TITLE
Allows creation of 3rd party apps

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -333,6 +333,36 @@
         "action": "logUserIn",
         "verbs": ["POST"]
     },
+    {
+        "path" : "/applications$",
+        "controller" : "ApplicationsController",
+        "action" : "listApplications",
+        "verbs" : ["GET"]
+    },
+    {
+        "path" : "/applications$",
+        "controller" : "ApplicationsController",
+        "action" : "createApplication",
+        "verbs" : ["POST"]
+    },
+    {
+        "path" : "/applications(/[0-9]+)$",
+        "controller" : "ApplicationsController",
+        "action" : "getApplication",
+        "verbs" : ["GET"]
+    },
+    {
+        "path" : "/applications(/[0-9]+)$",
+        "controller" : "ApplicationsController",
+        "action" : "editApplication",
+        "verbs" : ["PUT"]
+    },
+    {
+        "path" : "/applications(/[0-9]+)$",
+        "controller" : "ApplicationsController",
+        "action" : "deleteApplication",
+        "verbs" : ["DELETE"]
+    },
 
     {
         "path": "/?$",

--- a/src/controllers/ApplicationsController.php
+++ b/src/controllers/ApplicationsController.php
@@ -96,18 +96,88 @@ class ApplicationsController extends ApiController
             throw new Exception("You must be logged in", 401);
         }
 
-        throw new Exception('Not yet implemented', 501);
+        $app    = array();
+        $errors = array();
+
+        $app['name'] = filter_var(
+            $request->getParameter("name"),
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
+        );
+        if (empty($app['name'])) {
+            $errors[] = "'name' is a required field";
+        }
+
+        $app['description'] = filter_var(
+            $request->getParameter("description"),
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
+        );
+        if (empty($app['description'])) {
+            $errors[] = "'description' is a required field";
+        }
+
+        $app['callback_url'] = filter_var(
+            $request->getParameter("callback_url"),
+            FILTER_SANITIZE_URL
+        );
+
+        if ($errors) {
+            throw new Exception(implode(". ", $errors), 400);
+        }
+
+        $app['user_id'] = $request->user_id;
+
+        $clientMapper = $this->getClientMapper($db, $request);
+        $clientId = $clientMapper->updateClient($this->getItemId($request), $app);
+
+        $uri = $request->base . '/' . $request->version . '/applications/' . $clientId;
+        $request->getView()->setResponseCode(201);
+        $request->getView()->setHeader('Location', $uri);
+
+        $newClient = $clientMapper->getClientByIdAndUser($clientId, $request->user_id);
+
+        return $newClient->getOutputView($request);
+
     }
 
-    public function deleteApplication($request, $db)
+    public function deleteApplication(Request $request, PDO $db)
     {
         if (! isset($request->user_id)) {
             throw new Exception("You must be logged in", 401);
         }
 
-        throw new Exception('Not yet implemented', 501);
+        $clientMapper = $this->getClientMapper($db, $request);
+
+        $client = $clientMapper->getClientByIdAndUser(
+            $this->getItemId($request),
+            $request->user_id
+        );
+
+        if (! $client->getClients()) {
+            throw new Exception('No application found', 404);
+        }
+
+        try {
+            $clientMapper->deleteClient($this->getItemId($request));
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage(), 500, $e);
+        }
+
+        $request->getView()->setNoRender(true);
+        $request->getView()->setResponseCode(204);
+        $request->getView()->setHeader(
+            'Location',
+            $request->base . '/' . $request->version . '/applications'
+        );
     }
 
+    /**
+     * @param $db
+     * @param $request
+     *
+     * @return ClientMapper
+     */
     private function getClientMapper($db, $request)
     {
         return new ClientMapper($db, $request);

--- a/src/controllers/ApplicationsController.php
+++ b/src/controllers/ApplicationsController.php
@@ -1,0 +1,115 @@
+<?php
+
+class ApplicationsController extends ApiController
+{
+    public function getApplication($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in", 401);
+        }
+
+        $mapper = $this->getClientMapper($db, $request);
+
+        $client = $mapper->getClientByIdAndUser(
+            $this->getItemId($request),
+            $request->user_id
+        );
+
+        return $client->getOutputView($request, $this->getVerbosity($request));
+    }
+
+    public function listApplications($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in", 401);
+        }
+
+        $mapper = $this->getClientMapper($db, $request);
+
+        $clients = $mapper->getClientsForUser(
+            $request->user_id,
+            $this->getResultsPerPage($request),
+            $this->getStart($request)
+        );
+
+        return $clients->getOutputView($request, $this->getVerbosity($request));
+
+    }
+
+    public function createApplication($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in", 401);
+        }
+
+        $app    = array();
+        $errors = array();
+
+        $app['name'] = filter_var(
+            $request->getParameter("name"),
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
+        );
+        if (empty($app['name'])) {
+            $errors[] = "'name' is a required field";
+        }
+
+        $app['description'] = filter_var(
+            $request->getParameter("description"),
+            FILTER_SANITIZE_STRING,
+            FILTER_FLAG_NO_ENCODE_QUOTES
+        );
+        if (empty($app['description'])) {
+            $errors[] = "'description' is a required field";
+        }
+
+        $app['callback_url'] = filter_var(
+            $request->getParameter("callback_url"),
+            FILTER_SANITIZE_URL
+        );
+        if (empty($app['callback_url'])) {
+            $errors[] = "'callback_url' is a required field";
+        }
+
+        if ($errors) {
+            throw new Exception(implode(". ", $errors), 400);
+        }
+
+        $app['user_id']         = $request->user_id;
+
+        $clientMapper = $this->getClientMapper($db, $request);
+        $clientId = $clientMapper->createClient($app);
+
+        $uri = $request->base . '/' . $request->version . '/applications/' . $clientId;
+        $request->getView()->setResponseCode(201);
+        $request->getView()->setHeader('Location', $uri);
+
+        $mapper = $this->getClientMapper($db, $request);
+        $newClient = $mapper->getClientByIdAndUser($clientId, $request->user_id);
+
+        return $newClient->getOutputView($request);
+    }
+
+    public function editApplication($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in", 401);
+        }
+
+        throw new Exception('Not yet implemented', 501);
+    }
+
+    public function deleteApplication($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in", 401);
+        }
+
+        throw new Exception('Not yet implemented', 501);
+    }
+
+    private function getClientMapper($db, $request)
+    {
+        return new ClientMapper($db, $request);
+    }
+}

--- a/src/models/AbstractModel.php
+++ b/src/models/AbstractModel.php
@@ -85,7 +85,10 @@ abstract class AbstractModel
 
             // override if it is a date
             if (substr($output_name, - 5) == '_date' && ! empty($value)) {
-                $value = (new DateTime('@' . $value))->setTimezone($tz)->format('c');
+                if (is_numeric($value)) {
+                    $value = '@' . $value;
+                }
+                $value = (new DateTime($value))->setTimezone($tz)->format('c');
             }
 
             $item[$output_name] = $value;

--- a/src/models/ClientMapper.php
+++ b/src/models/ClientMapper.php
@@ -1,0 +1,125 @@
+<?php
+
+class ClientMapper extends ApiMapper
+{
+    /**
+     * Iterate through results from the database to ensure data consistency and
+     * add sub-resource data
+     *
+     * @param  array $results
+     *
+     * @return array
+     */
+    private function processResults($results)
+    {
+        if (!is_array($results)) {
+            // $results isn't an array. This shouldn't happen as an exception
+            // should have been raised by PDO. However if it does, return an
+            // empty array.
+            return [];
+        }
+
+        if (! count($results)) {
+            // $results is an array but empty. So let's return an empty arra
+            return [];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get all clients that are registered for a given user
+     *
+     * @param int $user_id          The user to fetch clients for
+     * @param int $resultsperpage   How many results to return on each page
+     * @param int $start            Which result to start with
+     *
+     * @return ClientModelCollection
+     */
+    public function getClientsForUser($user_id, $resultsperpage, $start)
+    {
+        $sql = 'SELECT * FROM oauth_consumers WHERE user_id = :user_id ';
+        $sql .= $this->buildLimit($resultsperpage, $start);
+
+        $stmt     = $this->_db->prepare($sql);
+        $response = $stmt->execute(array(
+            ':user_id' => $user_id
+        ));
+
+        if (! $response) {
+            return false;
+        }
+
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $total = $this->getTotalCount($sql, [':user_id' => $user_id]);
+        $results = $this->processResults($results);
+
+        return new ClientModelCollection($results, $total);
+    }
+
+    /**
+     * Get a specific client with given ID and user
+     *
+     * @param $clientId
+     * @param $userId
+     *
+     * @return ClientModel
+     */
+    public function getClientByIdAndUser($clientId, $userId)
+    {
+        $sql = 'SELECT * FROM oauth_consumers WHERE user_id = :user_id and id = :client_id';
+        $sql .= $this->buildLimit(1, 0);
+
+        $stmt     = $this->_db->prepare($sql);
+        $response = $stmt->execute([
+            ':user_id' => $userId,
+            ':client_id' => $clientId,
+        ]);
+
+        if (! $response) {
+            return false;
+        }
+
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $results = $this->processResults($results);
+
+        return new ClientModelCollection($results, 1);
+    }
+
+    /**
+     * Create a new client and return the new ID
+     *
+     * @param array $client
+     *
+     * @throws Exception
+     * @return int
+     */
+    public function createClient($data)
+    {
+        $clientSql = 'INSERT INTO oauth_consumers (consumer_key, consumer_secret,'
+                   . 'created_date, user_id, application, description, '
+                   . 'callback_url, enable_password_grant) VALUES (:consumer_key, '
+                   . ':consumer_secret, :created_date, :user_id, :application, '
+                   . ':description, :callback_url, :enable_password_grant);';
+
+        $stmt     = $this->_db->prepare($clientSql);
+        $stmt->execute([
+            ':consumer_key'          => base64_encode(openssl_random_pseudo_bytes(48)),
+            ':consumer_secret'       => base64_encode(openssl_random_pseudo_bytes(48)),
+            ':created_date'          => (new DateTime())->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+            ':user_id'               => $data['user_id'],
+            ':application'           => $data['name'],
+            ':description'           => $data['description'],
+            ':callback_url'          => $data['callback_url'],
+            ':enable_password_grant' => 1,
+        ]);
+
+        $clientId  = $this->_db->lastInsertId();
+
+        if (0 == $clientId) {
+            throw new Exception('There has been an error storing the application');
+        }
+
+        return $clientId;
+    }
+}

--- a/src/models/ClientMapper.php
+++ b/src/models/ClientMapper.php
@@ -63,7 +63,7 @@ class ClientMapper extends ApiMapper
      * @param $clientId
      * @param $userId
      *
-     * @return ClientModel
+     * @return ClientModelCollection
      */
     public function getClientByIdAndUser($clientId, $userId)
     {
@@ -121,5 +121,57 @@ class ClientMapper extends ApiMapper
         }
 
         return $clientId;
+    }
+
+    /**
+     * Update an existing Client
+     *
+     * @param int   $clientId
+     * @param array $data
+     *
+     * @throws Exception
+     * @return int
+     */
+    public function updateClient($clientId, array $data)
+    {
+        $clientSql = 'UPDATE oauth_consumers SET '
+                   . 'application = :application, description = :description, '
+                   . 'callback_url = :callback_url WHERE id = :client_id;';
+
+        $stmt = $this->_db->prepare($clientSql);
+
+        $result = $stmt->execute([
+            ':application'  => $data['name'],
+            ':description'  => $data['description'],
+            ':callback_url' => $data['callback_url'],
+            ':client_id'    => $clientId,
+        ]);
+
+        if (! $result) {
+            throw new Exception('There has been an error updating the application');
+        }
+
+        return $clientId;
+    }
+
+    /**
+     * Delete an existing client
+     *
+     * @param int $clientId
+     *
+     * @throws Exception
+     * @return bool
+     */
+    public function deleteClient($clientId)
+    {
+        $clientSql = 'DELETE FROM oauth_consumers WHERE id = :client_id';
+
+        $stmt = $this->_db->prepare($clientSql);
+
+        if (! $stmt->execute([':client_id' => $clientId])) {
+            throw new Exception('There has been an error updating the application');
+        }
+
+
     }
 }

--- a/src/models/ClientModel.php
+++ b/src/models/ClientModel.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Object that represents a talk
+ */
+class ClientModel extends AbstractModel
+{
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    public function getDefaultFields()
+    {
+        $fields = array(
+            'consumer_key' => 'consumer_key',
+            'created_date' => 'created_date',
+            'application'  => 'application',
+            'description'  => 'description',
+            'callback_url' => 'callback_url',
+        );
+
+        return $fields;
+    }
+
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    public function getVerboseFields()
+    {
+        $fields = $this->getDefaultFields();
+
+        $fields['consumer_secret'] = 'consumer_secret';
+        $fields['user_id']         = 'user_id';
+
+        return $fields;
+    }
+
+    /**
+     * Return this object with client-facing fields and hypermedia, ready for output
+     */
+    public function getOutputView(Request $request, $verbose = false)
+    {
+        $item = parent::getOutputView($request, $verbose);
+
+        $item['client_uri'] = sprintf(
+            '%1$s/%2$s/applications/%3$s',
+            $request->base,
+            $request->version,
+            $this->id
+        );
+
+        return $item;
+    }
+}

--- a/src/models/ClientModelCollection.php
+++ b/src/models/ClientModelCollection.php
@@ -53,7 +53,7 @@ class ClientModelCollection extends AbstractModelCollection
      *
      * @return array
      */
-    public function getTalks()
+    public function getClients()
     {
         return $this->list;
     }

--- a/src/models/ClientModelCollection.php
+++ b/src/models/ClientModelCollection.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Container for multiple Client objects, also handles
+ * collection metadata such as pagination
+ */
+class ClientModelCollection extends AbstractModelCollection
+{
+    protected $list = array();
+    protected $total;
+
+    /**
+     * Take arrays of data and create a collection of models; store metadata
+     */
+    public function __construct(array $data, $total)
+    {
+        $this->total = $total;
+
+        // hydrate the model objects if necessary and store to list
+        foreach ($data as $item) {
+            if (!$item instanceof ClientModel) {
+                $item = new ClientModel($item);
+            }
+            $this->list[] = $item;
+        }
+    }
+
+    /**
+     * Present this collection ready for the output handlers
+     *
+     * This creates the expected output structure, converting each resource
+     * to it's presentable representation and adding the meta fields for totals
+     * and pagination
+     *
+     * @
+     */
+    public function getOutputView($request, $verbose = false)
+    {
+        // handle the collection first
+        $retval['clients'] = [];
+        foreach ($this->list as $item) {
+            $retval['clients'][] = $item->getOutputView($request, $verbose);
+        }
+
+        // add other fields
+        $retval['meta'] = $this->addPaginationLinks($request);
+
+        return $retval;
+    }
+
+    /**
+     * Return the list of talks (internal representation)
+     *
+     * @return array
+     */
+    public function getTalks()
+    {
+        return $this->list;
+    }
+}

--- a/tests/views/ApiViewTest.php
+++ b/tests/views/ApiViewTest.php
@@ -81,4 +81,25 @@ class ApiViewTest extends PHPUnit_Framework_TestCase
         ];
         $this->assertEquals($expectedHeaders, xdebug_get_headers());
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testThatSettingHeadersDoesntOverwriteIntendedHeaders()
+    {
+        $view = new ApiView();
+        $view->setResponseCode(201);
+        $view->setHeader('Location', 'http://example.org');
+
+        ob_start();
+        $view->render('');
+        ob_end_clean();
+
+        $expectedHeaders = [
+            'Location: http://example.org',
+        ];
+        $this->assertEquals($expectedHeaders, xdebug_get_headers());
+        $this->assertEquals(201, http_response_code());
+    }
 }


### PR DESCRIPTION
This PR adds the possibility to retrieve 3rd party-applications (app)  that are registered for the lofgged-in user from the oauth_consumers-table via ```GET https://api.joind.in/v2.1/applications```. It also allows retrieval of informations about a single app via ```GET https://api.joind.in/v2.1/applications/<app-id>```. You can only retrieve informations about your own apps (meaning APPs that have your user_id as entry)

Additionally this PR contains code to create a new App via ```POST https://api.joind.in/v2.1/applications```. A ```name```and ```description```  are required and ```callback_url```  is an optional parameters. A customer_key and a customer_secret are generated via [```openssl_random_pseudo_bytes```](https://php.net/openssl_random_pseudo_bytes) with 48bytes length. The database cuts them off though due to length-restrictions.

There's also an endpoint ```PUT https://api.joind.in/v2.1/applications/<app-id>``` that takes ```name``` and ```description``` as required and ```callback_url``` as optional parameter.

And finally there's ```DELETE https://api.joind.in/v2.1/applications/<app-id>```. Only apps of the currently logged in user can be deleted!

That way it is possible to allow third-party developers to use the API also for writing informations. As the usual precautions are in place a user can't do more damage via a third-party app than via the web2-interface. 

This PR is lacking an implementation of any kind of rate-limiting whatsoever. That should be handled in a separate PR.

A PR for an interface on Web2 is available at https://github.com/joindin/joindin-web2/pull/391