### PR TITLE
Stop filtering title

### DIFF
--- a/src/controllers/TalksController.php
+++ b/src/controllers/TalksController.php
@@ -439,11 +439,7 @@ class TalksController extends BaseTalkController
         }
         $event = $list['events'][0];
 
-        $talk['title'] = filter_var(
-            $request->getParameter('talk_title'),
-            FILTER_SANITIZE_STRING,
-            FILTER_FLAG_NO_ENCODE_QUOTES
-        );
+        $talk['title'] = $request->getParameter('talk_title');
         if (empty($talk['title'])) {
             throw new Exception("The talk title field is required", 400);
         }


### PR DESCRIPTION
Filtering strip away valid text like tags (`<blink>`). With https://github.com/joindin/joindin-web2/pull/416 front ends will escape correctly, so we can start allowing these titles.