### PR TITLE
DB patch to fix oauth token generation error when access_token_secret…

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ INSERT INTO patch_history SET patch_number = 17;
 
 The number in that line should match the filename of your new patch number - check out the existing database patches in the project for examples.
 
+Patches can be applied using either of the two patchdb scripts (PHP/Shell) in the `scripts` directory.
+
 ### Coding Style
 
 Please do your best to ensure that any code you contributed adheres to the

--- a/db/patch77.sql
+++ b/db/patch77.sql
@@ -1,0 +1,5 @@
+# removing NOT NULL constraint preventing oauth access token generation
+
+ALTER TABLE oauth_access_tokens modify column access_token_secret varchar(32);
+
+INSERT INTO patch_history SET patch_number = 77;


### PR DESCRIPTION
… is not used.

Default DB schema requires an access_token_secret but this is not generated in the current version.

Users trying to login see the page refresh with the login credential section still visible. The API login request returns a 500 that is generated by the DB insert command to the oauth_access_tokens table.

This patch removes the NOT NULL constraint from the column allowing records to be inserted.

I have also added a line to the API README file to help newcomers apply their patches.