### PR TITLE
Fix: Inject SpamCheckService into controllers

### DIFF
--- a/src/ContainerFactory.php
+++ b/src/ContainerFactory.php
@@ -85,8 +85,11 @@ class ContainerFactory
                 return new EmailsController($config);
             });
 
-            $container[EventCommentsController::class] = $container->factory(function ($c) use ($config) {
-                return new EventCommentsController($config);
+            $container[EventCommentsController::class] = $container->factory(static function ($container) use ($config): EventCommentsController {
+                return new EventCommentsController(
+                    $container[SpamCheckServiceInterface::class],
+                    $config
+                );
             });
 
             $container[EventHostsController::class] = $container->factory(function ($c) use ($config) {
@@ -117,8 +120,11 @@ class ContainerFactory
                 return new TalkLinkController($config);
             });
 
-            $container[TalksController::class] = $container->factory(function ($c) use ($config) {
-                return new TalksController($config);
+            $container[TalksController::class] = $container->factory(static function ($container) use ($config): TalksController {
+                return new TalksController(
+                    $container[SpamCheckServiceInterface::class],
+                    $config
+                );
             });
 
             $container[TalkTypesController::class] = $container->factory(function ($c) use ($config) {

--- a/tests/Controller/TalksControllerDeleteTest.php
+++ b/tests/Controller/TalksControllerDeleteTest.php
@@ -5,6 +5,7 @@ namespace Joindin\Api\Test\Controller;
 use Exception;
 use Joindin\Api\Controller\TalksController;
 use Joindin\Api\Request;
+use Joindin\Api\Service\NullSpamCheckService;
 use Joindin\Api\View\ApiView;
 use JoindinTest\Inc\mockPDO;
 use Teapot\StatusCode\Http;
@@ -27,7 +28,8 @@ class TalksControllerDeleteTest extends TalkBase
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->removeStarFromTalk($request, $db);
     }
 
@@ -52,7 +54,8 @@ class TalksControllerDeleteTest extends TalkBase
         $this->talkMapper->method('setUserNonStarred')
             ->willReturn(true);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setTalkMapper($this->talkMapper);
 
         $talks_controller->removeStarFromTalk($request, $db);
@@ -74,7 +77,8 @@ class TalksControllerDeleteTest extends TalkBase
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->deleteTalk($request, $db);
     }
 
@@ -100,7 +104,8 @@ class TalksControllerDeleteTest extends TalkBase
             ->method('getTalkById')
             ->willReturn(false);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setTalkMapper($this->talk_mapper);
 
         $view = $this->getMockBuilder(ApiView::class)->getMock();
@@ -136,7 +141,8 @@ class TalksControllerDeleteTest extends TalkBase
 
         $talk_mapper = $this->createTalkMapper($db, $request);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setTalkMapper($talk_mapper);
 
 
@@ -165,7 +171,8 @@ class TalksControllerDeleteTest extends TalkBase
             ->method('thisUserHasAdminOn')
             ->willReturn(true);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setTalkMapper($this->talk_mapper);
 
         $view = $this->getMockBuilder(ApiView::class)->getMock();

--- a/tests/Controller/TalksControllerTest.php
+++ b/tests/Controller/TalksControllerTest.php
@@ -10,6 +10,8 @@ use Joindin\Api\Model\TalkMapper;
 use Joindin\Api\Model\TalkModelCollection;
 use Joindin\Api\Model\UserMapper;
 use Joindin\Api\Request;
+use Joindin\Api\Service\NullSpamCheckService;
+use Joindin\Api\Service\SpamCheckServiceInterface;
 use Joindin\Api\Service\TalkCommentEmailService;
 use JoindinTest\Inc\mockPDO;
 use Teapot\StatusCode\Http;
@@ -55,7 +57,8 @@ class TalksControllerTest extends TalkBase
             ]
         );
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $talks_controller->setSpeakerForTalk($request, $db);
@@ -83,7 +86,8 @@ class TalksControllerTest extends TalkBase
 
         $request->user_id = 2;
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
 
@@ -129,7 +133,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'Jane Bloggs'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -170,7 +175,8 @@ class TalksControllerTest extends TalkBase
             'username'  => 'janebloggs'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -211,7 +217,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  =>  'P Sherman'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -255,7 +262,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -302,7 +310,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -367,7 +376,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -414,7 +424,11 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'Jane Bloggs'
         ];
 
-        $talks_controller = new TalksController($this->config);
+        $talks_controller = new TalksController(
+            new NullSpamCheckService(),
+            $this->config
+        );
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -475,7 +489,11 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new TalksController($this->config);
+        $talks_controller = new TalksController(
+            new NullSpamCheckService(),
+            $this->config
+        );
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -541,7 +559,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'Jane Bloggs'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -604,7 +623,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'Jane Bloggs'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -668,7 +688,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'P Sherman'
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -723,7 +744,8 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'Jane Bloggs',
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -789,7 +811,11 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'P Sherman',
         ];
 
