### PR TITLE
fixes the spamcheck on the contactform

### DIFF
--- a/src/controllers/ContactController.php
+++ b/src/controllers/ContactController.php
@@ -62,7 +62,7 @@ class ContactController extends BaseApiController
                 $this->config['akismet']['blog']
             );
             $isValid          = $spamCheckService->isCommentAcceptable(
-                $data['comment'],
+                ['comment' => $data['comment']],
                 $request->getClientIP(),
                 $request->getClientUserAgent()
             );


### PR DESCRIPTION
Contactform submission is being blocked due to passing a string instead of an array to the spam check