### PR TITLE
Fixes Emojis not being storable

### DIFF
--- a/db/patch73.sql
+++ b/db/patch73.sql
@@ -1,0 +1,24 @@
+ALTER TABLE `talks` DROP INDEX url_friendly_talk_title;
+ALTER TABLE `talks` ADD UNIQUE url_friendly_talk_title(url_friendly_talk_title(150), event_id) ;
+ALTER TABLE `talks` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+
+ALTER TABLE `talk_comments` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+
+ALTER TABLE `events` DROP INDEX url_friendly_name;
+ALTER TABLE `events` ADD UNIQUE url_friendly_name(url_friendly_name(150)) ;
+ALTER TABLE `events` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+
+ALTER TABLE `email_verification_tokens` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `event_images` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `oauth_access_tokens` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `oauth_consumers` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `password_reset_tokens` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `pending_talk_claims` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `reported_event_comments` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `reported_talk_comments` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `tags` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `tags_events` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `twitter_request_tokens` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+ALTER TABLE `user_talk_star` convert to CHARACTER SET 'utf8mb4' COLLATE utf8mb4_general_ci;
+
+INSERT INTO patch_history SET patch_number = 73;

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -46,11 +46,6 @@ $ji_db = new PDO(
 );
 $ji_db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-// Set the correct charset for this connection
-$ji_db->query("SET NAMES 'utf8' COLLATE 'utf8_general_ci'");
-$ji_db->query("SET CHARACTER SET 'utf8mb4'");
-$ji_db->query("SET character_set_connection = 'utf8mb4'");
-
 // collect URL and headers
 $request = new Request($config, $_SERVER);
 

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -40,7 +40,7 @@ if ($config['mode'] == "development") {
 include '../database.php';
 $ji_db = new PDO(
     'mysql:host=' . $db['default']['hostname'] .
-    ';dbname=' . $db['default']['database'],
+    ';dbname=' . $db['default']['database'] . ';charset=utf8mb4',
     $db['default']['username'],
     $db['default']['password']
 );
@@ -48,8 +48,8 @@ $ji_db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 // Set the correct charset for this connection
 $ji_db->query("SET NAMES 'utf8' COLLATE 'utf8_general_ci'");
-$ji_db->query('SET CHARACTER SET utf8');
-
+$ji_db->query("SET CHARACTER SET 'utf8mb4'");
+$ji_db->query("SET character_set_connection = 'utf8mb4'");
 
 // collect URL and headers
 $request = new Request($config, $_SERVER);


### PR DESCRIPTION
This change was made to allow storage of emojis as most relevant database fields where using the utf8 encoding and not the utf8mb4

This will be changed by this commit