### PR TITLE
Fix: Remove unnecessary parentheses

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -31,13 +31,13 @@ set_exception_handler('handle_exception');
 
 // config setup
 define('BASEPATH', '.');
-include('../config.php');
+include '../config.php';
 if ($config['mode'] == "development") {
     ini_set("html_errors", 0);
 }
 
 // database setup
-include('../database.php');
+include '../database.php';
 $ji_db = new PDO(
     'mysql:host=' . $db['default']['hostname'] .
     ';dbname=' . $db['default']['database'],

--- a/tests/routers/ApiRouterTest.php
+++ b/tests/routers/ApiRouterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(__DIR__ . '/../../src/inc/Request.php');
+require_once __DIR__ . '/../../src/inc/Request.php';
 
 /**
  * A class to test ApiRouter

--- a/tests/routers/DefaultRouterTest.php
+++ b/tests/routers/DefaultRouterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(__DIR__ . '/../../src/inc/Request.php');
+require_once __DIR__ . '/../../src/inc/Request.php';
 
 /**
  * A class to test DefaultRouter

--- a/tests/routers/RouterTest.php
+++ b/tests/routers/RouterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(__DIR__ . '/../../src/inc/Request.php');
+require_once __DIR__ . '/../../src/inc/Request.php';
 
 /**
  * A class to test DefaultRouter

--- a/tests/routers/VersionedRouterTest.php
+++ b/tests/routers/VersionedRouterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(__DIR__ . '/../../src/inc/Request.php');
+require_once __DIR__ . '/../../src/inc/Request.php';
 
 /**
  * A class to test VersionedRouter


### PR DESCRIPTION
This PR

* [x] removes unnecessary parentheses when using `include` or `require`

💁‍♂️ For reference, see 

* http://php.net/manual/en/function.include.php
* http://php.net/manual/en/function.require.php.