### PR TITLE
Unit tests for Header class

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -90,7 +90,7 @@ class Header
         for ($i = 0, $total = count($values); $i < $total; $i++) {
             if (strpos($values[$i], $this->glue) !== false) {
                 // Explode on glue when the glue is not inside of a comma
-                foreach (preg_split('/' . preg_quote($this->glue) . '(?=([^"]*"[^"]*")*[^"]*$)/', $values[$i]) as $v) {
+                foreach (preg_split('/' . preg_quote($this->glue, '/') . '(?=([^"]*"[^"]*")*[^"]*$)/', $values[$i]) as $v) {
                     $values[] = trim($v);
                 }
                 unset($values[$i]);
@@ -104,7 +104,7 @@ class Header
 
     public function hasValue($searchValue)
     {
-        return in_array($searchValue, $this->toArray());
+        return in_array($searchValue, $this->toArray(), false);
     }
 
     public function removeValue($searchValue)
@@ -142,7 +142,7 @@ class Header
         foreach ($this->values as $value) {
             $parts = explode('=', $value);
             $key   = ucwords($parts[0]);
-            if (count($parts) == 1) {
+            if (count($parts) === 1) {
                 if (array_key_exists(0, $assocArray)) {
                     $assocArray[0][] = $parts[0];
                 } else {
@@ -173,7 +173,7 @@ class Header
                     continue;
                 }
                 $pieces           = array_map($callback, $matches[0]);
-                $part[$pieces[0]] = isset($pieces[1]) ? $pieces[1] : '';
+                $part[$pieces[0]] = $pieces[1] ?? '';
             }
             if ($part) {
                 $params[] = $part;

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -10,26 +10,38 @@ final class HeaderTest extends TestCase
     public function testParseParamsWithEmbededSeparator()
     {
         $headerStr = 'For=10.0.0.1,For=10.0.0.2;user-agent="test;test;test;test";For=10.0.0.3';
-        $header = new Header('Forwarded', $headerStr, ';');
+        $header    = new Header('Forwarded', $headerStr, ';');
 
         $header->parseParams();
         $this->assertEquals(3, $header->count());
     }
+
     public function testParseParamsWithTwoGlues()
     {
         $headerStr = 'For=10.0.0.1,For=10.0.0.2;user-agent="test;test;test;test";For=10.0.0.3;user-agent="secondLevel;some date"';
-        $header = new Header('Forwarded', $headerStr, ';');
+        $header    = new Header('Forwarded', $headerStr, ';');
 
         $header->parseParams();
         $header->setGlue(',');
         $header->parseParams();
         $this->assertEquals(5, $header->count());
+        $this->assertEquals(
+            [
+                'user-agent="test;test;test;test"',
+                'For=10.0.0.3',
+                'user-agent="secondLevel;some date"',
+                'For=10.0.0.1',
+                'For=10.0.0.2',
+            ],
+            $header->toArray()
+        );
     }
+
     public function testBuildEntityArray()
     {
         $headerStr = 'For=10.0.0.1;user-agent="test;test;test;test";For=10.0.0.2;user-agent="secondLevel;
         some date";for=10.0.0.3;user-agent="thirdLevel"';
-        $header = new Header('Forwarded', $headerStr, ';');
+        $header    = new Header('Forwarded', $headerStr, ';');
 
         $header->parseParams();
         $header->setGlue(',');
@@ -38,15 +50,138 @@ final class HeaderTest extends TestCase
         $this->assertCount(3, $entityArray['For']);
         $this->assertCount(3, $entityArray['User-agent']);
     }
+
     public function testBuildEntityArrayWithValueOnly()
     {
         $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
-        $header = new Header('X-Forwarded-For', $headerStr, ',');
+        $header    = new Header('X-Forwarded-For', $headerStr, ',');
         $header->parseParams();
         $this->assertEquals(3, $header->count());
         $partsArray = $header->toArray();
         $this->assertEquals('10.0.0.1', $partsArray[0]);
         $entityArray = $header->buildEntityArray();
         $this->assertCount(3, $entityArray[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function getNameReturnsTheHeaderName()
+    {
+        $name   = uniqid('headername', true);
+        $header = new Header($name, '', ',');
+        $this->assertEquals($name, $header->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function getGlueReturnsGlueValue()
+    {
+        $glue   = uniqid('glue', true);
+        $header = new Header('X-Forwarded-For', '', $glue);
+        $this->assertEquals($glue, $header->getGlue());
+    }
+
+    /**
+     * @test
+     */
+    public function getIteratorWorks()
+    {
+        $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
+        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header->parseParams();
+        $iterator = $header->getIterator();
+
+        $values = [];
+        foreach ($iterator as $value) {
+            $values[] = $value;
+        }
+        $this->assertEquals('10.0.0.1', $values[0]);
+        $this->assertEquals('10.0.0.2', $values[1]);
+        $this->assertEquals('10.0.0.3', $values[2]);
+    }
+
+    /**
+     * @test
+     */
+    public function toStringWorks()
+    {
+        $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
+        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $this->assertEquals($headerStr, (string)$header);
+        $header->parseParams();
+        $this->assertEquals('10.0.0.1, 10.0.0.2, 10.0.0.3', (string)$header);
+    }
+
+    /**
+     * @test
+     */
+    public function removeValueWorks()
+    {
+        $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
+        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header->parseParams();
+        $header->removeValue('10.0.0.2');
+        $this->assertEquals(['10.0.0.1', '10.0.0.3'], $header->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function hasValueReturnsTrueIfValueFound()
+    {
+        $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
+        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header->parseParams();
+        $this->assertTrue($header->hasValue('10.0.0.1'));
+        $this->assertTrue($header->hasValue('10.0.0.2'));
+        $this->assertTrue($header->hasValue('10.0.0.3'));
+    }
+
+    /**
+     * @test
+     */
+    public function hasValueReturnsFalseIfValueNotFound()
+    {
+        $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
+        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header->parseParams();
+        $this->assertFalse($header->hasValue('10.0.0.4'));
+    }
+
+    /**
+     * @test
+     */
+    public function setNameCanBeUsedAfterHeadersAreCreated()
+    {
+        $headerStr = 'application/json';
+        $header    = new Header('Accept', $headerStr, '/');
+        $this->assertEquals('Accept', $header->getName());
+        $header->setName('Content-Type');
+        $this->assertEquals('Content-Type', $header->getName());
+        $header->parseParams();
+        $this->assertEquals(['application', 'json'], $header->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function coverageForParseParams()
+    {
+        $headerChunks = [
+            ';abc',
+        ];
+        $header       = new Header('Foo', $headerChunks, ';');
+        $header->parseParams();
+        $header->setGlue('=');
+        $header->parseParams();
+        $this->assertEquals(
+            [
+                '',
+                'abc',
+            ],
+            $header->toArray()
+        );
     }
 }


### PR DESCRIPTION
This gets the Header class to 100% code coverage -- but...

The class appears to be a copy, or really close to a copy of the Guzzle 3 Header class. It might be good to go ahead and just use Guzzle's code via composer (although maybe not Guzzle 3).

The final test (coverageForParseParams) is there solely to hit coverage for the continue line for Header.php line 173 in the parseParams method. But it's a garbage test in that it doesn't help me or likely anyone else know or understand how parseParams works or should be used.