### PR TITLE
Adds rating info from logged in user

### DIFF
--- a/src/models/TalkModel.php
+++ b/src/models/TalkModel.php
@@ -46,6 +46,7 @@ class TalkModel extends AbstractModel
         $fields['slides_link'] = 'slides_link';
         $fields['talk_media']  = 'talk_media';
         $fields['language']    = 'lang_name';
+        $fields['user_rating'] = 'user_rating';
 
         return $fields;
     }


### PR DESCRIPTION
This commit adds information about the rating of the currently logged in user for talks. That way we can show

* that the user already rated that talk and
* how the rating was in regard to the overall rating

That information will only be available when a user is logged in and only that users information will then be shown.