### PR TITLE
Add rate limit user comments

### DIFF
--- a/db/patch81.sql
+++ b/db/patch81.sql
@@ -1,3 +1,6 @@
+ALTER TABLE talk_comments ADD COLUMN created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER date_made;
+UPDATE talk_comments SET talk_comments.created_at = FROM_UNIXTIME(date_made);
+
 ALTER TABLE talk_comments DROP COLUMN date_made;
 
 INSERT INTO patch_history SET patch_number = 81;

--- a/db/patch81.sql
+++ b/db/patch81.sql
@@ -1,0 +1,3 @@
+ALTER TABLE talk_comments DROP COLUMN date_made;
+
+INSERT INTO patch_history SET patch_number = 81;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2156,36 +2156,6 @@ parameters:
 			path: tests/Controller/TalksControllerTest.php
 
 		-
-			message: "#^Property class@anonymous/tests/Controller/TalksControllerTest\\.php\\:892\\:\\:\\$talkCommentEmailService has no typehint specified\\.$#"
-			count: 1
-			path: tests/Controller/TalksControllerTest.php
-
-		-
-			message: "#^Method class@anonymous/tests/Controller/TalksControllerTest\\.php\\:892\\:\\:getTalkCommentEmailService\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: tests/Controller/TalksControllerTest.php
-
-		-
-			message: "#^Method class@anonymous/tests/Controller/TalksControllerTest\\.php\\:892\\:\\:getTalkCommentEmailService\\(\\) has parameter \\$comment with no typehint specified\\.$#"
-			count: 1
-			path: tests/Controller/TalksControllerTest.php
-
-		-
-			message: "#^Method class@anonymous/tests/Controller/TalksControllerTest\\.php\\:892\\:\\:getTalkCommentEmailService\\(\\) has parameter \\$config with no typehint specified\\.$#"
-			count: 1
-			path: tests/Controller/TalksControllerTest.php
-
-		-
-			message: "#^Method class@anonymous/tests/Controller/TalksControllerTest\\.php\\:892\\:\\:getTalkCommentEmailService\\(\\) has parameter \\$recipients with no typehint specified\\.$#"
-			count: 1
-			path: tests/Controller/TalksControllerTest.php
-
-		-
-			message: "#^Method class@anonymous/tests/Controller/TalksControllerTest\\.php\\:892\\:\\:getTalkCommentEmailService\\(\\) has parameter \\$talk with no typehint specified\\.$#"
-			count: 1
-			path: tests/Controller/TalksControllerTest.php
-
-		-
 			message: "#^Method Joindin\\\\Api\\\\Test\\\\Controller\\\\TalksControllerTest\\:\\:getComments\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: tests/Controller/TalksControllerTest.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,12 @@
         <log type="junit" target="build/logs/junit.xml"/>
     </logging>
 
+    <groups>
+        <exclude>
+            <group>uses_pdo</group>
+        </exclude>
+    </groups>
+
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="false">
             <directory suffix=".php">src</directory>

--- a/public/index.php
+++ b/public/index.php
@@ -41,16 +41,15 @@ function handle_exception(Throwable $e)
             $request->getView()->setHeader('WWW-Authenticate', 'Bearer realm="api.joind.in');
         }
 
-    error_log(get_class($e) . ': ' . $e->getMessage() . " -- " . $e->getTraceAsString());
-
-    $message = $e->getMessage();
-    if ($e instanceof PDOException && (!isset($config['mode']) || $config['mode'] !== "development")) {
-        $message = "Database error";
+        $message = $e->getMessage();
+        if ($e instanceof PDOException && (!isset($config['mode']) || $config['mode'] !== "development")) {
+            $message = "Database error";
+        }
+        if ($e instanceof RateLimitExceededException) {
+            $request->getView()->setHeader('Retry-After', $e->getRateLimitRefresh());
+        }
+        $request->getView()->render([$message]);
     }
