### PR TITLE
Fix: Rename method to match invocation

### DIFF
--- a/src/models/EventHostMapper.php
+++ b/src/models/EventHostMapper.php
@@ -56,7 +56,7 @@ class EventHostMapper extends ApiMapper
         return $this->_db->lastInsertId();
     }
 
-    public function removeHostfromEvent($host_id, $event_id)
+    public function removeHostFromEvent($host_id, $event_id)
     {
         $sql = 'DELETE FROM user_admin WHERE uid = :user_id AND rid = :event_id AND rtype = :type';
         $stmt = $this->_db->prepare($sql);

--- a/tests/models/EventHostMapperTest.php
+++ b/tests/models/EventHostMapperTest.php
@@ -138,7 +138,7 @@ class EventHostMapperTest extends PHPUnit_Framework_TestCase
         $request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
 
         $mapper = new EventHostMapper($pdo, $request);
-        $this->assertTrue($mapper->removeHostfromEvent(12, 14));
+        $this->assertTrue($mapper->removeHostFromEvent(12, 14));
 
     }
 }


### PR DESCRIPTION
This PR

* [x] fixes a case-insensitive method call