### PR TITLE
Upgrade to PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - $HOME/.cache/composer/files
 matrix:
   include:
-    - php: 5.6
     - php: 7.3
   fast_finish: true
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,10 @@
             "@test"
         ]
     },
-    "config" : {
+    "config": {
+        "platform": {
+            "php": "7.3.2"
+        },
         "preferred-install": "dist",
         "sort-packages" : true,
         "optimize-autoloader" : true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbed19ebede28efdeaf4067edb213f92",
+    "content-hash": "3f032eae257d8113f9c290649044897c",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2660,5 +2660,8 @@
         "ext-json": "*",
         "ext-pdo": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3.2"
+    }
 }


### PR DESCRIPTION
Now that we're using PHP 7.3.2 on the vm, make that the target version for composer installs.

Takes care of #639 