### PR TITLE
OAuthModel throws exception on non-verified user login

### DIFF
--- a/src/models/OAuthModel.php
+++ b/src/models/OAuthModel.php
@@ -125,16 +125,22 @@ class OAuthModel
      */
     protected function getUserId($username, $password)
     {
-        $sql  = 'SELECT ID, password, email FROM user
-            WHERE username=:username
-            AND verified = 1';
+        $sql  = 'SELECT ID, password, email, verified FROM user
+            WHERE username=:username';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(array("username" => $username));
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
         if ($result) {
-            if (password_verify(md5($password), $result['password'])) {
-                return $result['ID'];
+            if ($result['verified'] == 1) {
+                if (password_verify(md5($password), $result['password'])) {
+                    return $result['ID'];
+                }
+
+                return false;
             }
+
+            throw new Exception("Not Verified", 401);
         }
 
         return false;

--- a/src/models/OAuthModel.php
+++ b/src/models/OAuthModel.php
@@ -131,20 +131,17 @@ class OAuthModel
         $stmt->execute(array("username" => $username));
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if ($result) {
-            if ($result['verified'] == 1) {
-                if (password_verify(md5($password), $result['password'])) {
-                    return $result['ID'];
-                }
+        if (!$result) return false;
 
-                return false;
-            }
-
-            throw new Exception("Not Verified", 401);
+        if ($result['verified'] != 1) {
+            throw new Exception("Not verified", 401);
         }
 
-        return false;
+        if (!password_verify(md5($password), $result['password'])) {
+            return false;
+        }
 
+        return $result['ID'];
     }
 
     /**

--- a/src/models/OAuthModel.php
+++ b/src/models/OAuthModel.php
@@ -131,7 +131,9 @@ class OAuthModel
         $stmt->execute(array("username" => $username));
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if (!$result) return false;
+        if (!$result) {
+            return false;
+        }
 
         if ($result['verified'] != 1) {
             throw new Exception("Not verified", 401);


### PR DESCRIPTION
This is part of a wider update for #JOINDIN-718 to show a user a link to the resend verification page if they try to login when not verified.