### PR TITLE
JOINDIN-763 #close

### DIFF
--- a/src/views/JsonView.php
+++ b/src/views/JsonView.php
@@ -22,7 +22,7 @@ class JsonView extends ApiView
         // Don't use JSON_NUMERIC_CHECK because it eats things (e.g. talk stubs)
 
         // Specify a list of fields to NOT convert to numbers
-        $this->string_fields = array("stub", "track_name", "comment");
+        $this->string_fields = array("stub", "track_name", "comment", "username");
 
         $output = $this->numericCheck($content);
 


### PR DESCRIPTION
Usernames were being presented in a dynamic type form. in the vent of a long numeric username being represented in a scientific number format when returned by the API. This was reported as an issue with web2 but the error actually existed within the API. 