### PR TITLE
Removes trailing '1' in API html output

### DIFF
--- a/src/views/HtmlView.php
+++ b/src/views/HtmlView.php
@@ -37,7 +37,7 @@ class HtmlView extends ApiView
         }
         $this->layoutStop();
 
-        return true;
+        return null;
     }
 
     /**


### PR DESCRIPTION
The buildOutput method in HtmlView.php was returning true, which when the output was being echoed this was converted to '1'.

This fixes #JOINDIN-729 by  updating the return value to be null.