### PR TITLE
Fixes changed users name on editing talks

### DIFF
--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -490,11 +490,10 @@ class TalkMapper extends ApiMapper
     public function updateSpeakersOnTalk($talk_id, array $speakers)
     {
         // get the current speakers
-        $sql = 'select ts.speaker_name, ts.speaker_name as val from talk_speaker ts where ts.talk_id = :talk_id';
+        $sql = 'select if(ts.speaker_id,user.full_name, ts.speaker_name) as val from talk_speaker ts left join user on user.ID = ts.speaker_id where ts.talk_id = :talk_id';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['talk_id' => $talk_id]);
-        $current_speakers = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
-
+        $current_speakers = $stmt->fetchAll(PDO::FETCH_COLUMN);
         // add the speakers that aren't already attached to the talk
         $new_speakers = array_diff($speakers, $current_speakers);
         $sql = "insert into talk_speaker

--- a/src/models/TalkMapper.php
+++ b/src/models/TalkMapper.php
@@ -490,7 +490,11 @@ class TalkMapper extends ApiMapper
     public function updateSpeakersOnTalk($talk_id, array $speakers)
     {
         // get the current speakers
-        $sql = 'select if(ts.speaker_id,user.full_name, ts.speaker_name) as val from talk_speaker ts left join user on user.ID = ts.speaker_id where ts.talk_id = :talk_id';
+        $sql = 'select '
+             . 'if(ts.speaker_id,user.full_name, ts.speaker_name) as val '
+             . 'from talk_speaker AS ts '
+             . 'left join user on user.ID = ts.speaker_id '
+             . 'where ts.talk_id = :talk_id';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['talk_id' => $talk_id]);
         $current_speakers = $stmt->fetchAll(PDO::FETCH_COLUMN);


### PR DESCRIPTION
As soon as a user changed the name and then edited a talk they where already assigned to the new name would appear in the speaker-name field but on submitting the already claimed talk was reassigned to the user with the new name. That happened due to the API comparing the users name
to the value stored in the talk_claim table that might not be valid anymore. Therefore that value no longer is checked on editing a talk.

This solves JOINDIN-743 and JOINDIN-745

Tests still to come!