### PR TITLE
Privatize mapper properties for BaseTalkController

### DIFF
--- a/src/Controller/BaseTalkController.php
+++ b/src/Controller/BaseTalkController.php
@@ -35,12 +35,12 @@ class BaseTalkController extends BaseApiController
     /**
      * @var TalkMapper
      */
-    public $talk_mapper;
+    private $talk_mapper;
 
     /**
      * @var UserMapper
      */
-    public $user_mapper;
+    private $user_mapper;
 
     protected function checkLoggedIn(Request $request)
     {


### PR DESCRIPTION
Resolves #748. Confirmed that child controllers use getters on both of these mappers so they're save to make private rather than protected.