### PR TITLE
Enhancement: Show actually installed dependencies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - composer install
 
 before_script:
+  - composer show
   - mkdir -p build/logs
   - cp src/config.php.dist src/config.php
 


### PR DESCRIPTION
This PR

* [x] shows actually installed dependencies on Travis

💁‍♂ As you can see in #785, especially https://github.com/joindin/joindin-api/pull/785/commits/13626631c221260fbdac7e959d48975b4fa0b1c8 and https://travis-ci.org/joindin/joindin-api/jobs/607726655#L475-L486, something is up with the caching of dependencies on Travis.

Can we clear the caches, perhaps?