### PR TITLE
Trusted users

### DIFF
--- a/db/patch72.sql
+++ b/db/patch72.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `user` ADD COLUMN `trusted` BOOLEAN DEFAULT 0;
+
+INSERT INTO patch_history SET patch_number = 72;

--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -255,7 +255,12 @@
         "action": "passwordReset",
         "verbs": ["POST"]
     },
-
+    {
+        "path": "/users(/[0-9]+)/trusted?$",
+        "controller": "UsersController",
+        "action": "setTrusted",
+        "verbs": ["POST"]
+    },
     {
         "path": "/users(/[^/]+)*/?$",
         "controller": "UsersController",
@@ -283,7 +288,6 @@
         "action": "updateUser",
         "verbs": ["PUT"]
     },
-
     {
         "path": "/event_comments(/[^/]+)*/?$",
         "controller": "Event_commentsController",

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -310,8 +310,11 @@ class EventsController extends ApiController
                 $event_owner           = $user_mapper->getUserById($request->user_id);
                 $event['contact_name'] = $event_owner['users'][0]['full_name'];
 
-                // When a site admin creates an event, we want to approve it immediately
-                $approveEventOnCreation = $user_mapper->isSiteAdmin($request->user_id);
+                /**
+                 * If the user is a site admin, or has been set to trusted,
+                 * then approve the event straight away
+                 */
+                $approveEventOnCreation = $user_mapper->isSiteAdmin($request->user_id) || $user_mapper->isTrusted($request->user_id);
 
                 // Do we want to automatically approve when testing?
                 if (isset($this->config['features']['allow_auto_approve_events'])

--- a/src/controllers/EventsController.php
+++ b/src/controllers/EventsController.php
@@ -314,7 +314,8 @@ class EventsController extends ApiController
                  * If the user is a site admin, or has been set to trusted,
                  * then approve the event straight away
                  */
-                $approveEventOnCreation = $user_mapper->isSiteAdmin($request->user_id) || $user_mapper->isTrusted($request->user_id);
+                $approveEventOnCreation = $user_mapper->isSiteAdmin($request->user_id)
+                    || $user_mapper->isTrusted($request->user_id);
 
                 // Do we want to automatically approve when testing?
                 if (isset($this->config['features']['allow_auto_approve_events'])

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -408,7 +408,7 @@ class UsersController extends ApiController
         $view = $request->getView();
         $view->setHeader('Content-Length', 0);
         $view->setResponseCode(204);
-        return;
+        return null;
     }
 
     public function setUserMapper(UserMapper $user_mapper)

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -402,7 +402,7 @@ class UsersController extends ApiController
 
         $user_mapper = $this->getUserMapper($db, $request);
         if (!$user_mapper->isSiteAdmin($request->getUserId())) {
-            throw new Exception("You must be an admin to change a user's trusted state", 401);
+            throw new Exception("You must be an admin to change a user's trusted state", 403);
         }
 
         $userId = $this->getItemId($request);

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -389,13 +389,10 @@ class UsersController extends ApiController
     /**
      * Allow users to be set as trusted
      *
-     * @param $request
-     * @param $db
-     *
-     * @return null
+     * @param $request Request
+     * @param $db      PDO
      *
      * @throws Exception
-     *
      */
     public function setTrusted($request, $db)
     {
@@ -414,12 +411,11 @@ class UsersController extends ApiController
         }
 
         if (!$user_mapper->setTrustedStatus($trustedStatus, $userId)) {
-            throw new Exception("Unable to update status");
+            throw new Exception("Unable to update status", 500);
         }
         $view = $request->getView();
         $view->setHeader('Content-Length', 0);
         $view->setResponseCode(204);
-        return null;
     }
 
     public function setUserMapper(UserMapper $user_mapper)

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -386,6 +386,31 @@ class UsersController extends ApiController
         $view->setResponseCode(204);
     }
 
