### PR TITLE
Add indexes on OAuth token + consumer tables that should've been there

### DIFF
--- a/db/patch79.sql
+++ b/db/patch79.sql
@@ -1,0 +1,7 @@
+ALTER TABLE oauth_access_tokens ADD INDEX idx_user_key (user_id, consumer_key);
+ALTER TABLE oauth_access_tokens ADD INDEX idx_consumer_key (consumer_key);
+ALTER TABLE oauth_access_tokens ADD INDEX idx_token_user (access_token, user_id);
+
+ALTER TABLE oauth_consumers ADD INDEX idx_user_key (user_id, consumer_key);
+
+INSERT INTO patch_history SET patch_number = 79;


### PR DESCRIPTION
A bit odd that we aren't enforcing uniqueness on tokens, nor using the
token ID as the primary key for that table, but we'll have to look a bit
more closely to make those changes, and these should drastically speed
up all authenticated API requests (okay, we're talking a few ms here but
those API calls are already very fast so there is some difference).