### PR TITLE
Fix user ID bug

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -413,17 +413,15 @@ class UsersController extends BaseApiController
         if (!isset($request->user_id)) {
             throw new Exception("You must be logged in to delete data", Http::UNAUTHORIZED);
         }
-        // delete the user
-        $userId = $this->getItemId($request);
 
         $userMapper = $this->getUserMapper($db, $request);
 
-        $isAdmin = $userMapper->isSiteAdmin($userId);
+        $isAdmin = $userMapper->isSiteAdmin($request->user_id);
         if (!$isAdmin) {
             throw new Exception("You do not have permission to do that", Http::FORBIDDEN);
         }
 
-        if (!$userMapper->delete($userId)) {
+        if (!$userMapper->delete($this->getItemId($request))) {
             throw new Exception("There was a problem trying to delete the user", Http::BAD_REQUEST);
         }
 

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -25,7 +25,7 @@ class UsersControllerTest extends TestCase
      *
      * @return void
      */
-    public function testDeleteUserWithNoUserIdThrowsException()
+    public function testDeleteUserWithoutBeingLoggedInThrowsException()
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('You must be logged in to delete data');
@@ -67,6 +67,7 @@ class UsersControllerTest extends TestCase
         $userMapper
             ->expects($this->once())
             ->method('isSiteAdmin')
+            ->with(2)
             ->willReturn(false);
 
         $usersController->setUserMapper($userMapper);
@@ -99,11 +100,13 @@ class UsersControllerTest extends TestCase
         $userMapper
             ->expects($this->once())
             ->method('isSiteAdmin')
+            ->with(1)
             ->willReturn(true);
 
         $userMapper
             ->expects($this->once())
             ->method('delete')
+            ->with(3)
             ->willReturn(false);
 
         $usersController->setUserMapper($userMapper);
@@ -133,11 +136,13 @@ class UsersControllerTest extends TestCase
         $userMapper
             ->expects($this->once())
             ->method('isSiteAdmin')
+            ->with(1)
             ->willReturn(true);
 
         $userMapper
             ->expects($this->once())
             ->method('delete')
+            ->with(3)
             ->willReturn(true);
 
         $usersController->setUserMapper($userMapper);


### PR DESCRIPTION
There was a mix-up between the logged in user ID and the user ID that was meant to be deleted. This resulted in an exception, because we were checking if the user to be deleted was an admin user instead of the actual logged in user.