### PR TITLE
Fix: Lock file is not up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
     - php: 7.3
   fast_finish: true
 
+before_install:
+  - composer validate --no-check-publish
+
 install:
   - composer install
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12c92c46a113c5ecb173a88a94495e6f",
+    "content-hash": "c8ef16acea3940c55a50d61b53e273f4",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2817,6 +2817,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
+        "ext-intl": "*",
         "ext-json": "*",
         "ext-pdo": "*"
     },


### PR DESCRIPTION
This PR

* [x] validates `composer.json` and `composer.lock` on Travis in `before_install` section
* [x] updates `composer.lock`

💁‍♂ For reference, see https://getcomposer.org/doc/03-cli.md#validate.

❗️ Should probably be merged after #691, so that we keep sections in order.
