### PR TITLE
Add a GET route to retrieve all images

### DIFF
--- a/src/Controller/EventImagesController.php
+++ b/src/Controller/EventImagesController.php
@@ -9,6 +9,15 @@ use Joindin\Api\Request;
 
 class EventImagesController extends BaseApiController
 {
+    public function listImages(Request $request, PDO $db)
+    {
+        $event_id = $this->getItemId($request);
+
+        $event_mapper = new EventMapper($db, $request);
+
+        return ['images' => $event_mapper->getImages($event_id)];
+    }
+
     public function createImage(Request $request, PDO $db)
     {
         if (!isset($request->user_id)) {

--- a/src/Model/EventMapper.php
+++ b/src/Model/EventMapper.php
@@ -1136,7 +1136,7 @@ class EventMapper extends ApiMapper
      *
      * @return array The images including metadata
      */
-    protected function getImages($event_id)
+    public function getImages($event_id)
     {
         $image_sql  = 'select i.type, i.url, i.width, i.height'
                       . ' from event_images i '

--- a/src/config/routes/2.1.php
+++ b/src/config/routes/2.1.php
@@ -75,6 +75,15 @@ return [
             ],
     ],
     [
+        'path'       => '/events(/[\\d]+)/images',
+        'controller' => EventImagesController::class,
+        'action'     => 'listImages',
+        'verbs'      =>
+            [
+                'GET',
+            ],
+    ],
+    [
         'path'       => '/events(/[^/]+)*/?$',
         'controller' => EventsController::class,
         'action'     => 'getAction',


### PR DESCRIPTION
- Created the GET route for /events/{id}/images
- Made the method `getImages` in the EventMapper model public so it can
be used for event data as well as images only
- Implemented an action method to return the list of images

Note that due to the implementation of `getImages` only one image of each
type is returned. We could change this to return a list of images per
type, but that will break API consumers. We also could make the images of
`/events/{id}` and `/events/{id}/images` have different data, but that
would not make sense.

Closes #636 