### PR TITLE
Fix: Remove unnecessary arguments and options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "lint": "parallel-lint --exclude vendor .",
     "security": "security-checker security:check composer.lock",
     "sniff": "phpcs --cache=build/.phpcs-cache --runtime-set ignore_warnings_on_exit true -p .",
-    "test": "phpunit -c . tests/"
+    "test": "phpunit"
   },
   "support": {
     "issues": "https://github.com/joindin/joindin-api/issues",


### PR DESCRIPTION
This PR

* [x] removes unnecessary arguments and options when invoking `phpunit` from the corresponding `composer` script