### PR TITLE
Fix: Configure path to cache file via phpcs.xml.dist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "fix": "phpcbf -p .",
     "lint": "parallel-lint --exclude vendor .",
     "security": "security-checker security:check composer.lock",
-    "sniff": "phpcs --cache=build/.phpcs-cache --runtime-set ignore_warnings_on_exit true -p .",
+    "sniff": "phpcs --runtime-set ignore_warnings_on_exit true -p .",
     "stan": "phpstan analyze --configuration=phpstan.neon",
     "test": "phpunit"
   },

--- a/composer.json
+++ b/composer.json
@@ -61,10 +61,16 @@
       "phpunit --dump-xdebug-filter=build/xdebug-filter.php",
       "phpunit --coverage-clover=build/logs/clover.xml --coverage-text --prepend=build/xdebug-filter.php"
     ],
-    "fix": "phpcbf -p .",
+    "fix": [
+      "mkdir -p build/",
+      "phpcbf -p ."
+    ],
     "lint": "parallel-lint --exclude vendor .",
     "security": "security-checker security:check composer.lock",
-    "sniff": "phpcs --runtime-set ignore_warnings_on_exit true -p .",
+    "sniff": [
+      "mkdir -p build/",
+      "phpcs --runtime-set ignore_warnings_on_exit true -p ."
+    ],
     "stan": "phpstan analyze --configuration=phpstan.neon",
     "test": "phpunit"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,7 @@
  <exclude-pattern>vendor</exclude-pattern>
 
  <arg name="basepath" value="."/>
- <arg name="cache" value=".phpcs-cache"/>
+ <arg name="cache" value="build/.phpcs-cache "/>
  <arg name="colors"/>
  <arg name="extensions" value="php"/>
 


### PR DESCRIPTION
This PR

* [x] configures the path to the cache file used by `phpcs` via `phpcs.xml.dist`
* [x] ensures that the `build` directory exists in the `fix` and `sniff` scripts