### PR TITLE
Provide users username on EventComments

### DIFF
--- a/src/models/EventCommentMapper.php
+++ b/src/models/EventCommentMapper.php
@@ -124,6 +124,7 @@ class EventCommentMapper extends ApiMapper
         // figure out user
         if ($row['user_id']) {
             $result['user_display_name'] = $row['full_name'];
+            $result['username']          = $row['username'];
             $result['user_uri']          = $base . '/' . $version . '/users/'
                                                     . $row['user_id'];
         } else {
@@ -147,7 +148,7 @@ class EventCommentMapper extends ApiMapper
 
     protected function getBasicSQL($include_hidden = false)
     {
-        $sql = 'select ec.*, user.email, user.full_name, e.event_tz_cont, e.event_tz_place '
+        $sql = 'select ec.*, user.username, user.email, user.full_name, e.event_tz_cont, e.event_tz_place '
                . 'from event_comments ec '
                . 'left join user on user.ID = ec.user_id '
                . 'inner join events e on ec.event_id = e.ID '


### PR DESCRIPTION
Alter EventCommentMapper to enable the API to provide the users username on an EventComment. This is already the case with TalkComments and this somewhat standardises the response fields on Event and Talk comments. 