### PR TITLE
Let model property accesses fall back to magic getter

### DIFF
--- a/src/Model/ClientModel.php
+++ b/src/Model/ClientModel.php
@@ -9,8 +9,6 @@ use Joindin\Api\Request;
  */
 class ClientModel extends BaseModel
 {
-    public $id;
-
     /**
      * Default fields in the output view
      *

--- a/src/Model/EventCommentReportModel.php
+++ b/src/Model/EventCommentReportModel.php
@@ -9,9 +9,6 @@ use Joindin\Api\Request;
  */
 class EventCommentReportModel extends BaseModel
 {
-    public $reporting_user_id;
-    public $event_id;
-
     /**
      * Default fields in the output view
      *

--- a/src/Model/TalkCommentReportModel.php
+++ b/src/Model/TalkCommentReportModel.php
@@ -9,10 +9,6 @@ use Joindin\Api\Request;
  */
 class TalkCommentReportModel extends BaseModel
 {
-    public $reporting_user_id;
-    public $event_id;
-    public $talk_id;
-
     /**
      * Default fields in the output view
      *

--- a/src/Model/TalkModel.php
+++ b/src/Model/TalkModel.php
@@ -9,10 +9,6 @@ use Joindin\Api\Request;
  */
 class TalkModel extends BaseModel
 {
-    public $event_id;
-    public $ID;
-    public $stub;
-
     /**
      * Default fields in the output view
      *

--- a/src/Model/TokenModel.php
+++ b/src/Model/TokenModel.php
@@ -9,8 +9,6 @@ use Joindin\Api\Request;
  */
 class TokenModel extends BaseModel
 {
-    public $id;
-
     /**
      * Default fields in the output view
      *

--- a/src/Model/TwitterRequestTokenModel.php
+++ b/src/Model/TwitterRequestTokenModel.php
@@ -9,8 +9,6 @@ use Joindin\Api\Request;
  */
 class TwitterRequestTokenModel extends BaseModel
 {
-    public $ID;
-
     /**
      * Default fields in the output view
      *


### PR DESCRIPTION
So, I mis-diagnosed part of what was going on in #747.

While things were failing due to explicitly declared variables, they were failing not because they had been implicitly declared before (for models, anyway) but because models use __get to grab properties from an internal array...even for accesses within the model (e.g. for building links).

As a result, declaring properties, private or otherwise, "shadowed" the magic getter that would've been called for those same properties, creating the issue that we saw. So the solution here is to let the magic getter do its job (though we may add explicit getters later) by dropping the explicit properties on these models.

This reduces the scope of #748.