### PR TITLE
Enhancement: Use Guzzle client to verify comment

### DIFF
--- a/src/ContainerFactory.php
+++ b/src/ContainerFactory.php
@@ -2,6 +2,7 @@
 
 namespace Joindin\Api;
 
+use GuzzleHttp\Client;
 use Joindin\Api\Controller\ApplicationsController;
 use Joindin\Api\Controller\ContactController;
 use Joindin\Api\Controller\DefaultController;
@@ -55,6 +56,7 @@ class ContainerFactory
             if (isset($config['akismet']['apiKey'], $config['akismet']['blog'])) {
                 $container[SpamCheckServiceInterface::class] = function ($c) use ($config) {
                     return new SpamCheckService(
+                        new Client(),
                         $config['akismet']['apiKey'],
                         $config['akismet']['blog']
                     );

--- a/tests/Service/SpamCheckServiceTest.php
+++ b/tests/Service/SpamCheckServiceTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Joindin\Api\Test\Service;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception;
+use GuzzleHttp\Psr7;
+use Joindin\Api\Service\SpamCheckService;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Teapot\StatusCode\Http;
+
+/**
+ * @covers \Joindin\Api\Service\SpamCheckService
+ */
+final class SpamCheckServiceTest extends TestCase
+{
+
+    /**
+     * @dataProvider provideBlankOrEmptyString
+     */
+    public function testIsCommentAcceptableReturnsFalseWhenCommentIsBlankOrEmptyString(string $comment): void
+    {
+        $apiKey = 'hello123';
+        $blog = 'foo-bar-baz';
+
+        $userIp = '123.456.789.012';
+        $userAgent = 'Foo/9000';
+
+        $service = new SpamCheckService(
+            $this->prophesize(ClientInterface::class)->reveal(),
+            $apiKey,
+            $blog
+        );
+
+        $isCommentAcceptable = $service->isCommentAcceptable(
+            $comment,
+            $userIp,
+            $userAgent
+        );
+
+        self::assertFalse($isCommentAcceptable);
+    }
+
+    public function provideBlankOrEmptyString(): array
+    {
+        return [
+            'blank' => [' '],
+            'empty' => [''],
+        ];
+    }
+
+    public function testIsCommentAcceptableReturnsFalseWhenExceptionIsThrownDuringRequest(): void
+    {
+        $comment = <<<TXT
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna. 
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute 
+irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat 
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+TXT;
+
+        $apiKey = 'hello123';
+        $blog = 'foo-bar-baz';
+
+        $userIp = '123.456.789.012';
+        $userAgent = 'Foo/9000';
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+
+        $httpClient
+            ->request(
+                Argument::is('POST'),
+                Argument::is(sprintf(
+                    'https://%s.rest.akismet.com/1.1/comment-check',
+                    $apiKey
+                )),
+                Argument::is([
+                    'body' => http_build_query([
+                        'blog' => $blog,
+                        'comment_content' => $comment,
+                        'user_agent' => $userAgent,
+                        'user_ip' => $userIp,
+                    ]),
+                ])
+            )
+            ->shouldBeCalled()
+            ->willThrow(new class extends \RuntimeException implements Exception\GuzzleException {
+            });
+
+        $service = new SpamCheckService(
+            $httpClient->reveal(),
+            $apiKey,
+            $blog
+        );
+
+        $isCommentAcceptable = $service->isCommentAcceptable(
+            $comment,
+            $userIp,
+            $userAgent
+        );
+
+        self::assertFalse($isCommentAcceptable);
+    }
+
+    public function testIsCommentAcceptableReturnsFalseWhenResponseBodyEqualsInvalid(): void
+    {
+        $comment = <<<TXT
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna. 
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute 
+irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat 
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+TXT;
+
+        $apiKey = 'hello123';
+        $blog = 'foo-bar-baz';
+
+        $userIp = '123.456.789.012';
+        $userAgent = 'Foo/9000';
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+
+        $httpClient
+            ->request(
+                Argument::is('POST'),
+                Argument::is(sprintf(
+                    'https://%s.rest.akismet.com/1.1/comment-check',
+                    $apiKey
+                )),
+                Argument::is([
+                    'body' => http_build_query([
+                        'blog' => $blog,
+                        'comment_content' => $comment,
+                        'user_agent' => $userAgent,
+                        'user_ip' => $userIp,
+                    ]),
+                ])
+            )
+            ->shouldBeCalled()
+            ->willReturn(new Psr7\Response(
+                Http::OK,
+                [],
+                'invalid'
+            ));
+
+        $service = new SpamCheckService(
+            $httpClient->reveal(),
+            $apiKey,
+            $blog
+        );
+
+        $isCommentAcceptable = $service->isCommentAcceptable(
+            $comment,
+            $userIp,
+            $userAgent
+        );
+
+        self::assertFalse($isCommentAcceptable);
+    }
+
+    public function testIsCommentAcceptableReturnsFalseWhenResponseBodyEqualsFalse(): void
+    {
+        $comment = <<<TXT
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna. 
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute 
+irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat 
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+TXT;
+
+        $apiKey = 'hello123';
+        $blog = 'foo-bar-baz';
+
+        $userIp = '123.456.789.012';
+        $userAgent = 'Foo/9000';
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+
+        $httpClient
+            ->request(
+                Argument::is('POST'),
+                Argument::is(sprintf(
+                    'https://%s.rest.akismet.com/1.1/comment-check',
+                    $apiKey
+                )),
+                Argument::is([
+                    'body' => http_build_query([
+                        'blog' => $blog,
+                        'comment_content' => $comment,
+                        'user_agent' => $userAgent,
+                        'user_ip' => $userIp,
+                    ]),
+                ])
+            )
+            ->shouldBeCalled()
+            ->willReturn(new Psr7\Response(
+                Http::OK,
+                [],
+                'false'
+            ));
+
+        $service = new SpamCheckService(
+            $httpClient->reveal(),
+            $apiKey,
+            $blog
+        );
+
+        $isCommentAcceptable = $service->isCommentAcceptable(
+            $comment,
+            $userIp,
+            $userAgent
+        );
+
+        self::assertFalse($isCommentAcceptable);
+    }
+
+    public function testIsCommentAcceptableReturnsTrueWhenResponseBodyEqualsTrue(): void
+    {
+        $comment = <<<TXT
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna. 
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute 
+irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat 
+cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+TXT;
+
+        $apiKey = 'hello123';
+        $blog = 'foo-bar-baz';
+
+        $userIp = '123.456.789.012';
+        $userAgent = 'Foo/9000';
+
+        $httpClient = $this->prophesize(ClientInterface::class);
+
+        $httpClient
+            ->request(
+                Argument::is('POST'),
+                Argument::is(sprintf(
+                    'https://%s.rest.akismet.com/1.1/comment-check',
+                    $apiKey
+                )),
+                Argument::is([
+                    'body' => http_build_query([
+                        'blog' => $blog,
+                        'comment_content' => $comment,
+                        'user_agent' => $userAgent,
+                        'user_ip' => $userIp,
+                    ]),
+                ])
+            )
+            ->shouldBeCalled()
+            ->willReturn(new Psr7\Response(
+                Http::OK,
+                [],
+                'true'
+            ));
+
+        $service = new SpamCheckService(
+            $httpClient->reveal(),
+            $apiKey,
+            $blog
+        );
+
+        $isCommentAcceptable = $service->isCommentAcceptable(
+            $comment,
+            $userIp,
+            $userAgent
+        );
+
+        self::assertTrue($isCommentAcceptable);
+    }
+}


### PR DESCRIPTION
This PR

* [x] uses a `GuzzleHttp\Client` to verify a comment with Akismet

💁‍♂ Since `guzzlehttp/guzzle` is already a dependency, why not use it instead of `curl` directly?

For reference, see https://akismet.com/development/api/#comment-check.