### PR TITLE
Explicitly declare $retval arrays

### DIFF
--- a/src/models/ClientModelCollection.php
+++ b/src/models/ClientModelCollection.php
@@ -37,7 +37,7 @@ class ClientModelCollection extends AbstractModelCollection
     public function getOutputView($request, $verbose = false)
     {
         // handle the collection first
-        $retval['clients'] = [];
+        $retval = ['clients' => []];
         foreach ($this->list as $item) {
             $retval['clients'][] = $item->getOutputView($request, $verbose);
         }

--- a/src/models/EventCommentReportModelCollection.php
+++ b/src/models/EventCommentReportModelCollection.php
@@ -34,7 +34,7 @@ class EventCommentReportModelCollection extends AbstractModelCollection
     public function getOutputView($request, $verbose = false)
     {
         // handle the collection first
-        $retval['reports'] = [];
+        $retval = ['reports' => []];
         foreach ($this->list as $item) {
             $retval['reports'][] = $item->getOutputView($request, $verbose);
         }

--- a/src/models/PendingTalkClaimModelCollection.php
+++ b/src/models/PendingTalkClaimModelCollection.php
@@ -34,7 +34,7 @@ class PendingTalkClaimModelCollection extends AbstractModelCollection
     public function getOutputView($request, $verbose = false)
     {
         // handle the collection first
-        $retval['claims'] = [];
+        $retval = ['claims' => []];
         foreach ($this->list as $item) {
             $retval['claims'][] = $item->getOutputView($request, $verbose);
         }

--- a/src/models/TalkCommentReportModelCollection.php
+++ b/src/models/TalkCommentReportModelCollection.php
@@ -34,7 +34,7 @@ class TalkCommentReportModelCollection extends AbstractModelCollection
     public function getOutputView($request, $verbose = false)
     {
         // handle the collection first
-        $retval['reports'] = [];
+        $retval = ['reports' => []];
         foreach ($this->list as $item) {
             $retval['reports'][] = $item->getOutputView($request, $verbose);
         }

--- a/src/models/TalkModelCollection.php
+++ b/src/models/TalkModelCollection.php
@@ -35,7 +35,7 @@ class TalkModelCollection extends AbstractModelCollection
     public function getOutputView($request, $verbose = false)
     {
         // handle the collection first
-        $retval['talks'] = [];
+        $retval= ['talks' => []];
         foreach ($this->list as $item) {
             $retval['talks'][] = $item->getOutputView($request, $verbose);
         }

--- a/src/models/TokenModelCollection.php
+++ b/src/models/TokenModelCollection.php
@@ -37,7 +37,7 @@ class TokenModelCollection extends AbstractModelCollection
     public function getOutputView($request, $verbose = false)
     {
         // handle the collection first
-        $retval['tokens'] = [];
+        $retval = ['tokens' => []];
         foreach ($this->list as $item) {
             $retval['tokens'][] = $item->getOutputView($request, $verbose);
         }

--- a/src/models/TwitterRequestTokenModelCollection.php
+++ b/src/models/TwitterRequestTokenModelCollection.php
@@ -29,8 +29,7 @@ class TwitterRequestTokenModelCollection extends AbstractModelCollection
     public function getOutputView($request, $verbose = false)
     {
         // handle the collection first
-        $retval                           = array();
-        $retval['twitter_request_tokens'] = array();
+        $retval = ['twitter_request_tokens' => []];
         foreach ($this->list as $item) {
             $retval['twitter_request_tokens'][] = $item->getOutputView($request, $verbose);
         }


### PR DESCRIPTION
In some locations, a `$retval` (aka "return value") array is implied but is never explicitly declared. Explicitly declaring the array has 2 benefits:
- it looks nicer
- it makes the IDE (in my case, PHPStorm) realize that what it is returning is actually an array and not some unknown type

This PR explicitly declares the array.