### PR TITLE
Fix: Actually collect coverage in coverage script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ before_script:
 
 script:
   - composer check
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # joindin-api
 
 [![Build Status](https://travis-ci.org/joindin/joindin-api.svg?branch=master)](https://travis-ci.org/joindin/joindin-api)
+[![codecov](https://codecov.io/gh/joindin/joindin-api/branch/master/graph/badge.svg)](https://codecov.io/gh/joindin/joindin-api)
 
 This is the API behind the joind.in website (the new version of it), the mobile applications, and many other consumers.  This project is a dependency for the majority of the other projects under the joind.in organization https://github.com/joindin
 

--- a/composer.json
+++ b/composer.json
@@ -56,8 +56,8 @@
       "@test"
     ],
     "coverage": [
-      "git diff origin/master... -- > diff.txt",
-      "diffFilter --phpunit diff.txt build/logs/clover.xml 80"
+      "phpunit --dump-xdebug-filter=build/xdebug-filter.php",
+      "phpunit --coverage-clover=build/logs/clover.xml --coverage-text --prepend=build/xdebug-filter.php"
     ],
     "fix": "phpcbf -p .",
     "lint": "parallel-lint --exclude vendor .",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
       "@lint",
       "@sniff",
       "@security",
-      "@test"
+      "@coverage"
     ],
     "coverage": [
       "phpunit --dump-xdebug-filter=build/xdebug-filter.php",


### PR DESCRIPTION
This PR

* [x] actually collects useful coverage information in the `coverage` script
* [x] runs the `coverage` script instead of the `test` script in the `check` script
* [x] sends code coverage information to https://codecov.io

💁‍♂ Not sure whether you have a preference for a service that collects code coverage information, but codecov is rather simple to set up and has nice coverage reports (with diffs) in pull requests, when enabled. 

Please take a look at 

* https://github.com/marketplace/codecov
* https://codecov.io/gh/joindin/joindin-api

as this needs setup from the maintainers' side.