### PR TITLE
JOINDIN-648 allow different talk types

### DIFF
--- a/db/patch68.sql
+++ b/db/patch68.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `talk_types_link` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `talk_id` int(11) NOT NULL,
+  `talk_type` int(11) NOT NULL,
+  `url` text NOT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `talk_id` (`talk_id`),
+  KEY `talk_type` (`talk_type`),
+  CONSTRAINT `talk_types_link_ibfk_1` FOREIGN KEY (`talk_id`) REFERENCES `talks` (`ID`),
+  CONSTRAINT `talk_types_link_ibfk_2` FOREIGN KEY (`talk_type`) REFERENCES `talk_types` (`ID`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `talk_types` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `type` varchar(255) NOT NULL,
+  `display_name` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`ID`)
+) ENGINE=InnoDB;
+
+
+INSERT INTO `talk_types`(`ID`,`type`,`display_name`) VALUES
+(1,'Slides','slides_link'),
+(2,'Video','video_link'),
+(3,'Audio','audio_link');
+

--- a/db/patch68.sql
+++ b/db/patch68.sql
@@ -1,26 +1,32 @@
-CREATE TABLE `talk_types_link` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `talk_id` int(11) NOT NULL,
-  `talk_type` int(11) NOT NULL,
-  `url` text NOT NULL,
-  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  KEY `talk_id` (`talk_id`),
-  KEY `talk_type` (`talk_type`),
-  CONSTRAINT `talk_types_link_ibfk_1` FOREIGN KEY (`talk_id`) REFERENCES `talks` (`ID`),
-  CONSTRAINT `talk_types_link_ibfk_2` FOREIGN KEY (`talk_type`) REFERENCES `talk_types` (`ID`)
-) ENGINE=InnoDB;
+#Theres already an unsed table relating to this, drop it
+DROP TABLE talk_link_types;
+#switch talks to innodb so FKs work
+ALTER TABLE `joindin`.`talks` ENGINE=INNODB;
 
