### PR TITLE
Fix: Run 'composer fix'

### DIFF
--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -159,13 +159,13 @@ class UsersControllerTest extends TestCase
                 ['twitter_username'],
                 ['biography']
             )->willReturnOnConsecutiveCalls(
-                'user"\'stuff',
-                'full"\'stuff',
-                'mailstuff@example.com',
-                'pass"\'stuff',
-                'twitter"\'stuff',
-                'Bio"\'stuff'
-            );
+            'user"\'stuff',
+            'full"\'stuff',
+            'mailstuff@example.com',
+            'pass"\'stuff',
+            'twitter"\'stuff',
+            'Bio"\'stuff'
+        );
 
         $view = $this->getMockBuilder(ApiView::class)->disableOriginalConstructor()->getMock();
         $view->expects($this->once())->method('setHeader')->with('Location', 'basepath_info/1');

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -158,14 +158,15 @@ class UsersControllerTest extends TestCase
                 ['password'],
                 ['twitter_username'],
                 ['biography']
-            )->willReturnOnConsecutiveCalls(
-            'user"\'stuff',
-            'full"\'stuff',
-            'mailstuff@example.com',
-            'pass"\'stuff',
-            'twitter"\'stuff',
-            'Bio"\'stuff'
-        );
+            )
+            ->willReturnOnConsecutiveCalls(
+                'user"\'stuff',
+                'full"\'stuff',
+                'mailstuff@example.com',
+                'pass"\'stuff',
+                'twitter"\'stuff',
+                'Bio"\'stuff'
+            );
 
         $view = $this->getMockBuilder(ApiView::class)->disableOriginalConstructor()->getMock();
         $view->expects($this->once())->method('setHeader')->with('Location', 'basepath_info/1');


### PR DESCRIPTION
This PR

* [x] runs `composer fix`
* [x] manually fixes an incorrect wrapping

💁‍♂ The disparity between issues reported by `phpcs` and issues fixed by `phpcbf` is a reason I personally dislike [`squizlabs/php_codesniffer`](https://github.com/squizlabs/PHP_CodeSniffer) and avoid to use it. I used to be a fan years ago, but this is just annoying.