### PR TITLE
Only show tokens in trusted apps

### DIFF
--- a/db/patch69.sql
+++ b/db/patch69.sql
@@ -1,0 +1,9 @@
+-- Add a new field `can_be_revoked` to the oauth_consumers table
+-- That field describes whether tokens from this consumer can be revoked by
+-- a user or not. Only tokens from consumers where that flag is set will be shown
+-- in the API endpoint /token/
+ALTER TABLE `oauth_consumers` ADD COLUMN can_be_revoked (tinyint(1) DEFAULT '1');
+
+UPDATE `oauth_consumers` SET can_be_revoked = 0 WHERE consumer_key = 'web2';
+
+INSERT INTO patch_history SET patch_number = 69;

--- a/src/controllers/TokenController.php
+++ b/src/controllers/TokenController.php
@@ -66,7 +66,7 @@ class TokenController extends ApiController
 
         $mapper = $this->getTokenMapper($db, $request);
 
-        $tokens = $mapper->getTokensForUser(
+        $tokens = $mapper->getRevokableTokensForUser(
             $request->user_id,
             $this->getResultsPerPage($request),
             $this->getStart($request)
@@ -99,7 +99,7 @@ class TokenController extends ApiController
 
         $tokenMapper = $this->getTokenMapper($db, $request);
 
-        $token = $tokenMapper->getTokenByIdAndUser(
+        $token = $tokenMapper->getRevokableTokenByIdAndUser(
             $this->getItemId($request),
             $request->user_id
         );

--- a/src/controllers/TokenController.php
+++ b/src/controllers/TokenController.php
@@ -66,6 +66,10 @@ class TokenController extends ApiController
 
         $mapper = $this->getTokenMapper($db, $request);
 
+        if (! $mapper->tokenBelongsToTrustedApplication($request->getAccessToken())) {
+            throw new Exception("You can not access the token list with this client", 403);
+        }
+
         $tokens = $mapper->getRevokableTokensForUser(
             $request->user_id,
             $this->getResultsPerPage($request),
@@ -83,6 +87,10 @@ class TokenController extends ApiController
 
         $mapper = $this->getTokenMapper($db, $request);
 
+        if (! $mapper->tokenBelongsToTrustedApplication($request->getAccessToken())) {
+            throw new Exception("You can not access the token list with this client", 403);
+        }
+
         $tokens = $mapper->getTokenByIdAndUser(
             $this->getItemId($request),
             $request->user_id
@@ -98,6 +106,10 @@ class TokenController extends ApiController
         }
 
         $tokenMapper = $this->getTokenMapper($db, $request);
+
+        if (! $tokenMapper->tokenBelongsToTrustedApplication($request->getAccessToken())) {
+            throw new Exception("You can not access the token list with this client", 403);
+        }
 
         $token = $tokenMapper->getRevokableTokenByIdAndUser(
             $this->getItemId($request),

--- a/src/models/TokenMapper.php
+++ b/src/models/TokenMapper.php
@@ -62,6 +62,42 @@ class TokenMapper extends ApiMapper
     }
 
     /**
+     * Get all tokens that are registered for a given user that can be revoked
+     *
+     * @param int $user_id          The user to fetch clients for
+     * @param int $resultsperpage   How many results to return on each page
+     * @param int $start            Which result to start with
+     *
+     * @return TokenModelCollection
+     */
+    public function getRevokableTokensForUser($user_id, $resultsperpage, $start)
+    {
+        $sql = 'SELECT a.id, b.application, a.created_date, a.last_used_date, c.full_name '
+               . 'FROM oauth_access_tokens AS a '
+               . 'LEFT JOIN oauth_consumers AS b on a.consumer_key=b.consumer_key '
+               . 'LEFT JOIN `user` as c ON b.user_id = c.id '
+               . 'WHERE a.user_id = :user_id AND b.can_be_revoked = 1';
+        $sql .= $this->buildLimit($resultsperpage, $start);
+
+        $stmt     = $this->_db->prepare($sql);
+        $response = $stmt->execute(array(
+            ':user_id' => $user_id
+        ));
+
+        if (! $response) {
+            return false;
+        }
+
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $total = $this->getTotalCount($sql, [':user_id' => $user_id]);
+        $results = $this->processResults($results);
+
+        return new TokenModelCollection($results, $total);
+    }
+
+
+
+    /**
      * Get a single token by id and user
      *
      * @param int $token_id The ID of the token
@@ -72,10 +108,44 @@ class TokenMapper extends ApiMapper
     public function getTokenByIdAndUser($token_id, $user_id)
     {
         $sql = 'SELECT a.id, b.application, a.created_date, a.last_used_date, c.full_name '
-             . 'FROM oauth_access_tokens AS a '
-             . 'LEFT JOIN oauth_consumers AS b on a.consumer_key=b.consumer_key '
-             . 'LEFT JOIN `user` as c ON b.user_id = c.id '
-             . 'WHERE a.user_id = :user_id AND a.id = :token_id';
+               . 'FROM oauth_access_tokens AS a '
+               . 'LEFT JOIN oauth_consumers AS b on a.consumer_key=b.consumer_key '
+               . 'LEFT JOIN `user` as c ON b.user_id = c.id '
+               . 'WHERE a.user_id = :user_id AND a.id = :token_id';
+        $sql .= $this->buildLimit(1, 0);
+
+        $stmt     = $this->_db->prepare($sql);
+        $response = $stmt->execute(array(
+            ':user_id'  => $user_id,
+            ':token_id' => $token_id,
+        ));
+
+        if (! $response) {
+            return new TokenModelCollection([], 1);
+        }
+
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $results = $this->processResults($results);
+
+        return new TokenModelCollection($results, 1);
+    }
+
+
+    /**
+     * Get a single token by id and user
+     *
+     * @param int $token_id The ID of the token
+     * @param int $user_id  The user to fetch the token for
+     *
+     * @return TokenModelCollection
+     */
+    public function getRevokableTokenByIdAndUser($token_id, $user_id)
+    {
+        $sql = 'SELECT a.id, b.application, a.created_date, a.last_used_date, c.full_name '
+               . 'FROM oauth_access_tokens AS a '
+               . 'LEFT JOIN oauth_consumers AS b on a.consumer_key=b.consumer_key '
+               . 'LEFT JOIN `user` as c ON b.user_id = c.id '
+               . 'WHERE a.user_id = :user_id AND a.id = :token_id AND b.can_be_revoked = 1';
         $sql .= $this->buildLimit(1, 0);
 
         $stmt     = $this->_db->prepare($sql);

--- a/src/models/TokenMapper.php
+++ b/src/models/TokenMapper.php
@@ -184,4 +184,31 @@ class TokenMapper extends ApiMapper
 
         return true;
     }
+
+    /**
+     * Check qwhether the given access token was issued by a trusted application
+     *
+     * @param string $accessToken
+     *
+     * @return bool
+     */
+    public function tokenBelongsToTrustedApplication($accessToken)
+    {
+        $sql = 'SELECT b.enable_password_grant '
+               . 'FROM oauth_access_tokens AS a '
+               . 'LEFT JOIN oauth_consumers AS b on a.consumer_key=b.consumer_key '
+               . 'WHERE a.access_token = :token';
+        $sql .= $this->buildLimit(1, 0);
+
+        $stmt     = $this->_db->prepare($sql);
+        $response = $stmt->execute(array(
+            ':token'  => $accessToken,
+        ));
+
+        if (! $response) {
+            return false;
+        }
+
+        return $stmt->fetchColumn() == 1;
+    }
 }


### PR DESCRIPTION
This PR will

1. Identify a trusted app by checking whether the access-token was issued by an app that has the ```enable_password_grant```-flag in the database set
2. Only display tokens issued by apps that have the (newly added) ```can_be_revoked```-flag in the database set.

For that a new flag in the ```oauth_consumers```-table has been added via patch-68.sql