### PR TITLE
Configuration file for PHPStan level 1

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    excludes_analyse:
+        - */public/index.php
+        - */scripts/*
+
+    level: 1
+
+    paths:
+        - src


### PR DESCRIPTION
Excluding public/index.php and the files in the
scripts directory because they don't do things
the way PHPStan would like them.

Also alphabetized parameters.