### PR TITLE
Fix: Move mockPDO into a file that can be autoloaded

### DIFF
--- a/tests/Controller/TalkBase.php
+++ b/tests/Controller/TalkBase.php
@@ -9,7 +9,7 @@ use Joindin\Api\Model\TalkMapper;
 use Joindin\Api\Model\TalkModel;
 use Joindin\Api\Model\UserMapper;
 use Joindin\Api\Request;
-use JoindinTest\Inc\mockPDO;
+use Joindin\Api\Test\Mock\mockPDO;
 use PHPUnit\Framework\TestCase;
 
 abstract class TalkBase extends TestCase

--- a/tests/Controller/TalkLinkControllerTest.php
+++ b/tests/Controller/TalkLinkControllerTest.php
@@ -5,7 +5,7 @@ namespace Joindin\Api\Test\Controller;
 use Exception;
 use Joindin\Api\Controller\TalkLinkController;
 use Joindin\Api\Request;
-use JoindinTest\Inc\mockPDO;
+use Joindin\Api\Test\Mock\mockPDO;
 use Teapot\StatusCode\Http;
 
 final class TalkLinkControllerTest extends TalkBase

--- a/tests/Controller/TalksControllerDeleteTest.php
+++ b/tests/Controller/TalksControllerDeleteTest.php
@@ -7,7 +7,7 @@ use Joindin\Api\Controller\TalksController;
 use Joindin\Api\Request;
 use Joindin\Api\Service\NullSpamCheckService;
 use Joindin\Api\View\ApiView;
-use JoindinTest\Inc\mockPDO;
+use Joindin\Api\Test\Mock\mockPDO;
 use Teapot\StatusCode\Http;
 
 final class TalksControllerDeleteTest extends TalkBase

--- a/tests/Controller/TalksControllerTest.php
+++ b/tests/Controller/TalksControllerTest.php
@@ -13,7 +13,7 @@ use Joindin\Api\Request;
 use Joindin\Api\Service\NullSpamCheckService;
 use Joindin\Api\Service\SpamCheckServiceInterface;
 use Joindin\Api\Service\TalkCommentEmailService;
-use JoindinTest\Inc\mockPDO;
+use Joindin\Api\Test\Mock\mockPDO;
 use Teapot\StatusCode\Http;
 use Teapot\StatusCode\WebDAV;
 

--- a/tests/Controller/UsersControllerTest.php
+++ b/tests/Controller/UsersControllerTest.php
@@ -13,7 +13,7 @@ use Joindin\Api\Request;
 use Joindin\Api\Service\UserRegistrationEmailService;
 use Joindin\Api\View\ApiView;
 use Joindin\Api\View\JsonView;
-use JoindinTest\Inc\mockPDO;
+use Joindin\Api\Test\Mock\mockPDO;
 use PDO;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Mock/mockPDO.php
+++ b/tests/Mock/mockPDO.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Joindin\Api\Test\Mock;
+
+/**
+ * Class to allow for mocking PDO to send to the OAuthModel
+ */
+class mockPDO extends \PDO
+{
+    /**
+     * Constructor that does nothing but helps us test with fake database
+     * adapters
+     */
+    public function __construct()
+    {
+        // We need to do this crap because PDO has final on the __sleep and
+        // __wakeup methods. PDO requires a parameter in the constructor but we don't
+        // want to create a real DB adapter. If you tell getMock to not call the
+        // original constructor, it fakes stuff out by unserializing a fake
+        // serialized string. This way, we've got a "PDO" object but we don't need
+        // PHPUnit to fake it by unserializing a made-up string. We've neutered
+        // the constructor in mockPDO.
+    }
+}

--- a/tests/Model/TalkMapperTest.php
+++ b/tests/Model/TalkMapperTest.php
@@ -4,7 +4,7 @@ namespace Joindin\Api\Test\Model;
 
 use Joindin\Api\Model\TalkMapper;
 use Joindin\Api\Request;
-use JoindinTest\Inc\mockPDO;
+use Joindin\Api\Test\Mock\mockPDO;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -460,7 +460,7 @@ final class RequestTest extends TestCase
         // Please see below for explanation of why we're mocking a "mock" PDO
         // class
         $db = $this->getMockBuilder(
-            '\JoindinTest\Inc\mockPDO'
+            '\Joindin\Api\Test\Mock\mockPDO'
         )->getMock();
         $db->method('getAvailableDrivers');
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,26 +4,3 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 //We are unit testing
 define('UNIT_TEST', 1);
-
-/**
- * Class to allow for mocking PDO to send to the OAuthModel
- */
-class mockPDO extends \PDO
-{
-    /**
-     * Constructor that does nothing but helps us test with fake database
-     * adapters
-     */
-    public function __construct()
-    {
-        // We need to do this crap because PDO has final on the __sleep and
-        // __wakeup methods. PDO requires a parameter in the constructor but we don't
-        // want to create a real DB adapter. If you tell getMock to not call the
-        // original constructor, it fakes stuff out by unserializing a fake
-        // serialized string. This way, we've got a "PDO" object but we don't need
-        // PHPUnit to fake it by unserializing a made-up string. We've neutered
-        // the constructor in mockPDO.
-    }
-}
-
-class_alias(mockPDO::class, 'JoindinTest\Inc\mockPDO');


### PR DESCRIPTION
This PR

* [x] moves a class that was declared in `tests/bootstrap.php` into a file that can be autoloaded

❗️ Blocks #791.