### PR TITLE
Switch previously implicitly declared properties to public visibility

### DIFF
--- a/src/Controller/BaseTalkController.php
+++ b/src/Controller/BaseTalkController.php
@@ -31,14 +31,16 @@ class BaseTalkController extends BaseApiController
      * @var EventMapper
      */
     protected $event_mapper;
+
     /**
      * @var TalkMapper
      */
-    private $talk_mapper;
+    public $talk_mapper;
+
     /**
      * @var UserMapper
      */
-    private $user_mapper;
+    public $user_mapper;
 
     protected function checkLoggedIn(Request $request)
     {

--- a/src/Model/ClientModel.php
+++ b/src/Model/ClientModel.php
@@ -9,7 +9,7 @@ use Joindin\Api\Request;
  */
 class ClientModel extends BaseModel
 {
-    private $id;
+    public $id;
 
     /**
      * Default fields in the output view

--- a/src/Model/EventCommentReportModel.php
+++ b/src/Model/EventCommentReportModel.php
@@ -9,8 +9,8 @@ use Joindin\Api\Request;
  */
 class EventCommentReportModel extends BaseModel
 {
-    private $reporting_user_id;
-    private $event_id;
+    public $reporting_user_id;
+    public $event_id;
 
     /**
      * Default fields in the output view

--- a/src/Model/TalkCommentReportModel.php
+++ b/src/Model/TalkCommentReportModel.php
@@ -9,9 +9,9 @@ use Joindin\Api\Request;
  */
 class TalkCommentReportModel extends BaseModel
 {
-    private $reporting_user_id;
-    private $event_id;
-    private $talk_id;
+    public $reporting_user_id;
+    public $event_id;
+    public $talk_id;
 
     /**
      * Default fields in the output view

--- a/src/Model/TalkModel.php
+++ b/src/Model/TalkModel.php
@@ -9,9 +9,9 @@ use Joindin\Api\Request;
  */
 class TalkModel extends BaseModel
 {
-    private $event_id;
-    private $ID;
-    private $stub;
+    public $event_id;
+    public $ID;
+    public $stub;
 
     /**
      * Default fields in the output view

--- a/src/Model/TokenModel.php
+++ b/src/Model/TokenModel.php
@@ -9,7 +9,7 @@ use Joindin\Api\Request;
  */
 class TokenModel extends BaseModel
 {
-    private $id;
+    public $id;
 
     /**
      * Default fields in the output view

--- a/src/Model/TwitterRequestTokenModel.php
+++ b/src/Model/TwitterRequestTokenModel.php
@@ -9,7 +9,7 @@ use Joindin\Api\Request;
  */
 class TwitterRequestTokenModel extends BaseModel
 {
-    private $ID;
+    public $ID;
 
     /**
      * Default fields in the output view


### PR DESCRIPTION
This resolves the bugged behavior from earlier today. Specifically:

1. As part of code cleanup to hit PHPStan Level 1, #735 explicitly declared properties that had been implicitly set before. One catch: implicit properties are public, but this declaration was private.
2. Talk link building relied on the talk ID property (one of the implicitly set ones) to be public. When it wasn't, links that would have included talk ID included '' instead. For example, /talks//comments instead of /talks/1234/comments.
3. web2 used the talk comments link handed back from the API to grab talk comments on talk page load. Since this was not, in fact, a valid URL (even after some middlebox along the way dropped the extra slash), the API threw back a 405.
4. web2, which assumes that the talk comments endpoint will always return successfully, tried to grab the comments element from what was actually a 405 error response, then iterate over that nonexistent value to show comments, fatal'ing in the process.

So, while a bunch of pieces in this chain were brittle, the quick fix for now is to switch properties back to being public, matching their behavior from implicit declaration. Creating a follow-on issue to get the properties back to private once we've made sure that every external or descendant consumer of these properties does the consumption via a getter (or updates via a setter).