### PR TITLE
Don't use nonexistent method to pull JSON from Twitter response body

### DIFF
--- a/src/Controller/TwitterController.php
+++ b/src/Controller/TwitterController.php
@@ -137,7 +137,10 @@ class TwitterController extends BaseApiController
                 }
 
                 if ($res->getStatusCode() == 200) {
-                    $result = $this->oauthModel->createUserFromTwitterUsername($clientId, $res->json());
+                    $result = $this->oauthModel->createUserFromTwitterUsername(
+                        $clientId,
+                        json_decode($res->getBody()->getContents(), JSON_OBJECT_AS_ARRAY)
+                    );
                 }
             }
 


### PR DESCRIPTION
Noticed this in errors on New Relic. So user creation via Twitter SSO...or sign-in via Twitter SSO at all...is probably broken at the moment.