### PR TITLE
Add an id field to the returned talk data

### DIFF
--- a/src/Model/TalkModel.php
+++ b/src/Model/TalkModel.php
@@ -19,6 +19,7 @@ class TalkModel extends BaseModel
     public function getDefaultFields()
     {
         return [
+            'id'                      => 'ID',
             'talk_title'              => 'talk_title',
             'url_friendly_talk_title' => 'url_friendly_talk_title',
             'talk_description'        => 'talk_desc',


### PR DESCRIPTION
When web requests event talks data, the api response now includes the
talk id (which was already available as part of url fields anyway,
this property just makes sure it is easier to access).

Closes #645