### PR TITLE
Fix: Remove enforceTimeLimit configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
   },
   "require-dev": {
     "jakub-onderka/php-parallel-lint": "^1.0",
-    "phpunit/php-invoker": "^2.0",
     "phpunit/phpunit": "^8.3.4",
     "roave/security-advisories": "dev-master",
     "sensiolabs/security-checker": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c38b2ff8e1b54faf65c6d6cc4a1d5ee5",
+    "content-hash": "0b2309b5efd72352c53c1dcc41fa16d1",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1159,56 +1159,6 @@
                 "iterator"
             ],
             "time": "2018-09-13T20:33:42+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "4a01883f660b10d4a19a14de5efd19b22eac2d93"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/4a01883f660b10d4a19a14de5efd19b22eac2d93",
-                "reference": "4a01883f660b10d4a19a14de5efd19b22eac2d93",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pcntl": "*",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "time": "2018-01-27T06:52:17+00:00"
         },
         {
             "name": "phpunit/php-text-template",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     bootstrap="./tests/bootstrap.php"
     cacheResultFile="build/.phpunit.result.cache"
     colors="true"
-    enforceTimeLimit="true"
     verbose="true"
 >
     <testsuite name="Joind.in Test Suite">


### PR DESCRIPTION
This PR

* [x] removes the `enforceTimeLimit` configuration from `phpunit.xml.dist`
* [x] removes `phpunit/php-invoker`

💁‍♂ Running

```
$ git grep -E '@(large|medium|small)'
```

on current `master` yields nothing. That is, enabling `enforceTimeLimit` does not have any effect, and in turn, `phpunit/php-invoker` is an unused dependency.

For reference, see https://phpunit.readthedocs.io/en/8.4/risky-tests.html#test-execution-timeout.