+    public function setTrusted($request, $db)
+    {
+        if (false == ($request->getUserId())) {
+            throw new Exception("You must be logged in to change a user account", 401);
+        }
+
+        $user_mapper = $this->getUserMapper($db, $request);
+        if (!$user_mapper->isSiteAdmin($request->getUserId())) {
+            throw new Exception("You must be an admin to change a user's trusted state", 401);
+        }
+
+        $userId = $this->getItemId($request);
+        if (!is_bool($trustedStatus = $request->getParameter("trusted", null))) {
+            throw new Exception("You must provide a trusted state", 400);
+        }
+
+        if (!$user_mapper->setTrustedStatus($trustedStatus, $userId)){
+            throw new Exception("Unable to update status");
+        }
+        $view = $request->getView();
+        $view->setHeader('Content-Length', 0);
+        $view->setResponseCode(204);
+        return;
+    }
+
     public function setUserMapper(UserMapper $user_mapper)
     {
         $this->user_mapper = $user_mapper;

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -386,6 +386,17 @@ class UsersController extends ApiController
         $view->setResponseCode(204);
     }
 
+    /**
+     * Allow users to be set as trusted
+     *
+     * @param $request
+     * @param $db
+     *
+     * @return null
+     *
+     * @throws Exception
+     *
+     */
     public function setTrusted($request, $db)
     {
         if (false == ($request->getUserId())) {
@@ -402,7 +413,7 @@ class UsersController extends ApiController
             throw new Exception("You must provide a trusted state", 400);
         }
 
-        if (!$user_mapper->setTrustedStatus($trustedStatus, $userId)){
+        if (!$user_mapper->setTrustedStatus($trustedStatus, $userId)) {
             throw new Exception("Unable to update status");
         }
         $view = $request->getView();

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -38,6 +38,7 @@ class UserMapper extends ApiMapper
             "username"         => "username",
             "full_name"        => "full_name",
             "twitter_username" => "twitter_username",
+            "trusted"          => "trusted"
         );
 
         return $fields;
@@ -99,7 +100,7 @@ class UserMapper extends ApiMapper
     protected function getUsers($resultsperpage, $start, $where = null, $order = null)
     {
         $sql = 'select user.username, user.ID, user.email, '
-               . 'user.full_name, user.twitter_username, user.admin '
+               . 'user.full_name, user.twitter_username, user.admin, user.trusted '
                . 'from user '
                . 'left join user_attend ua on (ua.uid = user.ID) '
                . 'where active = 1 ';
@@ -226,6 +227,39 @@ class UserMapper extends ApiMapper
 
         return false;
     }
+
+    /**
+     * Check if the user represented by $user_id is trusted
+     *
+     * @param $user_id
+     * @return bool
+     */
+    public function isTrusted($user_id)
+    {
+        $results = $this->getUsers(1, 0, 'user.ID=' . (int) $user_id, null);
+        if (isset($results[0]) && $results[0]['trusted'] == 1) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function setTrustedStatus($trustedStatus, $user_id)
+    {
+        $verify_sql = "update user set trusted = :trusted_status "
+            . "where ID = :user_id";
+
+        $verify_stmt = $this->_db->prepare($verify_sql);
+        $verify_data = array("trusted_status" => (int) $trustedStatus, "user_id" => $user_id);
+
+        $result = $verify_stmt->execute($verify_data);
+
+        if ($result) {
+            return true;
+        }
+        return false;
+    }
+
 
     public function createUser($user)
     {

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -244,6 +244,14 @@ class UserMapper extends ApiMapper
         return false;
     }
 
+    /**
+     * Update the trusted status for the given user
+     *
+     * @param $trustedStatus bool
+     * @param $user_id       int
+     *
+     * @return bool
+     */
     public function setTrustedStatus($trustedStatus, $user_id)
     {
         $verify_sql = "update user set trusted = :trusted_status "
@@ -252,12 +260,7 @@ class UserMapper extends ApiMapper
         $verify_stmt = $this->_db->prepare($verify_sql);
         $verify_data = array("trusted_status" => (int) $trustedStatus, "user_id" => $user_id);
 
-        $result = $verify_stmt->execute($verify_data);
-
-        if ($result) {
-            return true;
-        }
-        return false;
+        return $verify_stmt->execute($verify_data);
     }
 
 

--- a/tests/controllers/UsersControllerTest.php
+++ b/tests/controllers/UsersControllerTest.php
@@ -226,4 +226,192 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
 
         $controller->updateUser($request, $db);
     }
+
+    /**
+     * Ensures that if the setTrusted method is called and no user_id is set,
+     * an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage You must be logged in to change a user account
+     */
+    public function testSetTrustedWithNoUserIdThrowsException()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/users/4/trusted", 'REQUEST_METHOD' => 'POST']);
+
+        $usersController = new \UsersController();
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $usersController->setTrusted($request, $db);
+    }
+
+
+    /**
+     * Ensures that if the setTrsuted method is called and user_id is a,
+     * non-admin, an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage You must be an admin to change a user's trusted state
+     */
+    public function testSetTrustedWithNonAdminIdThrowsException()
+    {
+        $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/users/4/trusted", 'REQUEST_METHOD' => 'POST']);
+        $request->user_id = 2;
+        $usersController = new \UsersController();
+        // Please see below for explanation of why we're mocking a "mock" PDO
+        // class
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $userMapper = $this->getMockBuilder('\UserMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $userMapper
+            ->expects($this->once())
+            ->method('isSiteAdmin')
+            ->will($this->returnValue(false));
+
+        $usersController->setUserMapper($userMapper);
+        $usersController->setTrusted($request, $db);
+
+    }
+
+
+
+    /**
+     * Ensures that if the setTrusted method is called by an admin,
+     * but without a trusted state, an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage You must provide a trusted state
+     */
+    public function testSetTrustedWithoutStateThrowsException()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->method('getUserId')->willReturn(2);
+        $request->method('getParameter')
+            ->with("trusted")
+            ->willReturn(null);
+
+        $usersController = new \UsersController();
+        // Please see below for explanation of why we're mocking a "mock" PDO
+        // class
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $userMapper = $this->getMockBuilder('\UserMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $userMapper
+            ->expects($this->once())
+            ->method('isSiteAdmin')
+            ->will($this->returnValue(true));
+
+        $usersController->setUserMapper($userMapper);
+        $usersController->setTrusted($request, $db);
+
+    }
+
+    /**
+     * Ensures that if the setTrusted method is called by an admin,
+     * but the update fails, an exception is thrown
+     *
+     * @return void
+     *
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage Unable to update status
+     */
+    public function testSetTrustedWithFailureThrowsException()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->method('getUserId')->willReturn(2);
+        $request->method('getParameter')
+            ->with("trusted")
+            ->willReturn(true);
+
+        $usersController = new \UsersController();
+        // Please see below for explanation of why we're mocking a "mock" PDO
+        // class
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $userMapper = $this->getMockBuilder('\UserMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $userMapper
+            ->expects($this->once())
+            ->method('isSiteAdmin')
+            ->will($this->returnValue(true));
+
+        $userMapper
+            ->expects($this->once())
+            ->method("setTrustedStatus")
+            ->willReturn(false);
+
+        $usersController->setUserMapper($userMapper);
+        $usersController->setTrusted($request, $db);
+
+    }
+
+
+    /**
+     * Ensures that if the setTrusted method is called by an admin,
+     * and the update succeeds, a view is created and null is returned
+     *
+     * @return void
+     */
+    public function testSetTrustedWithSuccessCreatesView()
+    {
+        $request = $this->getMockBuilder('\Request')->disableOriginalConstructor()->getMock();
+        $request->method('getUserId')->willReturn(2);
+        $request->method('getParameter')
+            ->with("trusted")
+            ->willReturn(true);
+
+        $view = $this->getMockBuilder(\JsonView::class)->getMock();
+        $view->expects($this->once())
+            ->method("setHeader")
+            ->willReturn(true);
+
+        $view->expects($this->once())
+            ->method("setResponseCode")
+            ->with(204)
+            ->willReturn(true);
+
+        $request->expects($this->once())
+            ->method("getView")
+            ->willReturn($view);
+
+        $usersController = new \UsersController();
+        // Please see below for explanation of why we're mocking a "mock" PDO
+        // class
+        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+        $userMapper = $this->getMockBuilder('\UserMapper')
+            ->setConstructorArgs(array($db,$request))
+            ->getMock();
+
+        $userMapper
+            ->expects($this->once())
+            ->method('isSiteAdmin')
+            ->will($this->returnValue(true));
+
+        $userMapper
+            ->expects($this->once())
+            ->method("setTrustedStatus")
+            ->willReturn(true);
+
+        $usersController->setUserMapper($userMapper);
+        $this->assertNull($usersController->setTrusted($request, $db));
+
+    }
 }

