### PR TITLE
use composer for deployment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+scripts export-ignore
+tools export-ignore
+vendor/* export-ignore
+build.xml export-ignore
+build export-ignore

--- a/scripts/jenkinslaunch.sh
+++ b/scripts/jenkinslaunch.sh
@@ -39,6 +39,7 @@ mkdir -p $TARGET \
  ; git remote set-url deployremote https://github.com/$GITHUB_USER/$GITHUB_REPO.git \
 && git fetch deployremote \
 && git archive $LAUNCHREF | tar xC $TARGET \
+&& composer --prefer-dist --no-dev --no-progress --working-dir=$TARGET install \
 && (echo $TARGET ; echo $LAUNCHREF) > $TARGET/src/release.txt \
 && ln -s $TARGETBASE/config.php $TARGET/src/config.php \
 && ln -s $TARGETBASE/database.php $TARGET/src/database.php \


### PR DESCRIPTION
This PR adds ```composer install``` to the deployment process for the API.

This should be fairly safe to use as only libraries that are already defined in the composer.lock-file are added to the website and should a library be unavailable during the launch-process the script will break there and the incomplete build will not go live.

This PR does **not** remove libs that are already within the vendor-folder but it will overwrite the autoloading-informations.

This is though as a base for discussion.