### PR TITLE
Fix talk deletion route regex

### DIFF
--- a/src/config/routes/2.1.json
+++ b/src/config/routes/2.1.json
@@ -207,7 +207,7 @@
         "verbs": ["DELETE"]
     },
     {
-        "path": "/talks/[^\\d]/?$",
+        "path": "/talks/[\\d]+/?$",
         "controller": "TalksController",
         "action": "deleteTalk",
         "verbs": ["DELETE"]


### PR DESCRIPTION
Copies route regex from talk edit route, which we know works.

Fixes https://github.com/joindin/joindin-web2/issues/804