-    if ($e instanceof RateLimitExceededException) {
-        $request->getView()->setHeader('Retry-After', $e->getRateLimitRefresh());
-    }
-    $request->getView()->render([$message]);
 }
 
 set_exception_handler('handle_exception');

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,7 @@
 
 // @codingStandardsIgnoreFile
 use Joindin\Api\ContainerFactory;
+use Joindin\Api\Exception\RateLimitExceededException;
 use Joindin\Api\Request;
 use Joindin\Api\Router\ApiRouter;
 use Joindin\Api\Router\DefaultRouter;
@@ -40,8 +41,16 @@ function handle_exception(Throwable $e)
             $request->getView()->setHeader('WWW-Authenticate', 'Bearer realm="api.joind.in');
         }
 
-        $request->getView()->render([$message]);
+    error_log(get_class($e) . ': ' . $e->getMessage() . " -- " . $e->getTraceAsString());
+
+    $message = $e->getMessage();
+    if ($e instanceof PDOException && (!isset($config['mode']) || $config['mode'] !== "development")) {
+        $message = "Database error";
     }
+    if ($e instanceof RateLimitExceededException) {
+        $request->getView()->setHeader('Retry-After', $e->getRateLimitRefresh());
+    }
+    $request->getView()->render([$message]);
 }
 
 set_exception_handler('handle_exception');

--- a/src/Controller/TalkCommentsController.php
+++ b/src/Controller/TalkCommentsController.php
@@ -188,7 +188,10 @@ class TalkCommentsController extends BaseApiController
             $maxCommentEditMinutes = $this->config['limits']['max_comment_edit_minutes'];
         }
 
