### PR TITLE
Adds token-list and -delete endpoint

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -158,7 +158,18 @@
         "action": "postAction",
         "verbs": ["POST"]
     },
-
+    {
+        "path": "/token/?$",
+        "controller": "TokenController",
+        "action": "listTokensForUser",
+        "verbs": ["GET"]
+    },
+    {
+        "path": "/token(/[^/]+)*/?$",
+        "controller": "TokenController",
+        "action": "revokeToken",
+        "verbs": ["DELETE"]
+    },
     {
         "path": "/tracks(/[^/]+)*/?$",
         "controller": "TracksController",

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -165,6 +165,12 @@
         "verbs": ["GET"]
     },
     {
+        "path": "/token(/[^/]+)/?$",
+        "controller": "TokenController",
+        "action": "getToken",
+        "verbs": ["GET"]
+    },
+    {
         "path": "/token(/[^/]+)*/?$",
         "controller": "TokenController",
         "action": "revokeToken",

--- a/src/controllers/TokenController.php
+++ b/src/controllers/TokenController.php
@@ -75,6 +75,22 @@ class TokenController extends ApiController
         return $tokens->getOutputView($request, $this->getVerbosity($request));
     }
 
+    public function getToken($request, $db)
+    {
+        if (! isset($request->user_id)) {
+            throw new Exception("You must be logged in", 401);
+        }
+
+        $mapper = $this->getTokenMapper($db, $request);
+
+        $tokens = $mapper->getTokenByIdAndUser(
+            $this->getItemId($request),
+            $request->user_id
+        );
+
+        return $tokens->getOutputView($request, $this->getVerbosity($request));
+    }
+
     public function revokeToken(Request $request, PDO $db)
     {
         if (! isset($request->user_id)) {

--- a/src/models/TokenMapper.php
+++ b/src/models/TokenMapper.php
@@ -1,0 +1,117 @@
+<?php
+
+class TokenMapper extends ApiMapper
+{
+    /**
+     * Iterate through results from the database to ensure data consistency and
+     * add sub-resource data
+     *
+     * @param  array $results
+     *
+     * @return array
+     */
+    private function processResults($results)
+    {
+        if (!is_array($results)) {
+            // $results isn't an array. This shouldn't happen as an exception
+            // should have been raised by PDO. However if it does, return an
+            // empty array.
+            return [];
+        }
+
+        if (! count($results)) {
+            // $results is an array but empty. So let's return an empty arra
+            return [];
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get all tokens that are registered for a given user
+     *
+     * @param int $user_id          The user to fetch clients for
+     * @param int $resultsperpage   How many results to return on each page
+     * @param int $start            Which result to start with
+     *
+     * @return TokenModelCollection
+     */
+    public function getTokensForUser($user_id, $resultsperpage, $start)
+    {
+        $sql = 'SELECT a.id, b.application, a.created_date, a.last_used_date, c.full_name '
+             . 'FROM oauth_access_tokens AS a '
+             . 'LEFT JOIN oauth_consumers AS b on a.consumer_key=b.consumer_key '
+             . 'LEFT JOIN `user` as c ON b.user_id = c.id '
+             . 'WHERE a.user_id = :user_id ';
+        $sql .= $this->buildLimit($resultsperpage, $start);
+
+        $stmt     = $this->_db->prepare($sql);
+        $response = $stmt->execute(array(
+            ':user_id' => $user_id
+        ));
+
+        if (! $response) {
+            return false;
+        }
+
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $total = $this->getTotalCount($sql, [':user_id' => $user_id]);
+        $results = $this->processResults($results);
+
+        return new TokenModelCollection($results, $total);
+    }
+
+    /**
+     * Get a single token by id and user
+     *
+     * @param int $token_id The ID of the token
+     * @param int $user_id  The user to fetch the token for
+     *
+     * @return TokenModelCollection
+     */
+    public function getTokenByIdAndUser($token_id, $user_id)
+    {
+        $sql = 'SELECT a.id, b.application, a.created_date, a.last_used_date, c.full_name '
+             . 'FROM oauth_access_tokens AS a '
+             . 'LEFT JOIN oauth_consumers AS b on a.consumer_key=b.consumer_key '
+             . 'LEFT JOIN `user` as c ON b.user_id = c.id '
+             . 'WHERE a.user_id = :user_id AND a.id = :token_id';
+        $sql .= $this->buildLimit(1, 0);
+
+        $stmt     = $this->_db->prepare($sql);
+        $response = $stmt->execute(array(
+            ':user_id'  => $user_id,
+            ':token_id' => $token_id,
+        ));
+
+        if (! $response) {
+            return new TokenModelCollection([], 1);
+        }
+
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $results = $this->processResults($results);
+
+        return new TokenModelCollection($results, 1);
+    }
+
+    /**
+     * Delete an existing token
+     *
+     * @param int $tokenId
+     *
+     * @throws Exception
+     * @return bool
+     */
+    public function deleteToken($tokenId)
+    {
+        $tokenSql = 'DELETE FROM oauth_access_tokens WHERE id = :token_id';
+
+        $stmt = $this->_db->prepare($tokenSql);
+
+        if (! $stmt->execute([':token_id' => $tokenId])) {
+            throw new Exception('There has been an error removing the token');
+        }
+
+        return true;
+    }
+}

--- a/src/models/TokenModel.php
+++ b/src/models/TokenModel.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Object that represents a token
+ */
+class TokenModel extends AbstractModel
+{
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    public function getDefaultFields()
+    {
+        $fields = array(
+            'token' => 'id',
+            'application' => 'application',
+            'created_date'  => 'created_date',
+            'last_used_date'  => 'last_used_date',
+            'application_owner' => 'full_name',
+        );
+
+        return $fields;
+    }
+
+    /**
+     * Default fields in the output view
+     *
+     * format: [public facing name => database column]
+     *
+     * @return array
+     */
+    public function getVerboseFields()
+    {
+        return $this->getDefaultFields();
+    }
+
+    /**
+     * Return this object with client-facing fields and hypermedia, ready for output
+     */
+    public function getOutputView(Request $request, $verbose = false)
+    {
+        $item = parent::getOutputView($request, $verbose);
+
+        $item['token_uri'] = sprintf(
+            '%1$s/%2$s/token/%3$s',
+            $request->base,
+            $request->version,
+            $this->id
+        );
+
+        return $item;
+    }
+}

--- a/src/models/TokenModelCollection.php
+++ b/src/models/TokenModelCollection.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Container for multiple Token objects, also handles
+ * collection metadata such as pagination
+ */
+class TokenModelCollection extends AbstractModelCollection
+{
+    protected $list = array();
+    protected $total;
+
+    /**
+     * Take arrays of data and create a collection of models; store metadata
+     */
+    public function __construct(array $data, $total)
+    {
+        $this->total = $total;
+
+        // hydrate the model objects if necessary and store to list
+        foreach ($data as $item) {
+            if (!$item instanceof TokenModel) {
+                $item = new TokenModel($item);
+            }
+            $this->list[] = $item;
+        }
+    }
+
+    /**
+     * Present this collection ready for the output handlers
+     *
+     * This creates the expected output structure, converting each resource
+     * to it's presentable representation and adding the meta fields for totals
+     * and pagination
+     *
+     * @
+     */
+    public function getOutputView($request, $verbose = false)
+    {
+        // handle the collection first
+        $retval['tokens'] = [];
+        foreach ($this->list as $item) {
+            $retval['tokens'][] = $item->getOutputView($request, $verbose);
+        }
+
+        // add other fields
+        $retval['meta'] = $this->addPaginationLinks($request);
+
+        return $retval;
+    }
+
+    /**
+     * Return the list of talks (internal representation)
+     *
+     * @return array
+     */
+    public function getTokens()
+    {
+        return $this->list;
+    }
+}

--- a/tests/controllers/TokenControllerTest.php
+++ b/tests/controllers/TokenControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace JoindinTest\Controller;
+
+
+class TokenControllerTest extends \PHPUnit_Framework_TestCase
+{
+    private $request;
+
+    private $pdo;
+
+    public function setup()
+    {
+        $this->request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
+        $this->pdo     = $this->getMockBuilder('PDO')->disableOriginalConstructor()->getMock();
+    }
+
+    /**
+     * @expectedException        \Exception
+     * @expectedExceptionCode    401
+     * @expectedExceptionMessage You must be logged in
+     */
+    public function testThatDeletingATokenWithoutLoginThrowsException()
+    {
+        $usersController = new \TokenController();
+
+        $usersController->revokeToken($this->request, $this->pdo);
+    }
+
+    /**
+     * @expectedException        \Exception
+     * @expectedExceptionCode    401
+     * @expectedExceptionMessage You must be logged in
+     */
+    public function testThatRetrievingTokensWithoutLoginThrowsException()
+    {
+        $usersController = new \TokenController();
+
+        $usersController->listTokensForUser($this->request, $this->pdo);
+    }
+
+
+}


### PR DESCRIPTION
This commit adds 2 new API-Endpoints:

* GET v2.1/token to list all tokens the current user has currently open
* DELETE v2.1/token/<token-id> to delete a certain token if (and only if) it's a token associated with the currently logged in user

Unit-Tests need improvement and there are no integration test currently.

This is prerequisit to have an equivalent of https://legacy.joind.in/user/apikey in web2