### PR TITLE
Solves the broken jenkins cleanly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 .gitattributes export-ignore
 .gitignore export-ignore
+scripts export-ignore
+tests export-ignore
+tools export-ignore
 vendor/* export-ignore
 build.xml export-ignore
 build export-ignore

--- a/scripts/jenkinslaunch.sh
+++ b/scripts/jenkinslaunch.sh
@@ -45,7 +45,7 @@ mkdir -p $TARGET \
 && ln -s $TARGETBASE/config.php $TARGET/src/config.php \
 && ln -s $TARGETBASE/database.php $TARGET/src/database.php \
 && ln -s $TARGET $TARGETBASE/www.new \
-&& $TARGET/scripts/patchdb.sh $DBNAME \
+&& ./scripts/patchdb.sh -t '$TARGET' $DBNAME \
 && mv -Tf $TARGETBASE/www.new $TARGETBASE/www
 "
 


### PR DESCRIPTION
This solves the broken jenkins by using the currently checked out scripts-directory instead of the scripts-directory in the web-directory. Having fixed that we can again remove the tools and the scripts
directory as well as the tests…

Please @liam-wiltshire Check this before deploying 😉 