### PR TITLE
Remove dbunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "require-dev": {
         "exussum12/coverage-checker": "^0.11.0",
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "phpunit/dbunit": "^2.0",
         "phpunit/phpunit": "^5.7",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "phpunit/phpunit": "^5.7",
         "roave/security-advisories": "dev-master",
-        "squizlabs/php_codesniffer": "^3.4",
-        "sensiolabs/security-checker": "^5.0"
+        "sensiolabs/security-checker": "^5.0",
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload" : {
         "psr-4" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72b46e910726f546e2111e84b63ae4cf",
+    "content-hash": "9b4afb832c0b3cb751e3c58ee2ffce55",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -781,62 +781,6 @@
                 "stub"
             ],
             "time": "2018-08-05T17:53:17+00:00"
-        },
-        {
-            "name": "phpunit/dbunit",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/dbunit.git",
-                "reference": "5c35d74549c21ba55d0ea74ba89d191a51f8cf25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/dbunit/zipball/5c35d74549c21ba55d0ea74ba89d191a51f8cf25",
-                "reference": "5c35d74549c21ba55d0ea74ba89d191a51f8cf25",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pdo": "*",
-                "ext-simplexml": "*",
-                "php": "^5.4 || ^7.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0",
-                "symfony/yaml": "^2.1 || ^3.0"
-            },
-            "bin": [
-                "dbunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "DbUnit port for PHP/PHPUnit to support database interaction testing.",
-            "homepage": "https://github.com/sebastianbergmann/dbunit/",
-            "keywords": [
-                "database",
-                "testing",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2016-12-02T14:39:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -1222,6 +1222,11 @@
         {
             "name": "roave/security-advisories",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "344bf4ed1263c75e7f96b87b80c52e8373561e19"
+            },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<5.20.12",


### PR DESCRIPTION
phpunit/dbunit is marked as abandoned. I'm not seeing it used in the tests, so this appears to be safe to remove. Tests pass after removal.

This PR also includes automatic changes performed by the composer binary:
* alpha-sorting of the `require-dev` section of `composer.json`
* adding a source location for `roave/security-advisories` in `composer.lock`