### PR TITLE
Enhancement: Reference phpunit.xsd as installed with composer

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     beStrictAboutTestsThatDoNotTestAnything="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,11 +5,11 @@
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
-    beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutOutputDuringTests="true"
-    enforceTimeLimit="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
     bootstrap="./tests/bootstrap.php"
     colors="true"
+    enforceTimeLimit="true"
     verbose="true"
 >
     <testsuite name="Joind.in Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
-         enforceTimeLimit="true"
-         bootstrap="./tests/bootstrap.php"
-         colors="true"
-         verbose="true">
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutOutputDuringTests="true"
+    enforceTimeLimit="true"
+    bootstrap="./tests/bootstrap.php"
+    colors="true"
+    verbose="true"
+>
     <testsuite name="Joind.in Test Suite">
         <directory>tests/</directory>
     </testsuite>


### PR DESCRIPTION
This PR

* [x] fixes the wrapping in `phpunit.xml.dist`
* [x] references `phpunit.xsd` as installed with `composer`
* [x] keep attributes sorted by name

💁‍♂ Helps with auto-completion and validation in IDEs.