### PR TITLE
Fix: Drop phpstan level from 5 to 4

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
 
     inferPrivatePropertyTypeFromConstructor: true
 
-    level: 5
+    level: 4
 
     paths:
         - inc


### PR DESCRIPTION
This PR

* [x] reverts #773 

💁‍♂ This one wasn't ready yet - as pointed out, it fails when running locally, but it passes when running on Travis (which is rather odd).