### PR TITLE
Fix migration da

### DIFF
--- a/db/patch70.sql
+++ b/db/patch70.sql
@@ -1,7 +1,10 @@
+#Because of potential issuesm drop the talk_links table to be on the safe side
+DROP TABLE talk_links;
 #Theres already an unsed table relating to this, drop it
 DROP TABLE talk_link_types;
+
 #switch talks to innodb so FKs work
-ALTER TABLE `joindin`.`talks` ENGINE=INNODB;
+ALTER TABLE `talks` ENGINE=INNODB;
 
 CREATE TABLE `talk_link_types` (
   `ID` INT(11) NOT NULL AUTO_INCREMENT,
@@ -10,15 +13,15 @@ CREATE TABLE `talk_link_types` (
 ) ENGINE=INNODB;
 
 
-CREATE TABLE `joindin`.`talk_links`(
+CREATE TABLE `talk_links`(
   `ID` INT NOT NULL AUTO_INCREMENT,
   `talk_id` INT NOT NULL,
   `talk_type` INT NOT NULL,
   `url` TEXT NOT NULL,
   `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`ID`),
-  FOREIGN KEY (`talk_id`) REFERENCES `joindin`.`talks`(`ID`),
-  FOREIGN KEY (`talk_type`) REFERENCES `joindin`.`talk_link_types`(`ID`)
+  FOREIGN KEY (`talk_id`) REFERENCES `talks`(`ID`),
+  FOREIGN KEY (`talk_type`) REFERENCES `talk_link_types`(`ID`)
 );
 
 

--- a/db/patch71.sql
+++ b/db/patch71.sql
@@ -1,4 +1,4 @@
-INSERT INTO `joindin`.`talk_links` (`talk_id`, `talk_type`, `url`)
+INSERT INTO `talk_links` (`talk_id`, `talk_type`, `url`)
 SELECT
   id,
   1,


### PR DESCRIPTION
These two patches had a problem that we'd missed, that some of the queries had the database name.

The database name isn't consistent on test, so we have an issue where some of these updates have probably been run on the wrong database, or not run at all.

These updates patches should resolve this.