-CREATE TABLE `talk_types` (
-  `ID` int(11) NOT NULL AUTO_INCREMENT,
-  `type` varchar(255) NOT NULL,
-  `display_name` varchar(255) DEFAULT NULL,
+CREATE TABLE `talk_link_types` (
+  `ID` INT(11) NOT NULL AUTO_INCREMENT,
+  `display_name` VARCHAR(255) DEFAULT NULL,
   PRIMARY KEY (`ID`)
-) ENGINE=InnoDB;
+) ENGINE=INNODB;
 
 
-INSERT INTO `talk_types`(`ID`,`type`,`display_name`) VALUES
-(1,'Slides','slides_link'),
-(2,'Video','video_link'),
-(3,'Audio','audio_link');
+CREATE TABLE `joindin`.`talk_links`(
+  `ID` INT NOT NULL AUTO_INCREMENT,
+  `talk_id` INT NOT NULL,
+  `talk_type` INT NOT NULL,
+  `url` TEXT NOT NULL,
+  `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`ID`),
+  FOREIGN KEY (`talk_id`) REFERENCES `joindin`.`talks`(`ID`),
+  FOREIGN KEY (`talk_type`) REFERENCES `joindin`.`talk_link_types`(`ID`)
+);
 
+
+INSERT INTO `talk_link_types`(`ID`,`type`,`display_name`) VALUES
+(1,'slides_link'),
+(2,'video_link'),
+(3,'audio_link'),
+(4,'code_link'), #github / bitbucket links
+(5,'joindin_link'); #Links to another talk on the same topic by the speaker
+
+INSERT INTO patch_history SET patch_number = 67;

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -99,6 +99,12 @@
         "verbs": ["DELETE"]
     },
     {
+        "path": "/talks(/[\\d]+)/links$",
+        "controller": "TalksController",
+        "action": "getTalkLinks",
+        "verbs": ["GET"]
+    },
+    {
         "path": "/talks(/[\\d]+)/speakers/?$",
         "controller": "TalksController",
         "action": "getSpeakersForTalk",

--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -211,7 +211,13 @@ class TalksController extends ApiController
      */
     public function addTrackToTalk(Request $request, PDO $db)
     {
-        $this->checkLoggedIn($request);
+        try {
+            $this->checkLoggedIn($request);
+        } catch (Exception $e) {
+            // throw again with a 400 status, This should be removed for consistency
+            // but will break backwards compatibility
+            throw new Exception($e->getMessage(), 400);
+        }
 
         $talk_mapper = new TalkMapper($db, $request);
         $talk = $this->getTalkById($request, $db);
@@ -259,7 +265,13 @@ class TalksController extends ApiController
      */
     public function removeTrackFromTalk(Request $request, PDO $db)
     {
-        $this->checkLoggedIn($request);
+        try {
+            $this->checkLoggedIn($request);
+        } catch (Exception $e) {
+            // throw again with a 400 status, This should be removed for consistency
+            // but will break backwards compatibility
+            throw new Exception($e->getMessage(), 400);
+        }
 
         $track_id = $request->url_elements[5];
 
@@ -804,8 +816,8 @@ class TalksController extends ApiController
 
     public function getTalkLinks(Request $request, PDO $db)
     {
-        $this->getTalkById($request, $db);
-        $talk_id = $this->getItemId($request);
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
         $talk_mapper = $this->getTalkMapper($db, $request);
         return ['talk_links' => ($talk_mapper->getTalkMediaLinks($talk_id))];
     }

--- a/src/models/OAuthModel.php
+++ b/src/models/OAuthModel.php
@@ -167,11 +167,9 @@ class OAuthModel
     {
         $hash              = $this->generateToken();
         $accessToken       = substr($hash, 0, 16);
-        $accessTokenSecret = substr($hash, 16, 16);
 
         $sql = "INSERT INTO oauth_access_tokens set
                 access_token = :access_token,
-                access_token_secret = :access_token_secret,
                 consumer_key = :consumer_key,
                 user_id = :user_id,
                 last_used_date = NOW()
@@ -181,7 +179,6 @@ class OAuthModel
         $result = $stmt->execute(
             array(
                 'access_token'        => $accessToken,
-                'access_token_secret' => $accessTokenSecret,
                 'consumer_key'        => $consumer_key,
                 'user_id'             => $user_id,
             )

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -82,10 +82,11 @@ class TalkMapper extends ApiMapper
     /**
      * Retrieve a single talk
      *
-     * @param  integer  $talk_id
+     * @param  integer $talk_id
+     * @param  bool $verbose
      * @return TalkModel|false
      */
-    public function getTalkById($talk_id)
+    public function getTalkById($talk_id, $verbose = false)
     {
         $sql = $this->getBasicSQL();
         $sql .= ' and t.ID = :talk_id';
@@ -95,6 +96,10 @@ class TalkMapper extends ApiMapper
             $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             if ($results) {
                 $results = $this->processResults($results);
+                if ($verbose) {
+                    $results = $this->addTalkMediaTypes($results);
+                }
+
                 return new TalkModel($results[0]);
             }
         }
@@ -799,7 +804,7 @@ class TalkMapper extends ApiMapper
 
     public function assignTalkToSpeaker($talk_id, $claim_id, $speaker_id)
     {
-        $sql = 'update talk_speaker 
+        $sql = 'update talk_speaker
                 SET speaker_id = :speaker_id
                 WHERE ID = :claim_id AND talk_id = :talk_id';
         $stmt = $this->_db->prepare($sql);
@@ -810,5 +815,55 @@ class TalkMapper extends ApiMapper
                 'claim_id'      => $claim_id
             ]
         );
+    }
+
+    public function getTalkMediaLinks($talk_id)
+    {
+        $sql = '
+            select
+              ttl.id,
+              tt.`display_name`,
+              ttl.`url`
+            from
+              talks
+              inner join talk_types_link ttl
+                on ttl.`talk_id` = talks.`id`
+              inner join talk_types tt
+                on ttl.`talk_type` = tt.`id`
+            where talk_id = :talk_id
+        ';
+
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute(
+            [
+                'talk_id' => $talk_id,
+            ]
+        );
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function addTalkMediaTypes($talk)
+    {
+        $links = $this->getTalkMediaLinks($talk[0]['ID']);
+
+        foreach ($links as $link) {
+            $talk = $this->handleBackwardsCompatibleMedia($talk, $link);
+            $talk[0]['talk_media'][] = [$link['display_name'] => $link['url']];
+        }
+
+        return $talk;
+    }
+
+    /**
+     * Used for adding back the slide link to the request
+     */
+    private function handleBackwardsCompatibleMedia($talk, $link)
+    {
+        if ($link['display_name'] == "slides_link") {
+            $talk[0][$link['display_name']] = $link['url'];
+        }
+
+        return $talk;
     }
 }

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -821,15 +821,15 @@ class TalkMapper extends ApiMapper
     {
         $sql = '
             select
-              ttl.id,
-              tt.`display_name`,
-              ttl.`url`
+              tl.id,
+              tlt.`display_name`,
+              tl.`url`
             from
               talks
-              inner join talk_types_link ttl
-                on ttl.`talk_id` = talks.`id`
-              inner join talk_types tt
-                on ttl.`talk_type` = tt.`id`
+              inner join talk_links tl
+                on tl.`talk_id` = talks.`id`
+              inner join talk_link_types tlt
+                on tlt.`id` = tl.`talk_type`
             where talk_id = :talk_id
         ';
 

--- a/src/models/TalkModel.php
+++ b/src/models/TalkModel.php
@@ -44,6 +44,7 @@ class TalkModel extends AbstractModel
         $fields = $this->getDefaultFields();
 
         $fields['slides_link'] = 'slides_link';
+        $fields['talk_media']  = 'talk_media';
         $fields['language']    = 'lang_name';
 
         return $fields;

--- a/tests/controllers/TalksControllerTest.php
+++ b/tests/controllers/TalksControllerTest.php
@@ -2,8 +2,13 @@
 
 namespace JoindinTest\Controller;
 
+use JoindinTest\Inc\mockPDO;
+use PDOStatement;
+use PHPUnit_Framework_TestCase;
+use Request;
+use TalksController;
 
-class TalksControllerTest extends \PHPUnit_Framework_TestCase
+class TalksControllerTest extends PHPUnit_Framework_TestCase
 {
 
     /**
@@ -18,10 +23,16 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testClaimTalkWithNoUserIdThrowsException()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/326/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/326/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talks_controller->setSpeakerForTalk($request, $db);
 
@@ -33,17 +44,23 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage Talk not found
      */
     public function testClaimNonExistantTalkThrowsException()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
+
         $request->user_id = 2;
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
 
         $talk_mapper = $this->getMockBuilder('\TalkMapper')
@@ -71,20 +88,26 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage You must provide a display name and a username
      */
     public function testClaimTalkWithoutUsernameThrowsException()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
+
         $request->user_id = 2;
         $request->parameters = [
             'display_name'  => 'Jane Bloggs'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talks_controller->setTalkMapper($talk_mapper);
@@ -105,20 +128,26 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage You must provide a display name and a username
      */
     public function testClaimTalkWithoutDisplayNameThrowsException()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
+
         $request->user_id = 2;
         $request->parameters = [
             'username'  => 'janebloggs'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talks_controller->setTalkMapper($talk_mapper);
@@ -138,21 +167,27 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage No speaker matching that name found
      */
     public function testClaimTalkWithInvalidSpeakerThrowsException()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
+
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'janebloggs',
             'display_name'  =>  'P Sherman'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -178,20 +213,25 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage Talk already claimed
      */
     public function testClaimTalkAlreadyClaimedThrowsException(){
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'janebloggs',
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -222,20 +262,25 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage You must be the speaker or event admin to link a user to a talk
      */
     public function testClaimTalkForSomeoneElseThrowsException(){
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'psherman',
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -284,20 +329,25 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage Specified user not found
      */
     public function testAssignTalkAsHostToNonExistentUserThrowsException(){
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'psherman',
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -334,15 +384,21 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testClaimTalkAsUserIsSuccessful()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'janebloggs',
             'display_name'  => 'Jane Bloggs'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -394,15 +450,21 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAssignTalkAsHostIsSuccessful()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'psherman',
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -459,15 +521,21 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testApproveAssignmentAsUserWhoClaimedThrowsException()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'janebloggs',
             'display_name'  => 'Jane Bloggs'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -521,15 +589,21 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testApproveClaimAsHostWhoAssignedThrowsException()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'psherman',
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -574,15 +648,21 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testApproveAssignmentAsUserSucceeds()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'janebloggs',
             'display_name'  => 'Jane Bloggs',
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -639,15 +719,21 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testApproveClaimAsHostSucceeds()
     {
-        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers", 'REQUEST_METHOD' => 'POST']);
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
+                'REQUEST_METHOD' => 'POST'
+            ]
+        );
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'psherman',
             'display_name'  => 'P Sherman',
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -707,7 +793,7 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testRejectClaimAsHostSucceeds()
     {
-        $request = new \Request(
+        $request = new Request(
             [],
             [
                 'REQUEST_URI' => "http://api.dev.joind.in/v2.1/talks/9999/speakers",
@@ -721,8 +807,8 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
             'display_name'  => 'P Sherman',
         ];
 
-        $talks_controller = new \TalksController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $talks_controller = new TalksController();
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talk_mapper = $this->createTalkMapper($db, $request);
         $talk_mapper
@@ -773,6 +859,50 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($talks_controller->removeSpeakerForTalk($request, $db));
 
+    }
+
+    public function testDifferentTalkMedia()
+    {
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => 'http://api.dev.joind.in/v2.1/talks/3?verbose=yes',
+                'REQUEST_METHOD' => 'GET'
+            ]
+        );
+        $request->user_id = 1;
+        $request->parameters = [
+            'username'      => 'psherman',
+            'display_name'  => 'P Sherman',
+            'verbose'       => 'yes',
+        ];
+        $db = $this->getMockBuilder(mockPDO::class)->getMock();
+        $stmt = $this->getMockBuilder(PDOStatement::class)
+                ->setMethods(array("execute", 'fetchAll'))
+                ->getMock();
+
+        $stmt->method("execute")->willReturn(true);
+
+        $stmt->method("fetchAll")->will(
+            $this->onConsecutiveCalls(
+                $this->getValidTalkDBRows(),
+                $this->getValidTalkDBRows(),
+                $this->getValidTalkDBRows(),
+                $this->getValidMediaRows()
+            )
+        );
+
+        $db->method('prepare')
+        ->willReturn($stmt);
+
+        $talks_controller = new TalksController();
+
+        $output = $talks_controller->getAction($request, $db);
+
+        $this->assertSame(
+            $this->transformMediaRows($this->getValidMediaRows()),
+            $output['talks'][0]['talk_media']
+        );
     }
 
     private function createTalkMapper($db, $request)
@@ -864,5 +994,42 @@ class TalksControllerTest extends \PHPUnit_Framework_TestCase
             );
 
         return $event_mapper;
+    }
+    private function getValidMediaRows()
+    {
+        return [
+            [
+                'display_name' => "slides_link",
+                'url' => "https://slideshare.net",
+            ],
+            [
+                'display_name' => "video_link",
+                'url' => "https://youtube.com",
+            ]
+        ];
+    }
+
+    private function transformMediaRows($rows)
+    {
+        $transformedRows = [];
+
+        foreach ($rows as $row) {
+               $transformedRows[] = [$row['display_name'] => $row['url']];
+        }
+
+        return $transformedRows;
+    }
+
+    private function getValidTalkDBRows()
+    {
+        return [[
+            'ID' => 9999,
+            'talk_title' => 'Test Talk',
+            'full_name' => 'Talker Name',
+            'speaker_id' => 1,
+            'track_name' => 'test track',
+            'display_name' => 'test name',
+            'url' => 'url',
+        ]];
     }
 }

--- a/tests/models/TalkMapperTest.php
+++ b/tests/models/TalkMapperTest.php
@@ -1,0 +1,79 @@
+<?php
+namespace JoindinTest\Model;
+
+use JoindinTest\Inc\mockPDO;
+use PDOStatement;
+use PHPUnit_Framework_TestCase;
+use Request;
+use TalkMapper;
+
+class TalkMapperTest extends PHPUnit_Framework_TestCase
+{
+    public function testMediaTypesAreAddedCorrectly()
+    {
+        $request = new Request(
+            [],
+            [
+                'REQUEST_URI' => 'http://api.dev.joind.in/v2.1/talks/3?verbose=yes',
+                'REQUEST_METHOD' => 'GET'
+            ]
+        );
+
+        $mockdb = $this->getMockBuilder(mockPDO::class)->getMock();
+        $stmt = $this->getMockBuilder(PDOStatement::class)
+                ->setMethods(["execute", 'fetchAll'])
+                ->getMock();
+
+        $stmt->method("execute")->willReturn(true);
+
+        $stmt->method("fetchAll")->willReturn(
+            $this->getValidMediaRows()
+        );
+
+        $mockdb->method('prepare')
+            ->willReturn($stmt);
+
+        $talk_mapper = new TalkMapper($mockdb, $request);
+        $talk = [
+            [
+                'ID' => 3,
+            ]
+        ];
+        $talk = $talk_mapper->addTalkMediaTypes($talk);
+        
+        $this->assertSame(
+            'https://slideshare.net',
+            $talk[0]['slides_link']
+        );
+
+        $this->assertSame(
+            $this->transformMediaRows($this->getValidMediaRows()),
+            $talk[0]['talk_media']
+        ); 
+    }
+
+    private function getValidMediaRows()
+    {
+        return [
+            [
+                'display_name' => "slides_link",
+                'url' => "https://slideshare.net",
+            ],
+            [
+                'display_name' => "video_link",
+                'url' => "https://youtube.com",
+            ]
+        ];
+    }
+
+    private function transformMediaRows($rows)
+    {
+        $transformedRows = [];
+
+        foreach ($rows as $row) {
+               $transformedRows[] = [$row['display_name'] => $row['url']];
+        }
+
+        return $transformedRows;
+    }
+}

--- a/tests/models/TalkMapperTest.php
+++ b/tests/models/TalkMapperTest.php
@@ -40,7 +40,7 @@ class TalkMapperTest extends PHPUnit_Framework_TestCase
             ]
         ];
         $talk = $talk_mapper->addTalkMediaTypes($talk);
-        
+
         $this->assertSame(
             'https://slideshare.net',
             $talk[0]['slides_link']
@@ -49,7 +49,7 @@ class TalkMapperTest extends PHPUnit_Framework_TestCase
         $this->assertSame(
             $this->transformMediaRows($this->getValidMediaRows()),
             $talk[0]['talk_media']
-        ); 
+        );
     }
 
     private function getValidMediaRows()


### PR DESCRIPTION
Added new backend access for different talk type medias

This adds the new data to the verbose getTalk call and also added a new endpoint for getting all of the media types.

/v2.1/talks/3/links

and 
/v2.1/talks/3?verbose=yes

Have changed.

There is a backwards compatible change for for slide links (when they get moved over with another ticket)