### PR TITLE
Enhancement: Generate and include baseline for phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,11 @@
     "require-checker": "composer-require-checker --config-file=composer-require-checker.json",
     "security": "security-checker security:check composer.lock",
     "stan": "phpstan analyze --configuration=phpstan.neon",
+    "stan-baseline": [
+      "sed -e '/phpstan-baseline\\.neon/ s/^/#/' phpstan.neon > phpstan-without-baseline.neon",
+      "phpstan analyze --configuration phpstan-without-baseline.neon --error-format baselineNeon > phpstan-baseline.neon  || true",
+      "rm phpstan-without-baseline.neon"
+    ],
     "test": "phpunit"
   },
   "support": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,10 @@
+
+
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Joindin\\\\Api\\\\Test\\\\Mock\\\\mockPDO\\:\\:__construct\\(\\) does not call parent constructor from PDO\\.$#"
+			count: 1
+			path: tests/Mock/mockPDO.php
+
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,10 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     excludes_analyse:
         - public/
         - scripts/
-
-    ignoreErrors:
-        - '#Joindin\\Api\\Test\\Mock\\mockPDO::__construct\(\) does not call parent constructor from PDO\.#'
 
     inferPrivatePropertyTypeFromConstructor: true
 


### PR DESCRIPTION
This PR

* [x] generates and includes a baseline for `phpstan`

❗️ Blocks #807.

💁‍♂ Run

```
$ composer stan-baseline
```

to regenerate `phpstan-baseline.neon`.