### PR TITLE
Fix: Cache directory for composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ dist: trusty
 
 cache:
   directories:
-    - $HOME/.composer/cache/files
-    - $HOME/.cache/composer/files
+    - $HOME/.composer/cache
 
 matrix:
   include:


### PR DESCRIPTION
This PR

* [x] fixes the cache directories used by `composer` on Travis