### PR TITLE
Fix: List build steps instead of running 'composer check' on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,16 @@ install:
   - composer install
 
 before_script:
+  - mkdir -p build/logs
   - cp src/config.php.dist src/config.php
 
 script:
-  - composer check
+  - vendor/bin/parallel-lint --exclude vendor .
+  - vendor/bin/phpcs --runtime-set ignore_warnings_on_exit true -p .
+  - vendor/bin/phpstan analyze --configuration=phpstan.neon
+  - vendor/bin/security-checker security:check composer.lock
+  - vendor/bin/phpunit --dump-xdebug-filter=build/xdebug-filter.php
+  - vendor/bin/phpunit --coverage-clover=build/logs/clover.xml --coverage-text --prepend=build/xdebug-filter.php
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR

* [x] lists the individual build steps instead of running `composer check` on Travis

💁‍♂ Yes, this brings a bit of duplication, but it also makes it more transparent which steps we run, and which step exactly failed.
