### PR TITLE
Implements rate-limiting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,9 @@
 {
+    "autoload" : {
+        "psr-4" : {
+            "Joindin\\Api\\" : "src/"
+        }
+    },
     "preferred-install": "dist",
     "require" : {
         "swiftmailer/swiftmailer": "v5.0.3",

--- a/src/Middleware/RateLimit.php
+++ b/src/Middleware/RateLimit.php
@@ -29,9 +29,17 @@ class RateLimit
         }
 
         $userMapper = $this->getUserMapper();
+        $rates = $userMapper->getCurrentRateLimit($request->getUserId());
 
-        if (! $userMapper->hasValidRateLimit($request->getUserId())) {
-            throw new Exception('RateLimit Exceeded');
+        $request->getView()->setHeader('X-RateLimit-Limit', $rates['limit']);
+        $request->getView()->setHeader('X-RateLimit-Remaining', $rates['remaining']);
+        $request->getView()->setHeader('X-RateLimit-Reset', $rates['reset']);
+
+        if (1 > $rates['remaining']) {
+            throw new \Exception(sprintf(
+                'API rate limit exceeded for %1$s',
+                $rates['user']
+            ), 403);
         }
 
         $userMapper->countdownRateLimit($request->getUserId());

--- a/src/middleware/RateLimit.php
+++ b/src/middleware/RateLimit.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Joindin\Api\Middleware;
+
+class RateLimit
+{
+    private $userMapper;
+
+    private $verbs = [
+        'POST',
+        'PUT',
+        'DELETE',
+        'UPDATE',
+    ];
+
+    public function __construct(\UserMapper $userMapper)
+    {
+        $this->userMapper = $userMapper;
+    }
+
+    public function __invoke(\Request $request)
+    {
+        if (! in_array($request->getVerb(), $this->verbs)) {
+            return $request;
+        }
+
+        if (! $request->getUserId()) {
+            return $request;
+        }
+
+        $userMapper = $this->getUserMapper();
+
+        if (! $userMapper->hasValidRateLimit($request->getUserId())) {
+            throw new Exception('RateLimit Exceeded');
+        }
+
+        $userMapper->countdownRateLimit($request->getUserId());
+
+        return $request;
+    }
+
+
+    private function getUserMapper()
+    {
+        return $this->userMapper;
+    }
+}

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -692,9 +692,14 @@ class UserMapper extends ApiMapper
         }
     }
 
-    public function hasValidRateLimit($userId)
+    public function getCurrentRateLimit($userId)
     {
-        return true;
+        return [
+            'limit' => -1,
+            'remaining' => 1,
+            'reset' => time() + 100,
+            'user' => $userId,
+        ];
     }
 
     public function countdownRateLimit($userId)

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -691,4 +691,14 @@ class UserMapper extends ApiMapper
             return false;
         }
     }
+
+    public function hasValidRateLimit($userId)
+    {
+        return true;
+    }
+
+    public function countdownRateLimit($userId)
+    {
+        return true;
+    }
 }

--- a/tests/middleware/RateLimitTest.php
+++ b/tests/middleware/RateLimitTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright (c) Andreas Heigl<andreas@heigl.org>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright Andreas Heigl
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @since     13.12.2016
+ * @link      http://github.com/heiglandreas/joindin-vm
+ */
+
+namespace JoindinTest\Api\Middleware;
+
+use Joindin\Api\Middleware\RateLimit;
+
+class RateLimitTest extends \PHPUnit_Framework_TestCase
+{
+    private $mapper;
+
+    public function setUp()
+    {
+        $this->mapper = $this->getMockBuilder('UserMapper')->disableOriginalConstructor()->getMock();
+    }
+
+    public function testThatInstantiatingWorks()
+    {
+
+        $middleware = new RateLimit($this->mapper);
+
+        $this->assertAttributeSame($this->mapper, 'userMapper', $middleware);
+    }
+
+    public function testThatGetIsNotRateLimited()
+    {
+        $request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
+        $request->method('getVerb')->willReturn('GET');
+
+        $middleware = new RateLimit($this->mapper);
+
+        $this->assertSame($request, $middleware($request));
+    }
+
+    public function testThatPostIsNotRateLmitedWhenUserIsMissing()
+    {
+        $request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
+        $request->method('getVerb')->willReturn('POST');
+        $request->method('getUserId')->willReturn(null);
+
+        $middleware = new RateLimit($this->mapper);
+
+        $this->assertSame($request, $middleware($request));
+    }
+
+    public function testThatPostIsRateLimitedWhenRateIsNotExceeded()
+    {
+        $view = $this->getMockBuilder('ApiView')->disableOriginalConstructor()->getMock();
+        $view->expects($this->exactly(3))
+            ->method('setHeader')
+            ->withConsecutive(
+                [$this->equalTo('X-RateLimit-Limit'), $this->equalTo('-1')],
+                [$this->equalTo('X-RateLimit-Remaining'), $this->equalTo('1')],
+                [$this->equalTo('X-RateLimit-Reset'), $this->equalTo('100')]
+            );
+
+        $request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
+        $request->method('getVerb')->willReturn('POST');
+        $request->method('getUserId')->willReturn(10);
+        $request->method('getView')->willReturn($view);
+
+        $this->mapper->method('getCurrentRateLimit')->with(10)->willReturn([
+            'limit' => -1,
+            'remaining' => 1,
+            'reset' => 100,
+        ]);
+        $this->mapper->expects($this->once())->method('countdownRateLimit')->with(10);
+
+        $middleware = new RateLimit($this->mapper);
+
+        $this->assertSame($request, $middleware($request));
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage API rate limit exceeded for foo
+     * @expectedExceptionCode 403
+     */
+    public function testThatExceptionIsThrownWhenRateLmitIsExceeded()
+    {
+        $view = $this->getMockBuilder('ApiView')->disableOriginalConstructor()->getMock();
+        $view->expects($this->exactly(3))
+             ->method('setHeader')
+             ->withConsecutive(
+                 [$this->equalTo('X-RateLimit-Limit'), $this->equalTo('-1')],
+                 [$this->equalTo('X-RateLimit-Remaining'), $this->equalTo('0')],
+                 [$this->equalTo('X-RateLimit-Reset'), $this->equalTo('100')]
+             );
+
+        $request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
+        $request->method('getVerb')->willReturn('POST');
+        $request->method('getUserId')->willReturn(10);
+        $request->method('getView')->willReturn($view);
+
+        $this->mapper->method('getCurrentRateLimit')->with(10)->willReturn([
+            'limit' => -1,
+            'remaining' => 0,
+            'reset' => 100,
+            'user' => 'foo',
+        ]);
+        $this->mapper->expects($this->exactly(0))->method('countdownRateLimit');
+
+        $middleware = new RateLimit($this->mapper);
+
+        $middleware($request);
+
+    }
+
+}

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -6,6 +6,7 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'Joindin\\Api\\' => array($baseDir . '/src'),
     'GuzzleHttp\\Subscriber\\Oauth\\' => array($vendorDir . '/guzzlehttp/oauth-subscriber/src'),
     'GuzzleHttp\\Stream\\' => array($vendorDir . '/guzzlehttp/streams/src'),
     'GuzzleHttp\\' => array($vendorDir . '/guzzlehttp/guzzle/src'),


### PR DESCRIPTION
This adds a possibility to check rate-limits for either a user or an application. Currently the implementation doesn't actually limit as it returns true every time the hasValidRateLimit is called.

This might be necessary for https://github.com/joindin/joindin-api/pull/383

I'd much more like to use a PSR7-middleware for that but that needs much more adaptions so I went for the easy way…