### PR TITLE
Fix link to v1.2.0 of Contributor Covenant in CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,5 +37,4 @@ maintainers.
 
 This Code of Conduct is adapted from the
 [Contributor Covenant](http://contributor-covenant.org), version 1.2.0,
-available at [http://contributor- covenant.org/version/1/2/0/](http
-://contributor-covenant.org/version/1/2/0/)
+available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)


### PR DESCRIPTION
White space error prevented renderers from rendering as a link.