### PR TITLE
Fix: Mark test classes as final

### DIFF
--- a/tests/ContainerFactoryTest.php
+++ b/tests/ContainerFactoryTest.php
@@ -9,7 +9,7 @@ use Joindin\Api\Service\SpamCheckServiceInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class ContainerFactoryTest extends TestCase
+final class ContainerFactoryTest extends TestCase
 {
     private $config = [
         'akismet' => [

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -13,7 +13,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 use Teapot\StatusCode\Http;
 
-class ContactControllerTest extends TestCase
+final class ContactControllerTest extends TestCase
 {
     /**
      * @dataProvider dataProvider

--- a/tests/Controller/EventHostsControllerTest.php
+++ b/tests/Controller/EventHostsControllerTest.php
@@ -13,7 +13,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 use Teapot\StatusCode\Http;
 
-class EventHostsControllerTest extends TestCase
+final class EventHostsControllerTest extends TestCase
 {
     public function testThatNotLoggedInUsersCanNotAddAHost()
     {

--- a/tests/Controller/TalkLinkControllerTest.php
+++ b/tests/Controller/TalkLinkControllerTest.php
@@ -8,7 +8,7 @@ use Joindin\Api\Request;
 use JoindinTest\Inc\mockPDO;
 use Teapot\StatusCode\Http;
 
-class TalkLinkControllerTest extends TalkBase
+final class TalkLinkControllerTest extends TalkBase
 {
     /**
      * Test sending delete link where the link id is not found

--- a/tests/Controller/TalksControllerDeleteTest.php
+++ b/tests/Controller/TalksControllerDeleteTest.php
@@ -9,7 +9,7 @@ use Joindin\Api\View\ApiView;
 use JoindinTest\Inc\mockPDO;
 use Teapot\StatusCode\Http;
 
-class TalksControllerDeleteTest extends TalkBase
+final class TalksControllerDeleteTest extends TalkBase
 {
     public function testRemoveStarFromTalkFailsWhenNotLoggedIn()
     {

--- a/tests/Controller/TalksControllerTest.php
+++ b/tests/Controller/TalksControllerTest.php
@@ -15,7 +15,7 @@ use JoindinTest\Inc\mockPDO;
 use Teapot\StatusCode\Http;
 use Teapot\StatusCode\WebDAV;
 
-class TalksControllerTest extends TalkBase
+final class TalksControllerTest extends TalkBase
 {
     private $config;
 

--- a/tests/Controller/TokenControllerTest.php
+++ b/tests/Controller/TokenControllerTest.php
@@ -9,7 +9,7 @@ use PDO;
 use PHPUnit\Framework\TestCase;
 use Teapot\StatusCode\Http;
 
-class TokenControllerTest extends TestCase
+final class TokenControllerTest extends TestCase
 {
     private $request;
 

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Teapot\StatusCode\Http;
 
-class UsersControllerTest extends TestCase
+final class UsersControllerTest extends TestCase
 {
 
     /**

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -5,7 +5,7 @@ namespace Joindin\Api\Test;
 use Joindin\Api\Header;
 use PHPUnit\Framework\TestCase;
 
-class HeaderTest extends TestCase
+final class HeaderTest extends TestCase
 {
     public function testParseParamsWithEmbededSeparator()
     {

--- a/tests/Model/ApiMapperTest.php
+++ b/tests/Model/ApiMapperTest.php
@@ -13,7 +13,7 @@ use ReflectionClass;
 /**
  *
  */
-class ApiMapperTest extends TestCase
+final class ApiMapperTest extends TestCase
 {
     public function setup(): void
     {

--- a/tests/Model/EventHostMapperTest.php
+++ b/tests/Model/EventHostMapperTest.php
@@ -8,7 +8,7 @@ use PDO;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 
-class EventHostMapperTest extends TestCase
+final class EventHostMapperTest extends TestCase
 {
     public function testThatAddingHostToEventCallsExpectedInsert()
     {

--- a/tests/Model/OauthModelTest.php
+++ b/tests/Model/OauthModelTest.php
@@ -10,7 +10,7 @@ use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Teapot\StatusCode\Http;
 
-class OauthModelTest extends TestCase
+final class OauthModelTest extends TestCase
 {
     public function setup(): void
     {

--- a/tests/Model/TalkMapperTest.php
+++ b/tests/Model/TalkMapperTest.php
@@ -7,7 +7,7 @@ use JoindinTest\Inc\mockPDO;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 
-class TalkMapperTest extends TestCase
+final class TalkMapperTest extends TestCase
 {
     public function testMediaTypesAreAddedCorrectly()
     {

--- a/tests/Model/TestApiMapper.php
+++ b/tests/Model/TestApiMapper.php
@@ -4,7 +4,7 @@ namespace Joindin\Api\Test\Model;
 
 use Joindin\Api\Model\ApiMapper;
 
-class TestApiMapper extends ApiMapper
+final class TestApiMapper extends ApiMapper
 {
     public function getDefaultFields()
     {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -5,7 +5,7 @@ use Joindin\Api\Request;
 use PHPUnit\Framework\TestCase;
 use Teapot\StatusCode\Http;
 
-class RequestTest extends TestCase
+final class RequestTest extends TestCase
 {
     /**
      * Make sure we have everything we need - in this case the config

--- a/tests/Router/ApiRouterTest.php
+++ b/tests/Router/ApiRouterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \Joindin\Api\Router\ApiRouter
  */
-class ApiRouterTest extends TestCase
+final class ApiRouterTest extends TestCase
 {
     /**
      * DataProvider for testGetSetRouters

--- a/tests/Router/DefaultRouterTest.php
+++ b/tests/Router/DefaultRouterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \Joindin\Api\Router\DefaultRouter
  */
-class DefaultRouterTest extends TestCase
+final class DefaultRouterTest extends TestCase
 {
 
     /**

--- a/tests/Router/RouteTest.php
+++ b/tests/Router/RouteTest.php
@@ -14,7 +14,7 @@ use Teapot\StatusCode\Http;
  *
  * @covers \Joindin\Api\Router\Route
  */
-class RouteTest extends TestCase
+final class RouteTest extends TestCase
 {
 
     /**

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \Joindin\Api\Router\BaseRouter
  */
-class RouterTest extends TestCase
+final class RouterTest extends TestCase
 {
 
     /**

--- a/tests/Router/TestController3.php
+++ b/tests/Router/TestController3.php
@@ -4,7 +4,7 @@ namespace Joindin\Api\Test\Router;
 
 use Joindin\Api\Request;
 
-class TestController3
+final class TestController3
 {
     public function action(Request $request, $db)
     {

--- a/tests/Router/TestRouter3.php
+++ b/tests/Router/TestRouter3.php
@@ -7,7 +7,7 @@ use Joindin\Api\Request;
 use Joindin\Api\Router\BaseRouter;
 use Joindin\Api\Router\Route;
 
-class TestRouter3 extends BaseRouter
+final class TestRouter3 extends BaseRouter
 {
 
 

--- a/tests/Router/VersionedRouterTest.php
+++ b/tests/Router/VersionedRouterTest.php
@@ -13,7 +13,7 @@ use Teapot\StatusCode\Http;
  *
  * @covers \Joindin\Api\Router\VersionedRouter
  */
-class VersionedRouterTest extends TestCase
+final class VersionedRouterTest extends TestCase
 {
 
     /**

--- a/tests/Service/NullSpamCheckServiceTest.php
+++ b/tests/Service/NullSpamCheckServiceTest.php
@@ -5,7 +5,7 @@ namespace Joindin\Api\Test\Service;
 use Joindin\Api\Service\NullSpamCheckService;
 use PHPUnit\Framework\TestCase;
 
-class NullSpamCheckServiceTest extends TestCase
+final class NullSpamCheckServiceTest extends TestCase
 {
     public function testSpamCheckShouldReturnTrue()
     {

--- a/tests/Service/TalkCommentEmailServiceTest.php
+++ b/tests/Service/TalkCommentEmailServiceTest.php
@@ -6,7 +6,7 @@ use Joindin\Api\Model\TalkModel;
 use Joindin\Api\Service\TalkCommentEmailService;
 use PHPUnit\Framework\TestCase;
 
-class TalkCommentEmailServiceTest extends Testcase
+final class TalkCommentEmailServiceTest extends Testcase
 {
     protected $config = [
         'email' => [

--- a/tests/View/ApiViewTest.php
+++ b/tests/View/ApiViewTest.php
@@ -9,7 +9,7 @@ use Teapot\StatusCode\Http;
 /**
  * @covers \Joindin\Api\View\ApiView
  */
-class ApiViewTest extends TestCase
+final class ApiViewTest extends TestCase
 {
     /**
      * @runInSeparateProcess

--- a/tests/View/JsonViewTest.php
+++ b/tests/View/JsonViewTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers \Joindin\Api\View\JsonView
  */
-class JsonViewTest extends TestCase
+final class JsonViewTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
This PR

* [x] marks test classes as `final`

💁‍♂ There's probably no reason to extend from these classes.