### PR TITLE
Fix: Require phpstan/phpstan-shim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   },
   "require-dev": {
     "jakub-onderka/php-parallel-lint": "^1.0",
+    "phpstan/phpstan-shim": "~0.11.19",
     "phpunit/phpunit": "^8.3.4",
     "roave/security-advisories": "dev-master",
     "sensiolabs/security-checker": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b2309b5efd72352c53c1dcc41fa16d1",
+    "content-hash": "24c7c4e12746e78b6cfdd605474d3f7c",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1046,6 +1046,50 @@
                 "stub"
             ],
             "time": "2019-10-03T11:07:50+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-shim",
+            "version": "0.11.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-shim.git",
+                "reference": "e3c06b1d63691dae644ae1e5b540905c8c021801"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/e3c06b1d63691dae644ae1e5b540905c8c021801",
+                "reference": "e3c06b1d63691dae644ae1e5b540905c8c021801",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "replace": {
+                "nikic/php-parser": "^4.0.2",
+                "phpstan/phpdoc-parser": "^0.3.3",
+                "phpstan/phpstan": "self.version"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.11-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan Phar distribution",
+            "time": "2019-10-22T20:46:16+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
This PR

* [x] requires `phpstan/phpstan-shim` as a development dependency

🤷‍♂ Yes, it's somehow installed because it's in `composer.lock`, but it's not listed in `composer.json`. Apparently something went wrong here a while ago.