--- a/tests/controllers/UsersControllerTest.php
+++ b/tests/controllers/UsersControllerTest.php
@@ -243,7 +243,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
         $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/users/4/trusted", 'REQUEST_METHOD' => 'POST']);
 
         $usersController = new \UsersController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $db = $this->getMockBuilder(\PDO::class)->disableOriginalConstructor()->getMock();
 
         $usersController->setTrusted($request, $db);
     }
@@ -265,7 +265,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
         $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/users/4/trusted", 'REQUEST_METHOD' => 'POST']);
         $request->user_id = 2;
         $usersController = new \UsersController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $db = $this->getMockBuilder(\PDO::class)->disableOriginalConstructor()->getMock();
 
         $userMapper = $this->getMockBuilder('\UserMapper')
             ->setConstructorArgs(array($db,$request))
@@ -303,7 +303,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(null);
 
         $usersController = new \UsersController();
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $db = $this->getMockBuilder(\PDO::class)->disableOriginalConstructor()->getMock();
 
         $userMapper = $this->getMockBuilder('\UserMapper')
             ->setConstructorArgs(array($db,$request))
@@ -339,9 +339,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(true);
 
         $usersController = new \UsersController();
-        // Please see below for explanation of why we're mocking a "mock" PDO
-        // class
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $db = $this->getMockBuilder(\PDO::class)->disableOriginalConstructor()->getMock();
 
         $userMapper = $this->getMockBuilder('\UserMapper')
             ->setConstructorArgs(array($db,$request))