-        $talks_controller = new TalksController($this->config);
+        $talks_controller = new TalksController(
+            new NullSpamCheckService(),
+            $this->config
+        );
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -869,18 +895,24 @@ class TalksControllerTest extends TalkBase
 
         $talks_comment_email->method('sendEmail');
 
-        $talks_controller = $this->getMockBuilder(TalksController::class)
-            ->setMethods(['getTalkCommentEmailService'])
-            ->getMock();
+        $talks_controller = new class(new NullSpamCheckService(), $talks_comment_email) extends TalksController {
+            private $talkCommentEmailService;
 
-        $talks_controller
-            ->method('getTalkCommentEmailService')
-            ->with(
-                $this->anything(),
-                $expectedEmailsSent,
-                $this->anything(),
-                $this->anything()
-            )->willReturn($talks_comment_email);
+            public function __construct(
+                SpamCheckServiceInterface $spamCheckService,
+                TalkCommentEmailService $talkCommentEmailService,
+                array $config = []
+            ) {
+                parent::__construct($spamCheckService, $config);
+
+                $this->talkCommentEmailService = $talkCommentEmailService;
+            }
+
+            public function getTalkCommentEmailService($config, $recipients, $talk, $comment)
+            {
+                return $this->talkCommentEmailService;
+            }
+        };
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
@@ -965,7 +997,8 @@ class TalksControllerTest extends TalkBase
             ]
         );
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
-        $talks_controller = new TalksController();
+
+        $talks_controller = new TalksController(new NullSpamCheckService());
 
         $talks_controller->postAction($request, $db);
     }
@@ -993,7 +1026,7 @@ class TalksControllerTest extends TalkBase
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
 
         $talks_controller->setTalkMapper($this->talk_mapper);
 
@@ -1023,7 +1056,7 @@ class TalksControllerTest extends TalkBase
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
 
         $talks_controller->setTalkMapper($this->talk_mapper);
 
@@ -1050,7 +1083,11 @@ class TalksControllerTest extends TalkBase
             'display_name'  => 'P Sherman',
         ];
 
-        $talks_controller = new TalksController($this->config);
+        $talks_controller = new TalksController(
+            new NullSpamCheckService(),
+            $this->config
+        );
+
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
         $this->talk_mapper = $this->createTalkMapper($db, $request);
@@ -1157,7 +1194,8 @@ class TalksControllerTest extends TalkBase
             ['code_link' => 'https://github.com'],
         ];
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setTalkMapper($this->talk_mapper);
 
         $output = $talks_controller->getAction($request, $db);
@@ -1198,7 +1236,8 @@ class TalksControllerTest extends TalkBase
         $talkComment->method('getCommentsByTalkId')
             ->willReturn($expected);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setMapper(
             'talkcomment',
             $talkComment
@@ -1228,7 +1267,8 @@ class TalksControllerTest extends TalkBase
         $talkMapper->method('getUserStarred')
             ->willReturn($expected);
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setMapper(
             'talk',
             $talkMapper
@@ -1278,7 +1318,8 @@ class TalksControllerTest extends TalkBase
             ->willReturn($collection);
 
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
+
         $talks_controller->setMapper(
             'talk',
             $talkMapper
@@ -1304,7 +1345,7 @@ class TalksControllerTest extends TalkBase
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
 
-        $talks_controller = new TalksController();
+        $talks_controller = new TalksController(new NullSpamCheckService());
 
         $talks_controller->getTalkByKeyWord($request, $db);
     }


### PR DESCRIPTION
This PR

* [x] injects implementations of the `SpamCheckServiceInterface` into, rather than creating them in dependent services

❗️Blocks #716.