-        if ($comment['date_made'] + ($maxCommentEditMinutes * 60) < time()) {
+        $interval = sprintf('PT%dM', $maxCommentEditMinutes);
+        $edit_after_time = (new \DateTimeImmutable())->sub(new \DateInterval($interval));
+
+        if ($comment['created_at'] < $edit_after_time) {
             throw new Exception(
                 'Cannot edit the comment after ' . $maxCommentEditMinutes . ' minutes',
                 Http::BAD_REQUEST

--- a/src/Controller/TalksController.php
+++ b/src/Controller/TalksController.php
@@ -145,6 +145,8 @@ class TalksController extends BaseTalkController
                     $data['private'] = $private;
                     $data['source']  = $consumer_name;
 
+                    $comment_mapper->checkRateLimit($data['user_id']);
+
                     try {
                         $isValid = $this->spamCheckService->isCommentAcceptable(
                             $comment,

--- a/src/Exception/RateLimitExceededException.php
+++ b/src/Exception/RateLimitExceededException.php
@@ -6,10 +6,13 @@ use Throwable;
 
 final class RateLimitExceededException extends \Exception
 {
+    /** @var int */
     private $rate_limit_refresh;
+
+    /** @var int */
     private $rate_limit_limit;
 
-    private function __construct($message, $code, Throwable $previous = null)
+    private function __construct(string $message, int $code, Throwable $previous = null)
     {
         /*
          * The only reason for the constructor overwrite is to change the visibility
@@ -18,7 +21,7 @@ final class RateLimitExceededException extends \Exception
         parent::__construct($message, $code, $previous);
     }
 
-    public static function withLimitAndRefresh(int $rate_limit_limit, int $rate_limit_refresh)
+    public static function withLimitAndRefresh(int $rate_limit_limit, int $rate_limit_refresh): self
     {
         $message = sprintf('Rate limit exceeded. Try again in %d seconds', $rate_limit_refresh);
         $code = 429;
@@ -30,18 +33,12 @@ final class RateLimitExceededException extends \Exception
         return $exception;
     }
 
-    /**
-     * @return int
-     */
-    public function getRateLimitLimit()
+    public function getRateLimitLimit(): int
     {
         return $this->rate_limit_limit;
     }
 
-    /**
-     * @return int
-     */
-    public function getRateLimitRefresh()
+    public function getRateLimitRefresh(): int
     {
         return $this->rate_limit_refresh;
     }

--- a/src/Exception/RateLimitExceededException.php
+++ b/src/Exception/RateLimitExceededException.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Joindin\Api\Exception;
+
+use Throwable;
+
+final class RateLimitExceededException extends \Exception
+{
+    private $rate_limit_refresh;
+    private $rate_limit_limit;
+
+    private function __construct($message, $code, Throwable $previous = null)
+    {
+        /*
+         * The only reason for the constructor overwrite is to change the visibility
+         * and prevent creating an instance without the required parameters
+         */
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function withLimitAndRefresh(int $rate_limit_limit, int $rate_limit_refresh)
+    {
+        $message = sprintf('Rate limit exceeded. Try again in %d seconds', $rate_limit_refresh);
+        $code = 429;
+
+        $exception = new self($message, $code);
+        $exception->rate_limit_limit = $rate_limit_limit;
+        $exception->rate_limit_refresh = $rate_limit_refresh;
+
+        return $exception;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRateLimitLimit()
+    {
+        return $this->rate_limit_limit;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRateLimitRefresh()
+    {
+        return $this->rate_limit_refresh;
+    }
+}

--- a/src/Model/ApiMapper.php
+++ b/src/Model/ApiMapper.php
@@ -71,7 +71,8 @@ class ApiMapper
                     } else {
                         $tz = new DateTimeZone('UTC');
                     }
-                    $entry[$key] = (new DateTime('@' . $row[$value]))->setTimezone($tz)->format('c');
+                    $time = is_numeric($row[$value]) ? '@' . $row[$value] : $row[$value];
+                    $entry[$key] = (new \DateTimeImmutable($time))->setTimezone($tz)->format('c');
                 } else {
                     if (array_key_exists($value, $row)) {
                         $entry[$key] = $row[$value];

--- a/src/Model/TalkCommentMapper.php
+++ b/src/Model/TalkCommentMapper.php
@@ -246,7 +246,7 @@ class TalkCommentMapper extends ApiMapper
      * @param int $user_id
      * @throws RateLimitExceededException
      */
-    public function checkRateLimit(int $user_id)
+    public function checkRateLimit(int $user_id): void
     {
         $max_comments = 30;
         $duration_minutes = 60;
@@ -284,10 +284,10 @@ class TalkCommentMapper extends ApiMapper
             return;
         }
 
-        $rate_limit_time = (new \DateTimeImmutable())
+        $rate_limit_time = (int) (new \DateTimeImmutable())
             ->sub(new \DateInterval(sprintf('PT%dM', $duration_minutes)))
             ->format('U');
-        $oldest_comment = (new \DateTimeImmutable($row['created_at']))->format('U');
+        $oldest_comment = (int) (new \DateTimeImmutable($row['created_at']))->format('U');
 
         $wait = $oldest_comment - $rate_limit_time;
         if ($wait > 0) {

--- a/src/Model/TalkCommentMapper.php
+++ b/src/Model/TalkCommentMapper.php
@@ -5,6 +5,7 @@ namespace Joindin\Api\Model;
 use Exception;
 use Joindin\Api\Exception\RateLimitExceededException;
 use PDO;
+use function sprintf;
 
 class TalkCommentMapper extends ApiMapper
 {
@@ -284,12 +285,10 @@ class TalkCommentMapper extends ApiMapper
             return;
         }
 
-        $rate_limit_time = (int) (new \DateTimeImmutable())
-            ->sub(new \DateInterval(sprintf('PT%dM', $duration_minutes)))
-            ->format('U');
         $oldest_comment = (int) (new \DateTimeImmutable($row['created_at']))->format('U');
 
-        $wait = $oldest_comment - $rate_limit_time;
+        $wait = $oldest_comment - (int) $rate_limit_time->format('U');
+
         if ($wait > 0) {
             throw RateLimitExceededException::withLimitAndRefresh($max_comments, $wait);
         }

--- a/src/config.php.dist
+++ b/src/config.php.dist
@@ -6,6 +6,11 @@ return [
     // the URL of web2 website is used in links within emails
     'website_url' => 'http://dev.joind.in',
 
+    // maximum number of talk comments one can add in a certain time
+    'talk_comments_rate_limit_limit' => 30,
+    // the time in which those comments can be added (in minutes)
+    'talk_comments_rate_limit_reset' => 60,
+
     'oauth'            => [
         'expirable_client_ids' => [
             // some clients, (e.g. web2) do not hold onto their token after the

--- a/tests/Controller/EventHostsControllerTest.php
+++ b/tests/Controller/EventHostsControllerTest.php
@@ -15,6 +15,9 @@ use Teapot\StatusCode\Http;
 
 final class EventHostsControllerTest extends TestCase
 {
+    /**
+     * @group uses_pdo
+     */
     public function testThatNotLoggedInUsersCanNotAddAHost()
     {
         $this->expectException(Exception::class);

--- a/tests/Controller/TalksControllerDeleteTest.php
+++ b/tests/Controller/TalksControllerDeleteTest.php
@@ -14,6 +14,9 @@ final class TalksControllerDeleteTest extends TalkBase
 {
     private $talkMapper;
 
+    /**
+     * @group uses_pdo
+     */
     public function testRemoveStarFromTalkFailsWhenNotLoggedIn()
     {
         $this->expectException(Exception::class);
@@ -63,6 +66,9 @@ final class TalksControllerDeleteTest extends TalkBase
         $talks_controller->removeStarFromTalk($request, $db);
     }
 
+    /**
+     * @group uses_pdo
+     */
     public function testDeleteTalkWhenNotLoggedIn()
     {
         $this->expectException(Exception::class);

--- a/tests/Controller/TalksControllerTest.php
+++ b/tests/Controller/TalksControllerTest.php
@@ -14,6 +14,7 @@ use Joindin\Api\Service\NullSpamCheckService;
 use Joindin\Api\Service\SpamCheckServiceInterface;
 use Joindin\Api\Service\TalkCommentEmailService;
 use Joindin\Api\Test\Mock\mockPDO;
+use PHPUnit\Framework\MockObject\MockObject;
 use Teapot\StatusCode\Http;
 use Teapot\StatusCode\WebDAV;
 
@@ -884,6 +885,7 @@ final class TalksControllerTest extends TalkBase
             'rating' => '3',
         ];
 
+        /** @var TalkCommentEmailService&MockObject $talks_comment_email */
         $talks_comment_email =
             $this->getMockBuilder(TalkCommentEmailService::class)
                 ->disableOriginalConstructor()
@@ -892,6 +894,7 @@ final class TalksControllerTest extends TalkBase
         $talks_comment_email->method('sendEmail');
 
         $talks_controller = new class(new NullSpamCheckService(), $talks_comment_email) extends TalksController {
+            /** @var TalkCommentEmailService  */
             private $talkCommentEmailService;
 
             public function __construct(
@@ -904,6 +907,13 @@ final class TalksControllerTest extends TalkBase
                 $this->talkCommentEmailService = $talkCommentEmailService;
             }
 
+            /**
+             * @param array $config
+             * @param array $recipients
+             * @param string $talk
+             * @param string $comment
+             * @return TalkCommentEmailService
+             */
             public function getTalkCommentEmailService($config, $recipients, $talk, $comment)
             {
                 return $this->talkCommentEmailService;

--- a/tests/Controller/TalksControllerTest.php
+++ b/tests/Controller/TalksControllerTest.php
@@ -43,6 +43,8 @@ final class TalksControllerTest extends TalkBase
      * an exception is thrown
      *
      * @return void
+     *
+     * @group uses_pdo
      */
     public function testClaimTalkWithNoUserIdThrowsException()
     {
@@ -977,6 +979,9 @@ final class TalksControllerTest extends TalkBase
         ];
     }
 
+    /**
+     * @group uses_pdo
+     */
     public function testNotLoggedInPostAction()
     {
         $this->expectException(Exception::class);

--- a/tests/Controller/TokenControllerTest.php
+++ b/tests/Controller/TokenControllerTest.php
@@ -21,6 +21,9 @@ final class TokenControllerTest extends TestCase
         $this->pdo     = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
     }
 
+    /**
+     * @group uses_pdo
+     */
     public function testThatDeletingATokenWithoutLoginThrowsException()
     {
         $this->expectException(Exception::class);
@@ -32,6 +35,9 @@ final class TokenControllerTest extends TestCase
         $usersController->revokeToken($this->request, $this->pdo);
     }
 
+    /**
+     * @group uses_pdo
+     */
     public function testThatRetrievingTokensWithoutLoginThrowsException()
     {
         $this->expectException(Exception::class);

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -26,6 +26,8 @@ final class UsersControllerTest extends TestCase
      * an exception is thrown
      *
      * @return void
+     *
+     * @group uses_pdo
      */
     public function testDeleteUserWithoutBeingLoggedInThrowsException()
     {
@@ -340,6 +342,8 @@ final class UsersControllerTest extends TestCase
      * an exception is thrown
      *
      * @return void
+     *
+     * @group uses_pdo
      */
     public function testSetTrustedWithNoUserIdThrowsException()
     {

--- a/tests/Model/TalkCommentMapperTest.php
+++ b/tests/Model/TalkCommentMapperTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Joindin\Api\Test\Model;
+
+use DateInterval;
+use DateTimeImmutable;
+use Joindin\Api\Exception\RateLimitExceededException;
+use Joindin\Api\Model\TalkCommentMapper;
+use Joindin\Api\Request;
+use Joindin\Api\Test\Mock\mockPDO;
+use PDOStatement;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class TalkCommentMapperTest extends TestCase
+{
+    public function testCheckRateLimitDoesNotThrowWhenNoRatesAreSet(): void
+    {
+        $stmt = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
+        $stmt->method('rowCount')
+            ->willReturn(0);
+
+        $pdo = $this->getMockBuilder(mockPDO::class)->disableOriginalConstructor()->getMock();
+        $pdo->method('prepare')
+            ->willReturn($stmt);
+
+        $mapper = new TalkCommentMapper($pdo, new Request([1], [2]));
+
+        $mapper->checkRateLimit(12);
+
+        self::assertTrue(true);
+    }
+
+    public function testCheckRateLimitDoesNotThrowWhenRateIsBelowThreshold(): void
+    {
+        $stmt = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
+        $stmt->method('rowCount')
+            ->willReturn(1);
+
+        $stmt->method('fetch')
+            ->willReturn(['cnt' => 1]);
+
+        $pdo = $this->getMockBuilder(mockPDO::class)->disableOriginalConstructor()->getMock();
+        $pdo->method('prepare')
+            ->willReturn($stmt);
+
+        $mapper = new TalkCommentMapper($pdo, new Request([1], [2]));
+
+        $mapper->checkRateLimit(12);
+
+        self::assertTrue(true);
+    }
+
+    public function testCheckRateLimitDoesThrowWhenRateIsAboveThreshold(): void
+    {
+        $stmt = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
+        $stmt->method('rowCount')
+            ->willReturn(1);
+
+        $stmt->method('fetch')
+            ->willReturn(['cnt' => 61, 'created_at' => (new DateTimeImmutable())->format('c')]);
+
+        $pdo = $this->getMockBuilder(mockPDO::class)->disableOriginalConstructor()->getMock();
+        $pdo->method('prepare')
+            ->willReturn($stmt);
+
+        $mapper = new TalkCommentMapper($pdo, new Request([1], [2]));
+
+        self::expectException(RateLimitExceededException::class);
+
+        $mapper->checkRateLimit(12);
+    }
+
+    /**
+     * @throws RateLimitExceededException
+     *
+     * This tests a condition that should never ever happen as it assumes that the information returned from the
+     * Database contains a date that is earlier than the date that we are actually comparing for in the database.
+     * So this should never be possible.
+     */
+    public function testCheckRateLimitDoesNotThrowWhenRateIsAboveThresholdButBelowDuration(): void
+    {
+        $stmt = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
+        $stmt->method('rowCount')
+            ->willReturn(1);
+
+        $stmt->method('fetch')
+            ->willReturn(['cnt' => 61, 'created_at' => (new DateTimeImmutable())->sub(new DateInterval('PT90M'))->format('c')]);
+
+        $pdo = $this->getMockBuilder(mockPDO::class)->disableOriginalConstructor()->getMock();
+        $pdo->method('prepare')
+            ->willReturn($stmt);
+
+        $mapper = new TalkCommentMapper($pdo, new Request([1], [2]));
+
+        $mapper->checkRateLimit(12);
+
+        Assert::assertTrue(true);
+    }
+}

--- a/tools/dbgen/generator.class.php
+++ b/tools/dbgen/generator.class.php
@@ -38,7 +38,7 @@ class DataGenerator
     public function generate()
     {
         ob_implicit_flush(true);
-        
+
         // Generate languages and categories (it's not really generated data)
         $this->_generateLanguages();
         $this->_generateCategories();
@@ -92,7 +92,7 @@ class DataGenerator
     {
         return $this->_cache[$tag];
     }
-    
+
     /**
      * Find/Fetch an object based on the needle inside the $tag namespace
      *
@@ -115,7 +115,7 @@ class DataGenerator
 
         return null;
     }
-    
+
     /**
      * Store an $object on index $id in the $tag namespace
      *
@@ -173,7 +173,7 @@ class DataGenerator
             if ($id % 100 == 0) {
                 fwrite(STDERR, "TALK: $id         (" . (memory_get_usage(true)/1024) . " Kb)        \r");
             }
-            
+
             $talk = new StdClass();
             $talk->id = $id;
 
@@ -336,7 +336,7 @@ class DataGenerator
     protected function _generateTalkComments($count)
     {
         echo "TRUNCATE talk_comments;\n";
-        echo "INSERT INTO talk_comments (talk_id, rating, comment, date_made, ID, private, active, user_id, comment_type, source) VALUES \n";
+        echo "INSERT INTO talk_comments (talk_id, rating, comment, created_at, ID, private, active, user_id, comment_type, source) VALUES \n";
 
         $first = true;
 
@@ -386,11 +386,11 @@ class DataGenerator
             }
 
             printf(
-                "(%d, %d, '%s', %d, %d, %d, %d, %d, NULL, '%s')",
+                "(%d, %d, '%s', '%s', %d, %d, %d, %d, NULL, '%s')",
                 $talk->id,
                 $rating,
                 $comment,
-                $date_made,
+                (new DateTimeImmutable('@' . $date_made))->format('Y-m-d H:i:s'),
                 $id,
                 $private,
                 1,
@@ -600,11 +600,11 @@ class DataGenerator
 
             $event = new StdClass();
             $event->id = $id;
-            
+
             // Add a dampening for this event. This is a 0-5 value (0 being the most used) that will give an overall
             // view of the event. When a event wasn't good, it should reflect on the comments as well
             // because they should be lower than usual.
-            
+
             $event->dampening = floor(log(rand(1, 256) / log(2)));
             // Store this event in the cache
             $this->_cacheStore('events', $id, $event);
@@ -725,7 +725,7 @@ class DataGenerator
 
             // Generate and store user
             $user = $this->_genUser();
-            
+
             // Ensure that we don't duplicate usernames as that column has a unique index on it
             if (isset($usernames[$user->username])) {
                 continue;


### PR DESCRIPTION
Add rate limit for talk comments

Includes db migrations and some cleanup. Rate limit checks for 30 comments in 60 minutes (both configurable). If you try to add more, http status 429 is returned along with a message to wait.

Closes #648 