### PR TITLE
Allow users to add a small biography to their profile

### DIFF
--- a/db/patch74.sql
+++ b/db/patch74.sql
@@ -1,0 +1,5 @@
+# adding the bio column to the user info
+
+ALTER TABLE `user` add `biography` VARCHAR(400);
+
+INSERT INTO patch_history SET patch_number = 74;

--- a/db/patch74.sql
+++ b/db/patch74.sql
@@ -1,5 +1,5 @@
 # adding the bio column to the user info
 
-ALTER TABLE `user` add `biography` VARCHAR(400);
+ALTER TABLE `user` add `biography` TEXT;
 
 INSERT INTO patch_history SET patch_number = 74;

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -166,6 +166,11 @@ class UsersController extends BaseApiController
                 FILTER_SANITIZE_STRING,
                 FILTER_FLAG_NO_ENCODE_QUOTES
             );
+            $user['biography'] = filter_var(
+                trim($request->getParameter("biography")),
+                FILTER_SANITIZE_STRING,
+                FILTER_FLAG_NO_ENCODE_QUOTES
+            );
 
             // How does it look?  With no errors, we can proceed
             if ($errors) {
@@ -307,6 +312,14 @@ class UsersController extends BaseApiController
             if (false !== $twitter_username) {
                 $user['twitter_username'] = filter_var(
                     trim($twitter_username),
+                    FILTER_SANITIZE_STRING,
+                    FILTER_FLAG_NO_ENCODE_QUOTES
+                );
+            }
+            $biography = $request->getParameter("biography", false);
+            if (false !== $biography) {
+                $user['biography'] = filter_var(
+                    trim($biography),
                     FILTER_SANITIZE_STRING,
                     FILTER_FLAG_NO_ENCODE_QUOTES
                 );

--- a/src/models/UserMapper.php
+++ b/src/models/UserMapper.php
@@ -18,6 +18,7 @@ class UserMapper extends ApiMapper
         return array(
             "username"         => "username",
             "full_name"        => "full_name",
+            "biography"        => "biography",
             "twitter_username" => "twitter_username"
         );
     }
@@ -35,6 +36,7 @@ class UserMapper extends ApiMapper
             "username"         => "username",
             "full_name"        => "full_name",
             "twitter_username" => "twitter_username",
+            "biography"        => "biography",
             "trusted"          => "trusted"
         );
     }
@@ -115,7 +117,7 @@ class UserMapper extends ApiMapper
     protected function getUsers($resultsperpage, $start, $where = null, $order = null)
     {
         $sql = 'select user.username, user.ID, user.email, '
-               . 'user.full_name, user.twitter_username, user.admin, user.trusted '
+               . 'user.full_name, user.biography, user.twitter_username, user.admin, user.trusted '
                . 'from user '
                . 'left join user_attend ua on (ua.uid = user.ID) '
                . 'where active = 1 ';

--- a/tests/controllers/UsersControllerTest.php
+++ b/tests/controllers/UsersControllerTest.php
@@ -143,13 +143,15 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             ['full_name'],
             ['email'],
             ['password'],
-            ['twitter_username']
+            ['twitter_username'],
+            ['biography']
         )->willReturnOnConsecutiveCalls(
             'user"\'stuff',
             'full"\'stuff',
             'mailstuff@example.com',
             'pass"\'stuff',
-            'twitter"\'stuff'
+            'twitter"\'stuff',
+            'Bio"\'stuff'
         );
 
         $view = $this->getMockBuilder('\ApiView')->disableOriginalConstructor()->getMock();
@@ -169,6 +171,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             'email' => 'mailstuff@example.com',
             'password' => 'pass"\'stuff',
             'twitter_username' => 'twitter"\'stuff',
+            'biography' => 'Bio"\'stuff'
         ])->willReturn(true);
 
         $emailService = $this->getMockBuilder('\UserRegistrationEmailService')->disableOriginalConstructor()->getMock();
@@ -190,13 +193,15 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             ['full_name'],
             ['email'],
             ['username'],
-            ['twitter_username']
+            ['twitter_username'],
+            ['biography']
         )->willReturnOnConsecutiveCalls(
             '',
             'full"\'stuff',
             'mailstuff@example.com',
             'user"\'stuff',
-            'twitter"\'stuff'
+            'twitter"\'stuff',
+            'Bio"\'stuff'
         );
 
         $oauthmodel = $this->getMockBuilder('\OAuthModel')->disableOriginalConstructor()->getMock();
@@ -218,6 +223,7 @@ class UsersControllerTest extends \PHPUnit_Framework_TestCase
             'full_name' => 'full"\'stuff',
             'email' => 'mailstuff@example.com',
             'twitter_username' => 'twitter"\'stuff',
+            'biography' => 'Bio"\'stuff',
             'user_id' => false,
         ])->willReturn(true);
 


### PR DESCRIPTION
This will allow a user to add some more information regarding their occupation, specialization, interests and experience. That additional information can be useful for users interested in a speaker, for event organizers to get a feel for a speaker or for getting some context behind a comment.

The changes made in the API will be used by joindin/joindin-web2#443.

Github pages documentation is updated in #450.