### PR TITLE
Fix: Do not return anything from constructor

### DIFF
--- a/src/Model/ApiMapper.php
+++ b/src/Model/ApiMapper.php
@@ -39,8 +39,6 @@ class ApiMapper
             $this->_request    = $request;
             $this->website_url = $request->getConfigValue('website_url');
         }
-
-        return true;
     }
 
     public function getDefaultFields()


### PR DESCRIPTION
This PR

* [x] stops attempting to return a value from a constructor