### PR TITLE
Fix: Remove useless break statements

### DIFF
--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -82,7 +82,6 @@ class EventsController extends BaseApiController
                     break;
                 default:
                     throw new InvalidArgumentException('Unknown Subrequest', Http::NOT_FOUND);
-                    break;
             }
         } else {
             $mapper           = new EventMapper($db, $request);

--- a/src/Controller/TalksController.php
+++ b/src/Controller/TalksController.php
@@ -194,8 +194,6 @@ class TalksController extends BaseTalkController
                     }
 
                     throw new Exception("The comment could not be stored", Http::BAD_REQUEST);
-
-                    break;
                 case 'starred':
                     // the body of this request is completely irrelevant
                     // The logged in user *is* attending the talk.  Use DELETE to unattend

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -130,11 +130,8 @@ class UsersController extends BaseApiController
                     }
 
                     throw new Exception("Verification failed", Http::BAD_REQUEST);
-
-                    break;
                 default:
                     throw new InvalidArgumentException('Unknown Subrequest', Http::NOT_FOUND);
-                    break;
             }
         } else {
             $user   = [];


### PR DESCRIPTION
This PR

* [x] removes useless `break` statements