### PR TITLE
Allow users to create a login via twitter

### DIFF
--- a/src/controllers/TwitterController.php
+++ b/src/controllers/TwitterController.php
@@ -116,7 +116,7 @@ class TwitterController extends ApiController
                 try {
                     $res = $client1->get('1.1/account/verify_credentials.json?include_email=true');
 
-                } catch(Exception $e) {
+                } catch (Exception $e) {
                     throw new Exception('Could not retrieve user-informations from Twitter', 403, $e);
                 }
 

--- a/src/controllers/TwitterController.php
+++ b/src/controllers/TwitterController.php
@@ -95,15 +95,46 @@ class TwitterController extends ApiController
             $twitterUsername = $data['screen_name'];
 
             $result = $this->oauthModel->createAccessTokenFromTwitterUsername($clientId, $twitterUsername);
-            if ($result) {
-                // clean up request token data
-                $requestTokenMapper = new TwitterRequestTokenMapper($db);
-                $requestTokenMapper->delete($request_token);
+            if (! $result) {
+                // try to create the user.
 
-                return array('access_token' => $result['access_token'], 'user_uri' => $result['user_uri']);
+                $client1 = new Client(
+                    [
+                        'base_url' => 'https://api.twitter.com/',
+                        'defaults' => ['auth' => 'oauth']
+                    ]
+                );
+
+                $oauth1 = new Oauth1([
+                    'consumer_key'    => $this->config['twitter']['consumer_key'],
+                    'consumer_secret' => $this->config['twitter']['consumer_secret'],
+                    'token'           => $data['oauth_token'],
+                    'token_secret'    => $data['oauth_token_secret'],
+                ]);
+                $client1->getEmitter()->attach($oauth1);
+
+                try {
+                    $res = $client1->get('1.1/account/verify_credentials.json?include_email=true');
+
+                } catch(Exception $e) {
+                    throw new Exception('Could not retrieve user-informations from Twitter', 403, $e);
+                }
+
+                if ($res->getStatusCode() == 200) {
+                    $result = $this->oauthModel->createUserFromTwitterUsername($clientId, $res->json());
+                }
             }
 
-            throw new Exception("Could not sign in with Twitter", 403);
+            if (! $result) {
+                throw new Exception("Could not sign in with Twitter", 403);
+            }
+
+                // clean up request token data
+            $requestTokenMapper = new TwitterRequestTokenMapper($db);
+            $requestTokenMapper->delete($request_token);
+
+            return array('access_token' => $result['access_token'], 'user_uri' => $result['user_uri']);
+
         }
 
         throw new Exception("Twitter: error (" . $res->getStatusCode() . ": " . $res->getBody() . ")", 500);


### PR DESCRIPTION
This change allows users to not only log in via twitter but also to create a new account via login in from twitter.

This should make it much easier to get users to log into joind.in as there's much less effort to be taken to get an account.

That should raise the adopition rate for conference-attendees.

When a user now tries to log in via twitter and there is no such user-account a new account is created and the user is logged in. As the Email-address is taken from twitter and they already validated it, we (IMO) do not need a second validation step so we can let the user do whatever they want right away. Perhaps that might need to be tweaked for users that do not have set an email-address in twitter…

This targets https://joindin.jira.com/browse/JOINDIN-741