### PR TITLE
Fix: Remove PSR-4 mapping for non-existent code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Joindin\\Api\\": "src/",
-      "Joindin\\Modifier\\": "src/Modifier/"
+      "Joindin\\Api\\": "src/"
     }
   },
   "autoload-dev": {


### PR DESCRIPTION
This PR

* [x] removes a PSR-4 mapping for non-existent code