### PR TITLE
Fix: Remove dist configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: trusty
-
 cache:
   directories:
     - $HOME/.composer/cache

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -22,7 +22,7 @@ class UsersController extends BaseApiController
     private $userRegistrationEmailService;
 
     /**
-     * @var TalkCommentMapper
+     * @var TalkCommentMapper|null
      */
     private $talkCommentMapper;
 
@@ -515,7 +515,7 @@ class UsersController extends BaseApiController
 
     public function initializeTalkCommentMapper(PDO $db, Request $request): void
     {
-        if (!$this->talkCommentMapper) {
+        if (null === $this->talkCommentMapper) {
             $this->talkCommentMapper = new TalkCommentMapper($db, $request);
         }
     }


### PR DESCRIPTION
This PR

* [x] removes the `dist` configuration from `.travis.yml`
* [x] fixes an issue reported by `phpstan`

Probably related to problems in #773 and #785.

❗️ Blocks #785.

💁‍♂ Do we even care which distribution is used, or wouldn't it make more sense to let Travis CI decide for us?

Also see

- https://docs.travis-ci.com/user/reference/trusty/#using-trusty
- https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide