### PR TITLE
Fix: Mark class as abstract

### DIFF
--- a/tests/Controller/TalkBase.php
+++ b/tests/Controller/TalkBase.php
@@ -12,7 +12,7 @@ use Joindin\Api\Request;
 use JoindinTest\Inc\mockPDO;
 use PHPUnit\Framework\TestCase;
 
-class TalkBase extends TestCase
+abstract class TalkBase extends TestCase
 {
     protected $talk_mapper;
 

--- a/tests/Controller/TalkBase.php
+++ b/tests/Controller/TalkBase.php
@@ -26,7 +26,7 @@ abstract class TalkBase extends TestCase
         parent::setUp();
     }
 
-    protected function createTalkMapper(mockPDO $db, Request $request, $expectedCalls = 1)
+    final protected function createTalkMapper(mockPDO $db, Request $request, $expectedCalls = 1)
     {
         $talk_mapper = $this->getMockBuilder(TalkMapper::class)
             ->setConstructorArgs([$db,$request])
@@ -56,7 +56,7 @@ abstract class TalkBase extends TestCase
         return $talk_mapper;
     }
 
-    protected function createVerboseTalkMapper(mockPDO $db, Request $request)
+    final protected function createVerboseTalkMapper(mockPDO $db, Request $request)
     {
         $talk_mapper = $this->getMockBuilder(TalkMapper::class)
             ->setConstructorArgs([$db,$request])
@@ -91,7 +91,7 @@ abstract class TalkBase extends TestCase
         return $talk_mapper;
     }
 
-    protected function createUserMapper(mockPDO $db, Request $request)
+    final protected function createUserMapper(mockPDO $db, Request $request)
     {
         $user_mapper = $this->getMockBuilder(UserMapper::class)
             ->setConstructorArgs([$db,$request])
@@ -112,7 +112,7 @@ abstract class TalkBase extends TestCase
         return $user_mapper;
     }
 
-    protected function createEventMapper(mockPDO $db, Request $request)
+    final protected function createEventMapper(mockPDO $db, Request $request)
     {
         $event_mapper = $this->getMockBuilder(EventMapper::class)
             ->setConstructorArgs([$db,$request])
@@ -137,14 +137,14 @@ abstract class TalkBase extends TestCase
         return $event_mapper;
     }
 
-    protected function createTalkCommentMapper(mockPDO $db, Request $request)
+    final protected function createTalkCommentMapper(mockPDO $db, Request $request)
     {
         return $this->getMockBuilder(TalkCommentMapper::class)
             ->setConstructorArgs([$db,$request])
             ->getMock();
     }
 
-    protected function createOathModel(mockPDO $db, Request $request, $consumerName = "")
+    final protected function createOathModel(mockPDO $db, Request $request, $consumerName = "")
     {
         $oathModel = $this->getMockBuilder(OAuthModel::class)
             ->setConstructorArgs([$db,$request])


### PR DESCRIPTION
This PR

* [x] marks what appears to be an abstract test case as `abstract`
* [x] marks `protected` method declared in this `abstract` test case and never overridden by extending classes as `final`