### PR TITLE
Enhancement: Use named constants instead of magic numbers for HTTP status codes

### DIFF
--- a/src/Controller/ApplicationsController.php
+++ b/src/Controller/ApplicationsController.php
@@ -167,7 +167,7 @@ class ApplicationsController extends BaseApiController
         try {
             $clientMapper->deleteClient($this->getItemId($request));
         } catch (Exception $e) {
-            throw new Exception($e->getMessage(), 500, $e);
+            throw new Exception($e->getMessage(), Http::INTERNAL_SERVER_ERROR, $e);
         }
 
         $request->getView()->setNoRender(true);

--- a/src/Controller/FacebookController.php
+++ b/src/Controller/FacebookController.php
@@ -34,7 +34,7 @@ class FacebookController extends BaseApiController
             empty($this->config['facebook']['app_id'])
             || empty($this->config['facebook']['app_secret'])
         ) {
-            throw new Exception("Cannot login via Facebook", 501);
+            throw new Exception("Cannot login via Facebook", Http::NOT_IMPLEMENTED);
         }
 
         $clientId         = $request->getParameter('client_id');
@@ -106,6 +106,6 @@ class FacebookController extends BaseApiController
             ),
             E_USER_WARNING
         );
-        throw new Exception("Unexpected Facebook error", 500);
+        throw new Exception("Unexpected Facebook error", Http::INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/Controller/TalkCommentsController.php
+++ b/src/Controller/TalkCommentsController.php
@@ -189,7 +189,7 @@ class TalkCommentsController extends BaseApiController
 
         $updateSuccess = $commentMapper->updateCommentBody($commentId, $newCommentBody);
         if (false === $updateSuccess) {
-            throw new Exception('Comment update failed', 500);
+            throw new Exception('Comment update failed', Http::INTERNAL_SERVER_ERROR);
         }
 
         return $commentMapper->getCommentById($commentId);

--- a/src/Controller/TalkLinkController.php
+++ b/src/Controller/TalkLinkController.php
@@ -51,7 +51,7 @@ class TalkLinkController extends BaseTalkController
         if (!$talk_mapper->updateTalkLink($talk_id, $link_id, $display_name, $url)) {
             throw new Exception(
                 "Update of Link ID Failed",
-                500
+                Http::INTERNAL_SERVER_ERROR
             );
         }
 

--- a/src/Controller/TalksController.php
+++ b/src/Controller/TalksController.php
@@ -653,7 +653,7 @@ class TalksController extends BaseTalkController
                 $event_mapper->setUserAttendance($event_id, $speaker_id);
 
                 if (!$success) {
-                    throw new Exception("There was a problem assigning the talk", 500);
+                    throw new Exception("There was a problem assigning the talk", Http::INTERNAL_SERVER_ERROR);
                 }
 
                 if (!defined('UNIT_TEST')) {
@@ -671,12 +671,12 @@ class TalksController extends BaseTalkController
             if ($data['username'] === $user['username']) {
                 if ($pending_talk_claim_mapper->approveAssignmentAsSpeaker($talk_id, $user_id, $claim['ID'])) {
                     if (!$talk_mapper->assignTalkToSpeaker($talk_id, $claim['ID'], $speaker_id, $speaker_name)) {
-                        throw new Exception("There was a problem assigning the talk", 500);
+                        throw new Exception("There was a problem assigning the talk", Http::INTERNAL_SERVER_ERROR);
                     }
 
                     $event_mapper->setUserAttendance($event_id, $speaker_id);
                 } else {
-                    throw new Exception("There was a problem assigning the talk", 500);
+                    throw new Exception("There was a problem assigning the talk", Http::INTERNAL_SERVER_ERROR);
                 }
             } else {
                 throw new Exception("You must be the talk speaker to approve this assignment", Http::UNAUTHORIZED);
@@ -787,7 +787,7 @@ class TalksController extends BaseTalkController
         $claim_exists              = $pending_talk_claim_mapper->claimExists($talk_id, $speaker_id, $claim['ID']);
 
         if ($claim_exists !== PendingTalkClaimMapper::SPEAKER_CLAIM) {
-            throw new Exception("There was a problem with the claim", 500);
+            throw new Exception("There was a problem with the claim", Http::INTERNAL_SERVER_ERROR);
         }
         $method     = $this->getRequestParameter($request, 'action', 'approve');
         $recipients = [$user_mapper->getEmailByUserId($speaker_id)];
@@ -796,7 +796,7 @@ class TalksController extends BaseTalkController
         $success = $pending_talk_claim_mapper->rejectClaimAsHost($talk_id, $speaker_id, $claim['ID']);
 
         if (!$success) {
-            throw new Exception("There was a problem assigning the talk", 500);
+            throw new Exception("There was a problem assigning the talk", Http::INTERNAL_SERVER_ERROR);
         }
 
         $emailService = new TalkClaimRejectedEmailService($this->config, $recipients, $event, $talk);

--- a/src/Controller/TokenController.php
+++ b/src/Controller/TokenController.php
@@ -131,7 +131,7 @@ class TokenController extends BaseApiController
         try {
             $tokenMapper->deleteToken($this->getItemId($request));
         } catch (Exception $e) {
-            throw new Exception($e->getMessage(), 500, $e);
+            throw new Exception($e->getMessage(), Http::INTERNAL_SERVER_ERROR, $e);
         }
 
         $request->getView()->setNoRender(true);

--- a/src/Controller/TwitterController.php
+++ b/src/Controller/TwitterController.php
@@ -61,7 +61,7 @@ class TwitterController extends BaseApiController
             return $output_list;
         }
 
-        throw new Exception("Twitter: no request token (" . $res->getStatusCode() . ": " . $res->getBody() . ")", 500);
+        throw new Exception("Twitter: no request token (" . $res->getStatusCode() . ": " . $res->getBody() . ")", Http::INTERNAL_SERVER_ERROR);
     }
 
     /**
@@ -156,6 +156,6 @@ class TwitterController extends BaseApiController
             return ['access_token' => $result['access_token'], 'user_uri' => $result['user_uri']];
         }
 
-        throw new Exception("Twitter: error (" . $res->getStatusCode() . ": " . $res->getBody() . ")", 500);
+        throw new Exception("Twitter: error (" . $res->getStatusCode() . ": " . $res->getBody() . ")", Http::INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -487,7 +487,7 @@ class UsersController extends BaseApiController
         }
 
         if (!$userMapper->setTrustedStatus($trustedStatus, $userId)) {
-            throw new Exception("Unable to update status", 500);
+            throw new Exception("Unable to update status", Http::INTERNAL_SERVER_ERROR);
         }
         $view = $request->getView();
         $view->setHeader('Content-Length', 0);

--- a/src/Exception/AuthenticationException.php
+++ b/src/Exception/AuthenticationException.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Joindin\Api\Exception;
 
+use Teapot\StatusCode\Http;
+
 final class AuthenticationException extends \RuntimeException
 {
     private const MESSAGE = 'You must be logged in to perform this operation.';
 
     public static function forUnauthenticatedUser(string $message = null): self
     {
-        return new static($message ?? self::MESSAGE, 401);
+        return new static($message ?? self::MESSAGE, Http::UNAUTHORIZED);
     }
 }

--- a/src/Exception/AuthorizationException.php
+++ b/src/Exception/AuthorizationException.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Joindin\Api\Exception;
 
+use Teapot\StatusCode\Http;
+
 final class AuthorizationException extends \RuntimeException
 {
     private const MESSAGE = 'This operation requires %s privileges.';
 
     public static function forNonAdministrator(): self
     {
-        return new static(sprintf(self::MESSAGE, 'admin'), 403);
+        return new static(sprintf(self::MESSAGE, 'admin'), Http::FORBIDDEN);
     }
 }

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -127,7 +127,7 @@ class Route
         }
 
         if (!method_exists($controller = $container->get($className), $method)) {
-            throw new RuntimeException('Action not found', 500);
+            throw new RuntimeException('Action not found', Http::INTERNAL_SERVER_ERROR);
         }
 
         if (function_exists('newrelic_name_transaction')) {


### PR DESCRIPTION
This PR

* [x] uses named constants instead of magic numbers for HTTP status codes

Follows #726.