### PR TITLE
JOINDIN-730 Clicking claim twice

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -584,10 +584,12 @@ class TalksController extends BaseTalkController
             } else {
                 throw new Exception("You must be the speaker or event admin to link a user to a talk", 401);
             }
-        } elseif ($claim_exists === PendingTalkClaimMapper::SPEAKER_CLAIM) {
+        } elseif ((
+            $claim_exists === PendingTalkClaimMapper::SPEAKER_CLAIM &&
+            $this->getRequestParameter($request, 'action') == 'approve'
+        )) {
             //The host needs to approve
             if ($talk_mapper->thisUserHasAdminOn($talk_id)) {
-                $method = $this->getRequestParameter($request, 'action', 'approve');
                 $recipients   = [$user_mapper->getEmailByUserId($speaker_id)];
 
                 $success = $pending_talk_claim_mapper->approveClaimAsHost($talk_id, $speaker_id, $claim['ID'])

--- a/tests/controllers/TalksControllerTest.php
+++ b/tests/controllers/TalksControllerTest.php
@@ -536,7 +536,8 @@ class TalksControllerTest extends TalkBase
         $request->user_id = 2;
         $request->parameters = [
             'username'      => 'janebloggs',
-            'display_name'  => 'Jane Bloggs'
+            'display_name'  => 'Jane Bloggs',
+            'action'        => 'approve',
         ];
 
         $talks_controller = new TalksController();
@@ -735,6 +736,7 @@ class TalksControllerTest extends TalkBase
         $request->parameters = [
             'username'      => 'psherman',
             'display_name'  => 'P Sherman',
+            'action'        => 'approve',
         ];
 
         $talks_controller = new TalksController();


### PR DESCRIPTION
This will be a breaking change if anywhere else approves claims apart
from web2.

The button on the talk page calls the same end point with the same data
as the admin one.

The count of the call is the differenciator.

This PR adds some data in the call to know which place you came from