### PR TITLE
Fix: Drop support for PHP 7.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
+          - 7.3
 
     steps:
       - name: "Checkout"
@@ -86,7 +86,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
           - 7.3
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "homepage": "https://api.joind.in",
   "license": "BSD-3-Clause",
   "require": {
-    "php": "^7.2",
+    "php": "^7.3",
     "ext-curl": "*",
     "ext-filter": "*",
     "ext-gd": "*",
@@ -41,7 +41,7 @@
   "config": {
     "optimize-autoloader": true,
     "platform": {
-      "php": "7.2.23"
+      "php": "7.3.11"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9c5e9998006a0e850d0a9ace49d16a5",
+    "content-hash": "f50bf30d61442617fe7faa33ff74dda8",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -4311,7 +4311,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-curl": "*",
         "ext-filter": "*",
         "ext-gd": "*",
@@ -4322,6 +4322,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.23"
+        "php": "7.3.11"
     }
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.2

💁‍♂ Are we using PHP 7.3 in production? Then we probably don't need to be able to run on PHP 7.2.