### PR TITLE
Fix: Pass comment directly to SpamCheckService::isCommentAcceptable()

### DIFF
--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -96,7 +96,7 @@ class ContactController extends BaseApiController
         }
 
         if (!$this->spamCheckService->isCommentAcceptable(
-            $data,
+            $data['comment'],
             $request->getClientIP(),
             $request->getClientUserAgent()
         )) {

--- a/src/Controller/EventCommentsController.php
+++ b/src/Controller/EventCommentsController.php
@@ -114,7 +114,7 @@ class EventCommentsController extends BaseApiController
                 $this->config['akismet']['blog']
             );
             $isValid          = $spamCheckService->isCommentAcceptable(
-                $comment,
+                $commentText,
                 $request->getClientIP(),
                 $request->getClientUserAgent()
             );

--- a/src/Controller/TalksController.php
+++ b/src/Controller/TalksController.php
@@ -143,7 +143,7 @@ class TalksController extends BaseTalkController
                                 $this->config['akismet']['blog']
                             );
                             $isValid          = $spamCheckService->isCommentAcceptable(
-                                $data,
+                                $comment,
                                 $request->getClientIP(),
                                 $request->getClientUserAgent()
                             );

--- a/src/Service/NullSpamCheckService.php
+++ b/src/Service/NullSpamCheckService.php
@@ -8,13 +8,13 @@ class NullSpamCheckService implements SpamCheckServiceInterface
     /**
      * Check your comment against the spam check service
      *
-     * @param array  $data
+     * @param string $comment
      * @param string $userIp
      * @param string $userAgent
      *
      * @return bool true if the comment is okay, false if it got rated as spam
      */
-    public function isCommentAcceptable(array $data, $userIp, $userAgent)
+    public function isCommentAcceptable(string $comment, $userIp, $userAgent)
     {
         return true;
     }

--- a/src/Service/SpamCheckService.php
+++ b/src/Service/SpamCheckService.php
@@ -25,15 +25,15 @@ class SpamCheckService implements SpamCheckServiceInterface
     /**
      * Check your comment against the spam check service
      *
-     * @param array  $data
+     * @param string $comment
      * @param string $userIp
      * @param string $userAgent
      *
      * @return bool true if the comment is okay, false if it got rated as spam
      */
-    public function isCommentAcceptable(array $data, $userIp, $userAgent)
+    public function isCommentAcceptable(string $comment, $userIp, $userAgent)
     {
-        if (!array_key_exists('comment', $data) || !is_string($data['comment']) || '' === trim($data['comment'])) {
+        if ('' === trim($comment)) {
             return false;
         }
 
@@ -43,7 +43,7 @@ class SpamCheckService implements SpamCheckServiceInterface
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
         curl_setopt($ch, CURLOPT_POSTFIELDS, [
             'blog' =>  $this->blog,
-            'comment_content' => $data['comment'],
+            'comment_content' => $comment,
             'user_agent' => $userAgent,
             'user_ip' => $userIp,
         ]);

--- a/src/Service/SpamCheckService.php
+++ b/src/Service/SpamCheckService.php
@@ -39,9 +39,9 @@ class SpamCheckService implements SpamCheckServiceInterface
 
         $comment = [
             'blog' =>  $this->blog,
-            'user_ip' => $userIp,
-            'user_agent' => $userAgent,
             'comment_content' => $data['comment'],
+            'user_agent' => $userAgent,
+            'user_ip' => $userIp,
         ];
 
         // actually do the check

--- a/src/Service/SpamCheckService.php
+++ b/src/Service/SpamCheckService.php
@@ -37,18 +37,16 @@ class SpamCheckService implements SpamCheckServiceInterface
             return false;
         }
 
-        $comment = [
-            'blog' =>  $this->blog,
-            'comment_content' => $data['comment'],
-            'user_agent' => $userAgent,
-            'user_ip' => $userIp,
-        ];
-
         // actually do the check
         $ch = curl_init($this->akismetUrl . '/1.1/comment-check');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $comment);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, [
+            'blog' =>  $this->blog,
+            'comment_content' => $data['comment'],
+            'user_agent' => $userAgent,
+            'user_ip' => $userIp,
+        ]);
 
         $result = curl_exec($ch);
         curl_close($ch);

--- a/src/Service/SpamCheckService.php
+++ b/src/Service/SpamCheckService.php
@@ -37,17 +37,12 @@ class SpamCheckService implements SpamCheckServiceInterface
             return false;
         }
 
-        $comment = [];
-
-        // set some required fields
-        $comment['blog'] = $this->blog;
-
-        // TODO what are better values to use for these required fields?
-        $comment['user_ip']    = $userIp;
-        $comment['user_agent'] = $userAgent;
-
-        // now use the incoming data
-        $comment['comment_content'] = $data['comment'];
+        $comment = [
+            'blog' =>  $this->blog,
+            'user_ip' => $userIp,
+            'user_agent' => $userAgent,
+            'comment_content' => $data['comment'],
+        ];
 
         // actually do the check
         $ch = curl_init($this->akismetUrl . '/1.1/comment-check');

--- a/src/Service/SpamCheckServiceInterface.php
+++ b/src/Service/SpamCheckServiceInterface.php
@@ -7,11 +7,11 @@ interface SpamCheckServiceInterface
     /**
      * Check your comment against the spam check service
      *
-     * @param array  $data
+     * @param string $comment
      * @param string $userIp
      * @param string $userAgent
      *
      * @return bool true if the comment is okay, false if it got rated as spam
      */
-    public function isCommentAcceptable(array $data, $userIp, $userAgent);
+    public function isCommentAcceptable(string $comment, $userIp, $userAgent);
 }

--- a/tests/Service/NullSpamCheckServiceTest.php
+++ b/tests/Service/NullSpamCheckServiceTest.php
@@ -10,6 +10,6 @@ class NullSpamCheckServiceTest extends TestCase
     public function testSpamCheckShouldReturnTrue()
     {
         $service = new NullSpamCheckService();
-        $this->assertTrue($service->isCommentAcceptable([], '0.0.0.0', 'userAgent'));
+        $this->assertTrue($service->isCommentAcceptable('foo bar', '0.0.0.0', 'userAgent'));
     }
 }


### PR DESCRIPTION
This PR

* [x] simplifies `SpamCheckService::isCommentAcceptable()`
* [x] passes the comment directly to `SpamCheckService::isCommentAcceptable()`

Blocks #716, because fewer tests need to be written when we can avoid all of these unnecessary checks whether the `$data` argument

- is an array
- contains the `comment` key
- contains a `string` value for the `comment` key
- the value for the `comment` key is a non-blank `string`

Since the only value if interest is the value for the `comment` key, we can pass in the comment directly and avoid all of these checks here.

💁‍♂ Probably best reviewed commit by commit. 