@@ -392,9 +390,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             ->willReturn($view);
 
         $usersController = new \UsersController();
-        // Please see below for explanation of why we're mocking a "mock" PDO
-        // class
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+        $db = $this->getMockBuilder(\PDO::class)->disableOriginalConstructor()->getMock();
 
         $userMapper = $this->getMockBuilder('\UserMapper')
             ->setConstructorArgs(array($db,$request))

--- a/tests/controllers/UsersControllerTest.php
+++ b/tests/controllers/UsersControllerTest.php
@@ -41,9 +41,9 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
         $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/users/3", 'REQUEST_METHOD' => 'DELETE']);
         $request->user_id = 2;
         $usersController = new \UsersController();
-        // Please see below for explanation of why we're mocking a "mock" PDO
-        // class
-        $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
+
+
+        $db = $this->getMockBuilder(\PDO::class)->disableOriginalConstructor()->getMock();
 
         $userMapper = $this->getMockBuilder('\UserMapper')
             ->setConstructorArgs(array($db,$request))
@@ -236,6 +236,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
      * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage You must be logged in to change a user account
+     * @expectedExceptionCode 401
      */
     public function testSetTrustedWithNoUserIdThrowsException()
     {
@@ -257,14 +258,13 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
      * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage You must be an admin to change a user's trusted state
+     * @expectedExceptionCode 403
      */
     public function testSetTrustedWithNonAdminIdThrowsException()
     {
         $request = new \Request([], ['REQUEST_URI' => "http://api.dev.joind.in/v2.1/users/4/trusted", 'REQUEST_METHOD' => 'POST']);
         $request->user_id = 2;
         $usersController = new \UsersController();
-        // Please see below for explanation of why we're mocking a "mock" PDO
-        // class
         $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
 
         $userMapper = $this->getMockBuilder('\UserMapper')
@@ -292,6 +292,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
      * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage You must provide a trusted state
+     * @expectedExceptionCode 400
      */
     public function testSetTrustedWithoutStateThrowsException()
     {
@@ -302,8 +303,6 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(null);
 
         $usersController = new \UsersController();
-        // Please see below for explanation of why we're mocking a "mock" PDO
-        // class
         $db = $this->getMockBuilder('\JoindinTest\Inc\mockPDO')->getMock();
 
         $userMapper = $this->getMockBuilder('\UserMapper')
@@ -313,7 +312,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
         $userMapper
             ->expects($this->once())
             ->method('isSiteAdmin')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $usersController->setUserMapper($userMapper);
         $usersController->setTrusted($request, $db);
@@ -329,6 +328,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
      * @test
      * @expectedException        \Exception
      * @expectedExceptionMessage Unable to update status
+     * @expectedExceptionCode 500
      */
     public function testSetTrustedWithFailureThrowsException()
     {


### PR DESCRIPTION
This is a solution for a couple of problems:

- Users who arrange long-running usergroups but who have to wait for approval every month
- Conference organising 'veterans' who have been running conferences for years, and for who we don't really need to spend time reviewing

A user can be set as 'trusted' by a joind.in admin, at which point their future event submissions get approved automatically (in the same way that admin submissions do).

There isn't really a set criteria for allowing someone to be trusted - I know there are a few conference/UG organisers who have been after this feature for a while and that we know well, so I guess we'd try it out on them first.