### PR TITLE
[JOINDIN-733] Expanding return type of method

### DIFF
--- a/src/inc/Request.php
+++ b/src/inc/Request.php
@@ -188,7 +188,7 @@ class Request
      * @param string $param Parameter to retrieve
      * @param string $default Default to return if parameter doesn't exist
      *
-     * @return string
+     * @return mixed
      */
     public function getParameter($param, $default = '')
     {


### PR DESCRIPTION
The PHP manual goes for `mixed` for `json_decode()`, so let's use it here too.