### PR TITLE
Enhancement: Enable and configure binary_operator_spaces fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -23,6 +23,9 @@ return PhpCsFixer\Config::create()
             'syntax' => 'short',
         ],
         'backtick_to_shell_exec' => true,
+        'binary_operator_spaces' => [
+            'default' => 'single_space',
+        ],
         'blank_line_after_opening_tag' => true,
         'blank_line_before_statement' => [
             'statements' => [

--- a/inc/nginx-helper.php
+++ b/inc/nginx-helper.php
@@ -10,12 +10,12 @@
  */
 function apache_request_headers()
 {
-    $arh     = [];
+    $arh = [];
     $rx_http = '/\AHTTP_/';
 
     foreach ($_SERVER as $key => $val) {
         if (preg_match($rx_http, $key)) {
-            $arh_key    = preg_replace($rx_http, '', $key);
+            $arh_key = preg_replace($rx_http, '', $key);
             $rx_matches = [];
             // do some nasty string manipulations to restore the original letter case
             // this should work in most cases

--- a/scripts/newConsumerKeyFunc.php
+++ b/scripts/newConsumerKeyFunc.php
@@ -7,7 +7,7 @@
  */
 function new_consumer_key()
 {
-    $fp      = fopen('/dev/urandom', 'rb');
+    $fp = fopen('/dev/urandom', 'rb');
     $entropy = fread($fp, 32);
     fclose($fp);
     // in case /dev/urandom is reusing entropy from its pool,

--- a/scripts/password-migration.php
+++ b/scripts/password-migration.php
@@ -14,7 +14,7 @@ $count = 0;
 while ($row = $select_stmt->fetch(PDO::FETCH_ASSOC)) {
     $update_stmt->execute([
         "password" => password_hash($row['password'], PASSWORD_DEFAULT),
-        "id"       => $row['ID']
+        "id" => $row['ID']
     ]);
     $count++;
 }

--- a/src/Controller/ApplicationsController.php
+++ b/src/Controller/ApplicationsController.php
@@ -49,7 +49,7 @@ class ApplicationsController extends BaseApiController
             throw new Exception("You must be logged in", Http::UNAUTHORIZED);
         }
 
-        $app    = [];
+        $app = [];
         $errors = [];
 
         $app['name'] = filter_var(
@@ -88,13 +88,13 @@ class ApplicationsController extends BaseApiController
         $app['user_id'] = $request->user_id;
 
         $clientMapper = $this->getClientMapper($db, $request);
-        $clientId     = $clientMapper->createClient($app);
+        $clientId = $clientMapper->createClient($app);
 
         $uri = $request->base . '/' . $request->version . '/applications/' . $clientId;
         $request->getView()->setResponseCode(Http::CREATED);
         $request->getView()->setHeader('Location', $uri);
 
-        $mapper    = $this->getClientMapper($db, $request);
+        $mapper = $this->getClientMapper($db, $request);
         $newClient = $mapper->getClientByIdAndUser($clientId, $request->user_id);
 
         return $newClient->getOutputView($request);
@@ -106,7 +106,7 @@ class ApplicationsController extends BaseApiController
             throw new Exception("You must be logged in", Http::UNAUTHORIZED);
         }
 
-        $app    = [];
+        $app = [];
         $errors = [];
 
         $app['name'] = filter_var(
@@ -141,7 +141,7 @@ class ApplicationsController extends BaseApiController
         $app['user_id'] = $request->user_id;
 
         $clientMapper = $this->getClientMapper($db, $request);
-        $clientId     = $clientMapper->updateClient($this->getItemId($request), $app);
+        $clientId = $clientMapper->updateClient($this->getItemId($request), $app);
 
         $uri = $request->base . '/' . $request->version . '/applications/' . $clientId;
         $request->getView()->setResponseCode(Http::CREATED);

--- a/src/Controller/BaseTalkController.php
+++ b/src/Controller/BaseTalkController.php
@@ -21,7 +21,7 @@ class BaseTalkController extends BaseApiController
     protected $request;
 
     protected $classMappings = [
-        'talk'        => TalkMapper::class,
+        'talk' => TalkMapper::class,
         'talkcomment' => TalkCommentMapper::class,
     ];
 
@@ -45,10 +45,10 @@ class BaseTalkController extends BaseApiController
     protected function checkLoggedIn(Request $request)
     {
         $failMessages = [
-            'POST'   => 'create data',
+            'POST' => 'create data',
             'DELETE' => 'remove data',
-            'GET'    => 'view data',
-            'PUT'    => 'update data'
+            'GET' => 'view data',
+            'PUT' => 'update data'
         ];
 
         if (!isset($request->user_id)) {
@@ -138,7 +138,7 @@ class BaseTalkController extends BaseApiController
 
     protected function setDbAndRequest(PDO $db, Request $request)
     {
-        $this->db      = $db;
+        $this->db = $db;
         $this->request = $request;
     }
 

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -30,7 +30,7 @@ class ContactController extends BaseApiController
         SpamCheckServiceInterface $spamCheckService,
         array $config = []
     ) {
-        $this->emailService     = $emailService;
+        $this->emailService = $emailService;
         $this->spamCheckService = $spamCheckService;
 
         parent::__construct($config);
@@ -61,17 +61,17 @@ class ContactController extends BaseApiController
     public function contact(Request $request, PDO $db)
     {
         // only trusted clients can contact us to save on spam
-        $clientId     = $request->getParameter('client_id');
+        $clientId = $request->getParameter('client_id');
         $clientSecret = $request->getParameter('client_secret');
-        $oauthModel   = $request->getOauthModel($db);
+        $oauthModel = $request->getOauthModel($db);
 
         if (!$oauthModel->isClientPermittedPasswordGrant($clientId, $clientSecret)) {
             throw new Exception("This client cannot perform this action", Http::FORBIDDEN);
         }
 
         $fields = ['name', 'email', 'subject', 'comment'];
-        $error  = [];
-        $data   = [];
+        $error = [];
+        $data = [];
 
         foreach ($fields as $name) {
             $value = $request->getParameter($name);

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -11,12 +11,12 @@ class DefaultController extends BaseApiController
     {
         // just add the available methods, with links
         return [
-            'events'          => $request->base . '/' . $request->version . '/events',
-            'hot-events'      => $request->base . '/' . $request->version . '/events?filter=hot',
+            'events' => $request->base . '/' . $request->version . '/events',
+            'hot-events' => $request->base . '/' . $request->version . '/events?filter=hot',
             'upcoming-events' => $request->base . '/' . $request->version . '/events?filter=upcoming',
-            'past-events'     => $request->base . '/' . $request->version . '/events?filter=past',
-            'open-cfps'       => $request->base . '/' . $request->version . '/events?filter=cfp',
-            'docs'            => 'http://joindin.github.io/joindin-api/',
+            'past-events' => $request->base . '/' . $request->version . '/events?filter=past',
+            'open-cfps' => $request->base . '/' . $request->version . '/events?filter=cfp',
+            'docs' => 'http://joindin.github.io/joindin-api/',
         ];
     }
 }

--- a/src/Controller/EmailsController.php
+++ b/src/Controller/EmailsController.php
@@ -19,7 +19,7 @@ class EmailsController extends BaseApiController
     public function verifications(Request $request, PDO $db)
     {
         $user_mapper = new UserMapper($db, $request);
-        $email       = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
+        $email = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
 
         if (empty($email)) {
             throw new Exception("The email address must be supplied", Http::BAD_REQUEST);
@@ -35,7 +35,7 @@ class EmailsController extends BaseApiController
         // Generate a verification token and email it to the user
         $token = $user_mapper->generateEmailVerificationTokenForUserId($user_id);
 
-        $recipients   = [$email];
+        $recipients = [$email];
         $emailService = new UserRegistrationEmailService($this->config, $recipients, $token);
         $emailService->sendEmail();
 
@@ -47,7 +47,7 @@ class EmailsController extends BaseApiController
     public function usernameReminder(Request $request, PDO $db)
     {
         $user_mapper = new UserMapper($db, $request);
-        $email       = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
+        $email = filter_var($request->getParameter("email"), FILTER_VALIDATE_EMAIL);
 
         if (empty($email)) {
             throw new Exception("The email address must be supplied", Http::BAD_REQUEST);
@@ -61,7 +61,7 @@ class EmailsController extends BaseApiController
 
         $user = $list['users'][0];
 
-        $recipients   = [$email];
+        $recipients = [$email];
         $emailService = new UserUsernameReminderEmailService($this->config, $recipients, $user);
         $emailService->sendEmail();
 
@@ -73,7 +73,7 @@ class EmailsController extends BaseApiController
     public function passwordReset(Request $request, PDO $db)
     {
         $user_mapper = new UserMapper($db, $request);
-        $username    = filter_var($request->getParameter("username"), FILTER_SANITIZE_STRING);
+        $username = filter_var($request->getParameter("username"), FILTER_SANITIZE_STRING);
 
         if (empty($username)) {
             throw new Exception("A username must be supplied", Http::BAD_REQUEST);
@@ -88,8 +88,8 @@ class EmailsController extends BaseApiController
         $user = $list['users'][0];
 
         // neither user_id nor email are in the user resource returned by the mapper
-        $user_id    = $user_mapper->getUserIdFromUsername($username);
-        $email      = $user_mapper->getEmailByUserId($user_id);
+        $user_id = $user_mapper->getUserIdFromUsername($username);
+        $email = $user_mapper->getEmailByUserId($user_id);
         $recipients = [$email];
 
         // we need a token to send so we know it is a valid reset

--- a/src/Controller/EventCommentsController.php
+++ b/src/Controller/EventCommentsController.php
@@ -34,7 +34,7 @@ class EventCommentsController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         // pagination settings
-        $start          = $this->getStart($request);
+        $start = $this->getStart($request);
         $resultsperpage = $this->getResultsPerPage($request);
 
         $mapper = new EventCommentMapper($db, $request);
@@ -63,7 +63,7 @@ class EventCommentsController extends BaseApiController
         // verbosity
         $verbose = $this->getVerbosity($request);
 
-        $event_mapper   = new EventMapper($db, $request);
+        $event_mapper = new EventMapper($db, $request);
         $comment_mapper = new EventCommentMapper($db, $request);
 
         if (!isset($request->user_id) || empty($request->user_id)) {
@@ -81,7 +81,7 @@ class EventCommentsController extends BaseApiController
 
     public function createComment(Request $request, PDO $db)
     {
-        $comment             = [];
+        $comment = [];
         $comment['event_id'] = $this->getItemId($request);
 
         if (empty($comment['event_id'])) {
@@ -96,8 +96,8 @@ class EventCommentsController extends BaseApiController
             throw new Exception('You must log in to comment');
         }
         $user_mapper = new UserMapper($db, $request);
-        $users       = $user_mapper->getUserById($request->user_id);
-        $thisUser    = $users['users'][0];
+        $users = $user_mapper->getUserById($request->user_id);
+        $thisUser = $users['users'][0];
 
         $rating = $request->getParameter('rating', false);
 
@@ -116,14 +116,14 @@ class EventCommentsController extends BaseApiController
         }
 
         // Get the API key reference to save against the comment
-        $oauth_model   = $request->getOauthModel($db);
+        $oauth_model = $request->getOauthModel($db);
         $consumer_name = $oauth_model->getConsumerName($request->getAccessToken());
 
         $comment['user_id'] = $request->user_id;
         $comment['comment'] = $commentText;
-        $comment['rating']  = $rating;
-        $comment['cname']   = $thisUser['full_name'];
-        $comment['source']  = $consumer_name;
+        $comment['rating'] = $rating;
+        $comment['cname'] = $thisUser['full_name'];
+        $comment['source'] = $consumer_name;
 
         $isValid = $this->spamCheckService->isCommentAcceptable(
             $commentText,
@@ -135,7 +135,7 @@ class EventCommentsController extends BaseApiController
             throw new Exception("Comment failed spam check", Http::BAD_REQUEST);
         }
 
-        $event_mapper   = new EventMapper($db, $request);
+        $event_mapper = new EventMapper($db, $request);
         $comment_mapper = new EventCommentMapper($db, $request);
 
         // should rating be allowed?
@@ -178,7 +178,7 @@ class EventCommentsController extends BaseApiController
 
         $comment_mapper = new EventCommentMapper($db, $request);
 
-        $commentId   = $this->getItemId($request);
+        $commentId = $this->getItemId($request);
         $commentInfo = $comment_mapper->getCommentInfo($commentId);
 
         if (false === $commentInfo) {
@@ -190,10 +190,10 @@ class EventCommentsController extends BaseApiController
         $comment_mapper->userReportedComment($commentId, $request->user_id);
 
         // notify event admins
-        $comment      = $comment_mapper->getCommentById($commentId, true, true);
+        $comment = $comment_mapper->getCommentById($commentId, true, true);
         $event_mapper = new EventMapper($db, $request);
-        $recipients   = $event_mapper->getHostsEmailAddresses($eventId);
-        $event        = $event_mapper->getEventById($eventId, true, true);
+        $recipients = $event_mapper->getHostsEmailAddresses($eventId);
+        $event = $event_mapper->getEventById($eventId, true, true);
 
         $emailService = new EventCommentReportedEmailService($this->config, $recipients, $comment, $event);
         $emailService->sendEmail();
@@ -229,7 +229,7 @@ class EventCommentsController extends BaseApiController
 
         $comment_mapper = new EventCommentMapper($db, $request);
 
-        $commentId   = $this->getItemId($request);
+        $commentId = $this->getItemId($request);
         $commentInfo = $comment_mapper->getCommentInfo($commentId);
 
         if (false === $commentInfo) {
@@ -237,7 +237,7 @@ class EventCommentsController extends BaseApiController
         }
 
         $event_mapper = new EventMapper($db, $request);
-        $event_id     = $commentInfo['event_id'];
+        $event_id = $commentInfo['event_id'];
 
         if (false == $event_mapper->thisUserHasAdminOn($event_id)) {
             throw new Exception("You don't have permission to do that", Http::FORBIDDEN);

--- a/src/Controller/EventHostsController.php
+++ b/src/Controller/EventHostsController.php
@@ -38,7 +38,7 @@ class EventHostsController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         // pagination settings
-        $start          = $this->getStart($request);
+        $start = $this->getStart($request);
         $resultsperpage = $this->getResultsPerPage($request);
 
         $mapper = $this->getEventHostMapper($request, $db);
@@ -74,7 +74,7 @@ class EventHostsController extends BaseApiController
         $event_id = $this->getItemId($request);
 
         $eventMapper = $this->getEventMapper($request, $db);
-        $event       = $eventMapper->getEventById($event_id);
+        $event = $eventMapper->getEventById($event_id);
 
         if (false === $event) {
             throw new Exception('Event not found', Http::NOT_FOUND);
@@ -85,13 +85,13 @@ class EventHostsController extends BaseApiController
         if (!$isAdmin) {
             throw new Exception("You do not have permission to add hosts to this event", Http::FORBIDDEN);
         }
-        $username   = filter_var(
+        $username = filter_var(
             $request->getParameter('host_name'),
             FILTER_SANITIZE_STRING,
             FILTER_FLAG_NO_ENCODE_QUOTES
         );
         $userMapper = $this->getUserMapper($request, $db);
-        $user_id    = $userMapper->getUserIdFromUsername($username);
+        $user_id = $userMapper->getUserIdFromUsername($username);
 
         if (false === $user_id) {
             throw new Exception('No User found', Http::NOT_FOUND);
@@ -139,7 +139,7 @@ class EventHostsController extends BaseApiController
         $event_id = $this->getItemId($request);
 
         $eventMapper = $this->getEventMapper($request, $db);
-        $event       = $eventMapper->getEventById($event_id);
+        $event = $eventMapper->getEventById($event_id);
 
         if (false === $event) {
             throw new Exception('Event not found', Http::NOT_FOUND);
@@ -152,7 +152,7 @@ class EventHostsController extends BaseApiController
         }
 
         $userMapper = $this->getUserMapper($request, $db);
-        $user       = $userMapper->getUserById($user_id);
+        $user = $userMapper->getUserById($user_id);
 
         if (false === $user) {
             throw new Exception('No User found', Http::NOT_FOUND);

--- a/src/Controller/EventImagesController.php
+++ b/src/Controller/EventImagesController.php
@@ -73,12 +73,12 @@ class EventImagesController extends BaseApiController
         }
 
         // save the file - overwrite current one if there is one
-        $extensions[IMAGETYPE_GIF]  = '.gif';
+        $extensions[IMAGETYPE_GIF] = '.gif';
         $extensions[IMAGETYPE_JPEG] = '.jpg';
-        $extensions[IMAGETYPE_PNG]  = '.png';
-        $saved_filename             = 'icon-' . $event_id . '-orig' . $extensions[$filetype];
-        $event_image_path           = $request->getConfigValue('event_image_path');
-        $result                     = move_uploaded_file($uploaded_name, $event_image_path . $saved_filename);
+        $extensions[IMAGETYPE_PNG] = '.png';
+        $saved_filename = 'icon-' . $event_id . '-orig' . $extensions[$filetype];
+        $event_image_path = $request->getConfigValue('event_image_path');
+        $result = move_uploaded_file($uploaded_name, $event_image_path . $saved_filename);
 
         if (false === $result) {
             throw new Exception("The file could not be saved");
@@ -92,7 +92,7 @@ class EventImagesController extends BaseApiController
         $orig_image = imagecreatefromstring(file_get_contents($event_image_path . $saved_filename));
         imagealphablending($orig_image, false);
         imagesavealpha($orig_image, true);
-        $small_width  = 140;
+        $small_width = 140;
         $small_height = 140;
 
         $small_image = imagecreatetruecolor($small_width, $small_height);
@@ -125,7 +125,7 @@ class EventImagesController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id = $this->getItemId($request);
         $event_mapper = new EventMapper($db, $request);
         $event_mapper->removeImages($event_id);
 

--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -41,20 +41,20 @@ class EventsController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         // pagination settings
-        $start          = $this->getStart($request);
+        $start = $this->getStart($request);
         $resultsperpage = $this->getResultsPerPage($request);
 
         if (isset($request->url_elements[4])) {
             switch ($request->url_elements[4]) {
                 case 'talks':
                     $talk_mapper = new TalkMapper($db, $request);
-                    $talks       = $talk_mapper->getTalksByEventId($event_id, $resultsperpage, $start);
-                    $list        = $talks->getOutputView($request, $verbose);
+                    $talks = $talk_mapper->getTalksByEventId($event_id, $resultsperpage, $start);
+                    $list = $talks->getOutputView($request, $verbose);
 
                     break;
                 case 'comments':
                     $event_comment_mapper = new EventCommentMapper($db, $request);
-                    $list                 = $event_comment_mapper->getEventCommentsByEventId(
+                    $list = $event_comment_mapper->getEventCommentsByEventId(
                         $event_id,
                         $resultsperpage,
                         $start,
@@ -64,7 +64,7 @@ class EventsController extends BaseApiController
                     break;
                 case 'talk_comments':
                     $talk_comment_mapper = new TalkCommentMapper($db, $request);
-                    $list                = $talk_comment_mapper->getCommentsByEventId(
+                    $list = $talk_comment_mapper->getCommentsByEventId(
                         $event_id,
                         $resultsperpage,
                         $start,
@@ -74,17 +74,17 @@ class EventsController extends BaseApiController
                     break;
                 case 'attendees':
                     $user_mapper = new UserMapper($db, $request);
-                    $list        = $user_mapper->getUsersAttendingEventId($event_id, $resultsperpage, $start, $verbose);
+                    $list = $user_mapper->getUsersAttendingEventId($event_id, $resultsperpage, $start, $verbose);
 
                     break;
                 case 'attending':
                     $mapper = new EventMapper($db, $request);
-                    $list   = $mapper->getUserAttendance($event_id, $request->user_id);
+                    $list = $mapper->getUserAttendance($event_id, $request->user_id);
 
                     break;
                 case 'tracks':
                     $mapper = new TrackMapper($db, $request);
-                    $list   = $mapper->getTracksByEventId($event_id, $resultsperpage, $start, $verbose);
+                    $list = $mapper->getTracksByEventId($event_id, $resultsperpage, $start, $verbose);
 
                     break;
 
@@ -92,9 +92,9 @@ class EventsController extends BaseApiController
                     throw new InvalidArgumentException('Unknown Subrequest', Http::NOT_FOUND);
             }
         } else {
-            $mapper           = new EventMapper($db, $request);
-            $user_mapper      = new UserMapper($db, $request);
-            $isSiteAdmin      = $user_mapper->isSiteAdmin($request->user_id);
+            $mapper = new EventMapper($db, $request);
+            $user_mapper = new UserMapper($db, $request);
+            $isSiteAdmin = $user_mapper->isSiteAdmin($request->user_id);
             $activeEventsOnly = $isSiteAdmin ? false : true;
 
             if ($event_id) {
@@ -118,7 +118,7 @@ class EventsController extends BaseApiController
                         if (!isset($request->user_id)) {
                             throw new Exception("You must be logged in to view pending events", Http::BAD_REQUEST);
                         }
-                        $user_mapper      = new UserMapper($db, $request);
+                        $user_mapper = new UserMapper($db, $request);
                         $canApproveEvents = $user_mapper->isSiteAdmin($request->user_id);
 
                         if (!$canApproveEvents) {
@@ -128,7 +128,7 @@ class EventsController extends BaseApiController
                 }
 
                 if (isset($request->parameters['title'])) {
-                    $title           = filter_var(
+                    $title = filter_var(
                         $request->parameters['title'],
                         FILTER_SANITIZE_STRING,
                         FILTER_FLAG_NO_ENCODE_QUOTES
@@ -137,7 +137,7 @@ class EventsController extends BaseApiController
                 }
 
                 if (isset($request->parameters['stub'])) {
-                    $stub           = filter_var(
+                    $stub = filter_var(
                         $request->parameters['stub'],
                         FILTER_SANITIZE_STRING,
                         FILTER_FLAG_NO_ENCODE_QUOTES
@@ -203,7 +203,7 @@ class EventsController extends BaseApiController
                 case 'attending':
                     // the body of this request is completely irrelevant
                     // The logged in user *is* attending the event.  Use DELETE to unattend
-                    $event_id     = $this->getItemId($request);
+                    $event_id = $this->getItemId($request);
                     $event_mapper = new EventMapper($db, $request);
                     $event_mapper->setUserAttendance($event_id, $request->user_id);
 
@@ -220,7 +220,7 @@ class EventsController extends BaseApiController
             // Create a new event, pending unless user has privs
 
             // incoming data
-            $event  = [];
+            $event = [];
             $errors = [];
 
             $event['name'] = filter_var(
@@ -256,7 +256,7 @@ class EventsController extends BaseApiController
             $tz = new DateTimeZone('UTC');
 
             $start_date = strtotime($request->getParameter("start_date"));
-            $end_date   = strtotime($request->getParameter("end_date"));
+            $end_date = strtotime($request->getParameter("end_date"));
 
             if (!$start_date || ! $end_date) {
                 $errors[] = "Both 'start_date' and 'end_date' must be supplied in a recognised format";
@@ -270,7 +270,7 @@ class EventsController extends BaseApiController
                     FILTER_SANITIZE_STRING,
                     FILTER_FLAG_NO_ENCODE_QUOTES
                 );
-                $event['tz_place']     = filter_var(
+                $event['tz_place'] = filter_var(
                     $request->getParameter("tz_place"),
                     FILTER_SANITIZE_STRING,
                     FILTER_FLAG_NO_ENCODE_QUOTES
@@ -280,10 +280,10 @@ class EventsController extends BaseApiController
                     // make the timezone, and read in times with respect to that
                     $tz = new DateTimeZone($event['tz_continent'] . '/' . $event['tz_place']);
 
-                    $start_date          = new DateTime($request->getParameter("start_date"), $tz);
-                    $end_date            = new DateTime($request->getParameter("end_date"), $tz);
+                    $start_date = new DateTime($request->getParameter("start_date"), $tz);
+                    $end_date = new DateTime($request->getParameter("end_date"), $tz);
                     $event['start_date'] = $start_date->format('U');
-                    $event['end_date']   = $end_date->format('U');
+                    $event['end_date'] = $end_date->format('U');
                 } catch (Exception $e) {
                     // the time zone isn't right
                     $errors[] = "The fields 'tz_continent' and 'tz_place' must be supplied and valid " .
@@ -307,13 +307,13 @@ class EventsController extends BaseApiController
                 $cfp_start_date = strtotime($request->getParameter("cfp_start_date"));
 
                 if ($cfp_start_date) {
-                    $cfp_start_date          = new DateTime($request->getParameter("cfp_start_date"), $tz);
+                    $cfp_start_date = new DateTime($request->getParameter("cfp_start_date"), $tz);
                     $event['cfp_start_date'] = $cfp_start_date->format('U');
                 }
                 $cfp_end_date = strtotime($request->getParameter("cfp_end_date"));
 
                 if ($cfp_end_date) {
-                    $cfp_end_date          = new DateTime($request->getParameter("cfp_end_date"), $tz);
+                    $cfp_end_date = new DateTime($request->getParameter("cfp_end_date"), $tz);
                     $event['cfp_end_date'] = $cfp_end_date->format('U');
                 }
                 $latitude = filter_var(
@@ -363,7 +363,7 @@ class EventsController extends BaseApiController
             $current_pending = $event_mapper->getPendingEventsCountByUser($request->user_id);
 
             if ($current_pending >= $max_pending_events) {
-                $suffix   = $max_pending_events == 1 ? '' : 's';
+                $suffix = $max_pending_events == 1 ? '' : 's';
                 $errors[] = sprintf('You may only have %d pending event%s at one time', $max_pending_events, $suffix);
             }
 
@@ -374,7 +374,7 @@ class EventsController extends BaseApiController
 
             $user_mapper = new UserMapper($db, $request);
 
-            $event_owner           = $user_mapper->getUserById($request->user_id);
+            $event_owner = $user_mapper->getUserById($request->user_id);
             $event['contact_name'] = $event_owner['users'][0]['full_name'];
 
             /**
@@ -422,9 +422,9 @@ class EventsController extends BaseApiController
 
             // Send an email if we didn't auto-approve
             if (!$user_mapper->isSiteAdmin($request->user_id)) {
-                $event        = $event_mapper->getPendingEventById($event_id);
-                $count        = $event_mapper->getPendingEventsCount();
-                $recipients   = $user_mapper->getSiteAdminEmails();
+                $event = $event_mapper->getPendingEventById($event_id);
+                $count = $event_mapper->getPendingEventsCount();
+                $recipients = $user_mapper->getSiteAdminEmails();
                 $emailService = new EventSubmissionEmailService($this->config, $recipients, $event, $count);
                 $emailService->sendEmail();
             }
@@ -440,7 +440,7 @@ class EventsController extends BaseApiController
         if (isset($request->url_elements[4])) {
             switch ($request->url_elements[4]) {
                 case 'attending':
-                    $event_id     = $this->getItemId($request);
+                    $event_id = $this->getItemId($request);
                     $event_mapper = new EventMapper($db, $request);
                     $event_mapper->setUserNonAttendance($event_id, $request->user_id);
 
@@ -472,7 +472,7 @@ class EventsController extends BaseApiController
 
         if (!isset($request->url_elements[4])) {
             // Edit an Event
-            $event_mapper   = new EventMapper($db, $request);
+            $event_mapper = new EventMapper($db, $request);
             $existing_event = $event_mapper->getEventById($event_id, true);
 
             if (!$existing_event) {
@@ -487,7 +487,7 @@ class EventsController extends BaseApiController
             }
 
             // initialise a new set of fields to save
-            $event  = ["event_id" => $event_id];
+            $event = ["event_id" => $event_id];
             $errors = [];
 
             $event['name'] = filter_var(
@@ -521,7 +521,7 @@ class EventsController extends BaseApiController
             }
 
             $start_date = strtotime($request->getParameter("start_date"));
-            $end_date   = strtotime($request->getParameter("end_date"));
+            $end_date = strtotime($request->getParameter("end_date"));
 
             if (!$start_date || ! $end_date) {
                 $errors[] = "Both 'start_date' and 'end_date' must be supplied in a recognised format";
@@ -534,7 +534,7 @@ class EventsController extends BaseApiController
                     FILTER_SANITIZE_STRING,
                     FILTER_FLAG_NO_ENCODE_QUOTES
                 );
-                $event['tz_place']     = filter_var(
+                $event['tz_place'] = filter_var(
                     $request->getParameter("tz_place"),
                     FILTER_SANITIZE_STRING,
                     FILTER_FLAG_NO_ENCODE_QUOTES
@@ -542,11 +542,11 @@ class EventsController extends BaseApiController
 
                 try {
                     // make the timezone, and read in times with respect to that
-                    $tz                  = new DateTimeZone($event['tz_continent'] . '/' . $event['tz_place']);
-                    $start_date          = new DateTime($request->getParameter("start_date"), $tz);
-                    $end_date            = new DateTime($request->getParameter("end_date"), $tz);
+                    $tz = new DateTimeZone($event['tz_continent'] . '/' . $event['tz_place']);
+                    $start_date = new DateTime($request->getParameter("start_date"), $tz);
+                    $end_date = new DateTime($request->getParameter("end_date"), $tz);
                     $event['start_date'] = $start_date->format('U');
-                    $event['end_date']   = $end_date->format('U');
+                    $event['end_date'] = $end_date->format('U');
                 } catch (Exception $e) {
                     // the time zone isn't right
                     $errors[] = "The fields 'tz_continent' and 'tz_place' must be supplied and valid " .
@@ -573,17 +573,17 @@ class EventsController extends BaseApiController
             }
 
             $event['cfp_start_date'] = null;
-            $cfp_start_date          = $request->getParameter("cfp_start_date", false);
+            $cfp_start_date = $request->getParameter("cfp_start_date", false);
 
             if (false !== $cfp_start_date && strtotime($cfp_start_date)) {
-                $cfp_start_date          = new DateTime($cfp_start_date, $tz);
+                $cfp_start_date = new DateTime($cfp_start_date, $tz);
                 $event['cfp_start_date'] = $cfp_start_date->format('U');
             }
             $event['cfp_end_date'] = null;
-            $cfp_end_date          = $request->getParameter("cfp_end_date", false);
+            $cfp_end_date = $request->getParameter("cfp_end_date", false);
 
             if (false !== $cfp_end_date && strtotime($cfp_end_date)) {
-                $cfp_end_date          = new DateTime($cfp_end_date, $tz);
+                $cfp_end_date = new DateTime($cfp_end_date, $tz);
                 $event['cfp_end_date'] = $cfp_end_date->format('U');
             }
             $latitude = $request->getParameter("latitude", false);
@@ -598,7 +598,7 @@ class EventsController extends BaseApiController
             $longitude = $request->getParameter("longitude", false);
 
             if (false !== $longitude) {
-                $longitude          = filter_var($longitude, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+                $longitude = filter_var($longitude, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
                 $event['longitude'] = $longitude;
             }
             $incoming_tag_list = $request->getParameter('tags');
@@ -635,7 +635,7 @@ class EventsController extends BaseApiController
             throw new Exception("You must be logged in to view pending claims", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id = $this->getItemId($request);
         $event_mapper = $this->getEventMapper($db, $request);
 
         $pending_talk_claim_mapper = $this->getPendingTalkClaimMapper($db, $request);
@@ -670,8 +670,8 @@ class EventsController extends BaseApiController
             throw new Exception("You must be logged in to create a track", Http::UNAUTHORIZED);
         }
 
-        $track             = [];
-        $event_id          = $this->getItemId($request);
+        $track = [];
+        $event_id = $this->getItemId($request);
         $track['event_id'] = $event_id;
 
         if (empty($track['event_id'])) {
@@ -682,7 +682,7 @@ class EventsController extends BaseApiController
         }
 
         $event_mapper = new EventMapper($db, $request);
-        $events       = $event_mapper->getEventById($event_id, true);
+        $events = $event_mapper->getEventById($event_id, true);
 
         if (!$events || $events['meta']['count'] == 0) {
             throw new Exception("Associated event not found", Http::NOT_FOUND);
@@ -693,7 +693,7 @@ class EventsController extends BaseApiController
         }
 
         // validate fields
-        $errors              = [];
+        $errors = [];
         $track['track_name'] = filter_var(
             $request->getParameter("track_name"),
             FILTER_SANITIZE_STRING,
@@ -718,7 +718,7 @@ class EventsController extends BaseApiController
         }
 
         $track_mapper = new TrackMapper($db, $request);
-        $track_id     = $track_mapper->createEventTrack($track, $event_id);
+        $track_id = $track_mapper->createEventTrack($track, $event_id);
 
         $uri = $request->base . '/' . $request->version . '/tracks/' . $track_id;
 
@@ -745,7 +745,7 @@ class EventsController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id = $this->getItemId($request);
         $event_mapper = new EventMapper($db, $request);
 
         if (!$event_mapper->thisUserCanApproveEvents()) {
@@ -759,8 +759,8 @@ class EventsController extends BaseApiController
         }
 
         // Send a notification email as we have approved
-        $event        = $event_mapper->getEventById($event_id, true)['events'][0];
-        $recipients   = $event_mapper->getHostsEmailAddresses($event_id);
+        $event = $event_mapper->getEventById($event_id, true)['events'][0];
+        $recipients = $event_mapper->getHostsEmailAddresses($event_id);
         $emailService = new EventApprovedEmailService($this->config, $recipients, $event);
         $emailService->sendEmail();
 
@@ -786,7 +786,7 @@ class EventsController extends BaseApiController
             throw new Exception("You must be logged in to create data", Http::UNAUTHORIZED);
         }
 
-        $event_id     = $this->getItemId($request);
+        $event_id = $this->getItemId($request);
         $event_mapper = new EventMapper($db, $request);
         $reason = filter_var($request->getParameter('reason'), FILTER_SANITIZE_STRING);
 
@@ -802,8 +802,8 @@ class EventsController extends BaseApiController
 
         // Only send an email if we provided a reason
         if (!empty($reason)) {
-            $event        = $event_mapper->getEventById($event_id, true, false)['events'][0];
-            $recipients   = array_merge([$this->config['email']['from']], $event_mapper->getHostsEmailAddresses($event_id));
+            $event = $event_mapper->getEventById($event_id, true, false)['events'][0];
+            $recipients = array_merge([$this->config['email']['from']], $event_mapper->getHostsEmailAddresses($event_id));
             $emailService = new EventRejectedEmailService($this->config, $recipients, $event);
             $emailService->sendEmail();
         }

--- a/src/Controller/FacebookController.php
+++ b/src/Controller/FacebookController.php
@@ -36,8 +36,8 @@ class FacebookController extends BaseApiController
             throw new Exception("Cannot login via Facebook", Http::NOT_IMPLEMENTED);
         }
 
-        $clientId         = $request->getParameter('client_id');
-        $clientSecret     = $request->getParameter('client_secret');
+        $clientId = $request->getParameter('client_id');
+        $clientSecret = $request->getParameter('client_secret');
         $this->oauthModel = $request->getOauthModel($db);
 
         if (!$this->oauthModel->isClientPermittedPasswordGrant($clientId, $clientSecret)) {
@@ -56,10 +56,10 @@ class FacebookController extends BaseApiController
 
         $res = $client->get('https://graph.facebook.com/v2.10/oauth/access_token', [
             'query' => [
-                'client_id'     => $this->config['facebook']['app_id'],
-                'redirect_uri'  => $this->config['website_url'] . '/user/facebook-access',
+                'client_id' => $this->config['facebook']['app_id'],
+                'redirect_uri' => $this->config['website_url'] . '/user/facebook-access',
                 'client_secret' => $this->config['facebook']['app_secret'],
-                'code'          => $code,
+                'code' => $code,
             ]
         ]);
 
@@ -76,14 +76,14 @@ class FacebookController extends BaseApiController
             throw new Exception("Unexpected Facebook error", Http::INTERNAL_SERVER_ERROR);
         }
 
-        $data         = json_decode((string) $res->getBody(), true);
+        $data = json_decode((string) $res->getBody(), true);
         $access_token = $data['access_token'];
 
         // retrieve email address from Facebook profile
         $res = $client->get('https://graph.facebook.com/me', [
             'query' => [
                 'access_token' => $access_token,
-                'fields'       => 'name,email',
+                'fields' => 'name,email',
             ]
         ]);
 
@@ -96,9 +96,9 @@ class FacebookController extends BaseApiController
         if (!array_key_exists('email', $data)) {
             throw new Exception("Email address is unavailable", Http::FORBIDDEN);
         }
-        $email    = $data['email'];
+        $email = $data['email'];
         $fullName = $data['name'];
-        $id       = $data['id'];
+        $id = $data['id'];
 
         $result = $this->oauthModel->createAccessTokenFromTrustedEmail(
             $clientId,

--- a/src/Controller/LanguagesController.php
+++ b/src/Controller/LanguagesController.php
@@ -17,7 +17,7 @@ class LanguagesController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         $mapper = new LanguageMapper($db, $request);
-        $list   = $mapper->getLanguageById($language_id, $verbose);
+        $list = $mapper->getLanguageById($language_id, $verbose);
 
         if (count($list['languages']) == 0) {
             throw new Exception('Language not found', Http::NOT_FOUND);
@@ -32,7 +32,7 @@ class LanguagesController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         // pagination settings
-        $start          = $this->getStart($request);
+        $start = $this->getStart($request);
         $resultsperpage = $this->getResultsPerPage($request);
 
         $mapper = new LanguageMapper($db, $request);

--- a/src/Controller/TalkCommentsController.php
+++ b/src/Controller/TalkCommentsController.php
@@ -50,7 +50,7 @@ class TalkCommentsController extends BaseApiController
             throw new UnexpectedValueException("Event not found", Http::NOT_FOUND);
         }
 
-        $eventMapper   = new EventMapper($db, $request);
+        $eventMapper = new EventMapper($db, $request);
         $commentMapper = $this->getCommentMapper($request, $db);
 
         if (!isset($request->user_id) || empty($request->user_id)) {
@@ -75,23 +75,23 @@ class TalkCommentsController extends BaseApiController
 
         $commentMapper = $this->getCommentMapper($request, $db);
 
-        $commentId   = $this->getItemId($request);
+        $commentId = $this->getItemId($request);
         $commentInfo = $commentMapper->getCommentInfo($commentId);
 
         if (false === $commentInfo) {
             throw new Exception('Comment not found', Http::NOT_FOUND);
         }
 
-        $talkId  = $commentInfo['talk_id'];
+        $talkId = $commentInfo['talk_id'];
         $eventId = $commentInfo['event_id'];
 
         $commentMapper->userReportedComment($commentId, $request->user_id);
 
         // notify event admins
-        $comment      = $commentMapper->getCommentById($commentId, true, true);
-        $eventMapper  = new EventMapper($db, $request);
-        $recipients   = $eventMapper->getHostsEmailAddresses($eventId);
-        $event        = $eventMapper->getEventById($eventId, true, true);
+        $comment = $commentMapper->getCommentById($commentId, true, true);
+        $eventMapper = new EventMapper($db, $request);
+        $recipients = $eventMapper->getHostsEmailAddresses($eventId);
+        $event = $eventMapper->getEventById($eventId, true, true);
 
         $emailService = new CommentReportedEmailService($this->config, $recipients, $comment, $event);
         $emailService->sendEmail();
@@ -127,7 +127,7 @@ class TalkCommentsController extends BaseApiController
 
         $commentMapper = $this->getCommentMapper($request, $db);
 
-        $commentId   = $this->getItemId($request);
+        $commentId = $this->getItemId($request);
         $commentInfo = $commentMapper->getCommentInfo($commentId);
 
         if (false === $commentInfo) {
@@ -135,7 +135,7 @@ class TalkCommentsController extends BaseApiController
         }
 
         $eventMapper = new EventMapper($db, $request);
-        $eventId     = $commentInfo['event_id'];
+        $eventId = $commentInfo['event_id'];
 
         if (false == $eventMapper->thisUserHasAdminOn($eventId)) {
             throw new Exception("You don't have permission to do that", Http::FORBIDDEN);
@@ -149,8 +149,8 @@ class TalkCommentsController extends BaseApiController
 
         $commentMapper->moderateReportedComment($decision, $commentId, $request->user_id);
 
-        $talkId  = $commentInfo['talk_id'];
-        $uri     = $request->base . '/' . $request->version . '/talks/' . $talkId . "/comments";
+        $talkId = $commentInfo['talk_id'];
+        $uri = $request->base . '/' . $request->version . '/talks/' . $talkId . "/comments";
 
         $view = $request->getView();
         $view->setHeader('Location', $uri);
@@ -170,9 +170,9 @@ class TalkCommentsController extends BaseApiController
             throw new Exception('The field "comment" is required', Http::BAD_REQUEST);
         }
 
-        $commentId     = $this->getItemId($request);
+        $commentId = $this->getItemId($request);
         $commentMapper = $this->getCommentMapper($request, $db);
-        $comment       = $commentMapper->getRawComment($commentId);
+        $comment = $commentMapper->getRawComment($commentId);
 
         if (false === $comment) {
             throw new Exception('Comment not found', Http::NOT_FOUND);

--- a/src/Controller/TalkLinkController.php
+++ b/src/Controller/TalkLinkController.php
@@ -12,8 +12,8 @@ class TalkLinkController extends BaseTalkController
 {
     public function getTalkLinks(Request $request, PDO $db)
     {
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
         $talk_mapper = $this->getTalkMapper($db, $request);
 
         return ['talk_links' => ($talk_mapper->getTalkMediaLinks($talk_id))];
@@ -21,10 +21,10 @@ class TalkLinkController extends BaseTalkController
 
     public function getTalkLink(Request $request, PDO $db)
     {
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
         $talk_mapper = $this->getTalkMapper($db, $request);
-        $links       = $talk_mapper->getTalkMediaLinks($talk_id, $request->url_elements[5]);
+        $links = $talk_mapper->getTalkMediaLinks($talk_id, $request->url_elements[5]);
 
         if (count($links) !== 1) {
             throw new Exception(
@@ -38,15 +38,15 @@ class TalkLinkController extends BaseTalkController
 
     public function updateTalkLink(Request $request, PDO $db)
     {
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
         $talk_mapper = $this->getTalkMapper($db, $request);
 
         $this->checkAdminOrSpeaker($request, $talk_mapper, $talk_id);
 
-        $link_id      = $request->url_elements[5];
+        $link_id = $request->url_elements[5];
         $display_name = $request->getParameter('display_name');
-        $url          = $request->getParameter('url');
+        $url = $request->getParameter('url');
 
         if (!$talk_mapper->updateTalkLink($talk_id, $link_id, $display_name, $url)) {
             throw new Exception(
@@ -62,8 +62,8 @@ class TalkLinkController extends BaseTalkController
 
     public function removeTalkLink(Request $request, PDO $db)
     {
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
         $talk_mapper = $this->getTalkMapper($db, $request);
 
         $this->checkAdminOrSpeaker($request, $talk_mapper, $talk_id);
@@ -82,14 +82,14 @@ class TalkLinkController extends BaseTalkController
 
     public function addTalkLink(Request $request, PDO $db)
     {
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
         $talk_mapper = $this->getTalkMapper($db, $request);
         $this->checkAdminOrSpeaker($request, $talk_mapper, $talk_id);
 
         //Check the content is in the correct format
         $display_name = $request->getParameter('display_name');
-        $url          = $request->getParameter('url');
+        $url = $request->getParameter('url');
 
         if (!$display_name || ! $url) {
             throw new Exception(
@@ -121,7 +121,7 @@ class TalkLinkController extends BaseTalkController
      */
     protected function checkAdminOrSpeaker(Request $request, TalkMapper $mapper, $talk_id)
     {
-        $is_admin   = $mapper->thisUserHasAdminOn($talk_id);
+        $is_admin = $mapper->thisUserHasAdminOn($talk_id);
         $is_speaker = $mapper->isUserASpeakerOnTalk($talk_id, $request->user_id);
 
         if (!($is_admin || $is_speaker)) {

--- a/src/Controller/TalkTypesController.php
+++ b/src/Controller/TalkTypesController.php
@@ -16,7 +16,7 @@ class TalkTypesController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         // pagination settings
-        $start          = $this->getStart($request);
+        $start = $this->getStart($request);
         $resultsperpage = $this->getResultsPerPage($request);
 
         $mapper = new TalkTypeMapper($db, $request);
@@ -31,7 +31,7 @@ class TalkTypesController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         $mapper = new TalkTypeMapper($db, $request);
-        $list   = $mapper->getTalkTypeById($talk_type_id, $verbose);
+        $list = $mapper->getTalkTypeById($talk_type_id, $verbose);
 
         if (count($list['talk_types']) == 0) {
             throw new Exception('Talk type not found', Http::NOT_FOUND);

--- a/src/Controller/TalksController.php
+++ b/src/Controller/TalksController.php
@@ -46,7 +46,7 @@ class TalksController extends BaseTalkController
 
         $verbose = $this->getVerbosity($request);
 
-        $talk       = $this->getTalkById($request, $db, $talk_id, $verbose);
+        $talk = $this->getTalkById($request, $db, $talk_id, $verbose);
         $collection = new TalkModelCollection([$talk], 1);
 
         return $collection->getOutputView($request, $verbose);
@@ -59,7 +59,7 @@ class TalksController extends BaseTalkController
         $verbose = $this->getVerbosity($this->request);
 
         // pagination settings
-        $start          = $this->getStart($this->request);
+        $start = $this->getStart($this->request);
         $resultsperpage = $this->getResultsPerPage($this->request);
 
         /** @var TalkCommentMapper $comment_mapper */
@@ -74,7 +74,7 @@ class TalksController extends BaseTalkController
         $talk_id = $this->getItemId($request);
 
         /** @var TalkMapper $mapper */
-        $mapper  = $this->getMapper('talk');
+        $mapper = $this->getMapper('talk');
 
         return $mapper->getUserStarred($talk_id, $this->request->user_id);
     }
@@ -95,12 +95,12 @@ class TalksController extends BaseTalkController
 
         $verbose = $this->getVerbosity($this->request);
 
-        $start          = $this->getStart($this->request);
+        $start = $this->getStart($this->request);
         $resultsperpage = $this->getResultsPerPage($this->request);
 
         /** @var TalkMapper $mapper */
         $mapper = $this->getMapper('talk');
-        $talks  = $mapper->getTalksByTitleSearch($keyword, $resultsperpage, $start);
+        $talks = $mapper->getTalksByTitleSearch($keyword, $resultsperpage, $start);
 
         return $talks->getOutputView($this->request, $verbose);
     }
@@ -131,19 +131,19 @@ class TalksController extends BaseTalkController
                     $private = ($request->getParameter('private') ? 1 : 0);
 
                     // Get the API key reference to save against the comment
-                    $oauth_model   = $request->getOauthModel($db);
+                    $oauth_model = $request->getOauthModel($db);
                     $consumer_name = $oauth_model->getConsumerName($request->getAccessToken());
 
-                    $talk_mapper    = $this->getTalkMapper($db, $request);
+                    $talk_mapper = $this->getTalkMapper($db, $request);
                     /** @var TalkCommentMapper $comment_mapper */
                     $comment_mapper = $this->getMapper('talkcomment', $db, $request);
 
                     $data['user_id'] = $request->user_id;
                     $data['talk_id'] = $talk_id;
                     $data['comment'] = $comment;
-                    $data['rating']  = $rating;
+                    $data['rating'] = $rating;
                     $data['private'] = $private;
-                    $data['source']  = $consumer_name;
+                    $data['source'] = $consumer_name;
 
                     try {
                         $isValid = $this->spamCheckService->isCommentAcceptable(
@@ -173,8 +173,8 @@ class TalksController extends BaseTalkController
                     }
 
                     if ($new_id) {
-                        $comment    = $comment_mapper->getCommentById($new_id);
-                        $speakers   = $talk_mapper->getSpeakerEmailsByTalkId($talk_id);
+                        $comment = $comment_mapper->getCommentById($new_id);
+                        $speakers = $talk_mapper->getSpeakerEmailsByTalkId($talk_id);
                         $recipients = [];
 
                         foreach ($speakers as $person) {
@@ -221,7 +221,7 @@ class TalksController extends BaseTalkController
     {
         $this->checkLoggedIn($request);
 
-        $talk_id     = $this->getItemId($request);
+        $talk_id = $this->getItemId($request);
         $talk_mapper = $this->getTalkMapper($db, $request);
         $talk_mapper->setUserNonStarred($talk_id, $request->user_id);
 
@@ -234,7 +234,7 @@ class TalksController extends BaseTalkController
     {
         $this->checkLoggedIn($request);
 
-        $talk_id     = $this->getItemId($request);
+        $talk_id = $this->getItemId($request);
         $talk_mapper = $this->getTalkMapper($db, $request);
 
         $talk = $talk_mapper->getTalkById($talk_id);
@@ -272,10 +272,10 @@ class TalksController extends BaseTalkController
         }
 
         $talk_mapper = new TalkMapper($db, $request);
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
 
-        $is_admin   = $talk_mapper->thisUserHasAdminOn($talk_id);
+        $is_admin = $talk_mapper->thisUserHasAdminOn($talk_id);
         $is_speaker = $talk_mapper->isUserASpeakerOnTalk($talk_id, $request->user_id);
 
         if (!($is_admin || $is_speaker)) {
@@ -283,7 +283,7 @@ class TalksController extends BaseTalkController
         }
 
         $track_uri = $request->getParameter("track_uri");
-        $pattern   = '@/' . $request->version . '/tracks/([\d]+)$@';
+        $pattern = '@/' . $request->version . '/tracks/([\d]+)$@';
 
         if (!preg_match($pattern, $track_uri, $matches)) {
             throw new Exception('Invalid track_uri', Http::BAD_REQUEST);
@@ -334,10 +334,10 @@ class TalksController extends BaseTalkController
         $track_id = $request->url_elements[5];
 
         $talk_mapper = new TalkMapper($db, $request);
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
 
-        $is_admin   = $talk_mapper->thisUserHasAdminOn($talk_id);
+        $is_admin = $talk_mapper->thisUserHasAdminOn($talk_id);
         $is_speaker = $talk_mapper->isUserASpeakerOnTalk($talk_id, $request->user_id);
 
         if (!($is_admin || $is_speaker)) {
@@ -392,7 +392,7 @@ class TalksController extends BaseTalkController
         }
 
         $event_mapper = new EventMapper($db, $request);
-        $talk_mapper  = new TalkMapper($db, $request);
+        $talk_mapper = new TalkMapper($db, $request);
 
         $is_admin = $event_mapper->thisUserHasAdminOn($event_id);
 
@@ -401,7 +401,7 @@ class TalksController extends BaseTalkController
         }
 
         // retrieve the talk data from the request
-        $talk             = $this->getTalkDataFromRequest($db, $request, $event_id);
+        $talk = $this->getTalkDataFromRequest($db, $request, $event_id);
         $talk['event_id'] = $event_id;
 
         // create the talk
@@ -422,7 +422,7 @@ class TalksController extends BaseTalkController
         $request->getView()->setResponseCode(Http::CREATED);
         $request->getView()->setHeader('Location', $uri);
 
-        $new_talk   = $this->getTalkById($request, $db, $new_id);
+        $new_talk = $this->getTalkById($request, $db, $new_id);
         $collection = new TalkModelCollection([$new_talk], 1);
 
         return $collection->getOutputView($request);
@@ -449,7 +449,7 @@ class TalksController extends BaseTalkController
 
         $talk = $this->getTalkById($request, $db);
 
-        $is_admin   = $talk_mapper->thisUserHasAdminOn($talk_id);
+        $is_admin = $talk_mapper->thisUserHasAdminOn($talk_id);
         $is_speaker = $talk_mapper->isUserASpeakerOnTalk($talk_id, $request->user_id);
 
         if (!($is_admin || $is_speaker)) {
@@ -484,7 +484,7 @@ class TalksController extends BaseTalkController
     {
         // get the event so we can get the timezone info & it
         $event_mapper = new EventMapper($db, $request);
-        $list         = $event_mapper->getEventById($event_id, true);
+        $list = $event_mapper->getEventById($event_id, true);
 
         if (count($list['events']) == 0) {
             throw new Exception('Event not found', Http::NOT_FOUND);
@@ -518,7 +518,7 @@ class TalksController extends BaseTalkController
         );
 
         $talk_type_mapper = new TalkTypeMapper($db, $request);
-        $talk_types       = $talk_type_mapper->getTalkTypesLookupList();
+        $talk_types = $talk_type_mapper->getTalkTypesLookupList();
 
         if (!array_key_exists($talk['type'], $talk_types)) {
             throw new Exception("The type '{$talk['type']}' is unknown", Http::BAD_REQUEST);
@@ -534,11 +534,11 @@ class TalksController extends BaseTalkController
         if (empty($start_date)) {
             throw new Exception("Please give the date and time of the talk", Http::BAD_REQUEST);
         }
-        $tz           = new DateTimeZone($event['tz_continent'] . '/' . $event['tz_place']);
+        $tz = new DateTimeZone($event['tz_continent'] . '/' . $event['tz_place']);
         $talk['date'] = (new DateTime($start_date, $tz))->format('U');
 
         $event_start_date = (new DateTime($event['start_date']))->format('U');
-        $event_end_date   = (new DateTime($event['end_date']))->add(new DateInterval('P1D'))->format('U');
+        $event_end_date = (new DateTime($event['end_date']))->add(new DateInterval('P1D'))->format('U');
 
         if ($talk['date'] < $event_start_date || $talk['date'] >= $event_end_date) {
             throw new Exception("The talk must be held between the start and end date of the event", Http::BAD_REQUEST);
@@ -591,7 +591,7 @@ class TalksController extends BaseTalkController
     public function getSpeakersForTalk(Request $request, PDO $db)
     {
         $talk_id = $this->getItemId($request);
-        $talk    = $this->getTalkById($request, $db, $talk_id);
+        $talk = $this->getTalkById($request, $db, $talk_id);
 
         return $talk->speakers;
     }
@@ -600,17 +600,17 @@ class TalksController extends BaseTalkController
     {
         $this->checkLoggedIn($request);
 
-        $talk        = $this->getTalkById($request, $db);
-        $talk_id     = $talk->ID;
+        $talk = $this->getTalkById($request, $db);
+        $talk_id = $talk->ID;
         $talk_mapper = $this->getTalkMapper($db, $request);
 
-        $event_id     = $talk->event_id;
+        $event_id = $talk->event_id;
         $event_mapper = $this->getEventMapper($db, $request);
-        $event        = $event_mapper->getEventById($event_id);
+        $event = $event_mapper->getEventById($event_id);
 
-        $user_id     = $request->user_id;
+        $user_id = $request->user_id;
         $user_mapper = $this->getUserMapper($db, $request);
-        $user        = $user_mapper->getUserById($user_id)['users'][0];
+        $user = $user_mapper->getUserById($user_id)['users'][0];
 
         $data = $this->getLinkUserDataFromRequest($request);
 
@@ -639,7 +639,7 @@ class TalksController extends BaseTalkController
         $speaker_name = $user_mapper->getUserById($speaker_id)['users'][0]['full_name'];
 
         $pending_talk_claim_mapper = $this->getPendingTalkClaimMapper($db, $request);
-        $claim_exists              = $pending_talk_claim_mapper->claimExists($talk_id, $speaker_id, $claim['ID']);
+        $claim_exists = $pending_talk_claim_mapper->claimExists($talk_id, $speaker_id, $claim['ID']);
 
         if ($claim_exists === false) {
             //This is a new claim
@@ -647,7 +647,7 @@ class TalksController extends BaseTalkController
             if ($data['username'] === $user['username']) {
                 $pending_talk_claim_mapper->claimTalkAsSpeaker($talk_id, $user_id, $claim['ID']);
                 //We need to send an email to the host asking for confirmation
-                $recipients   = $event_mapper->getHostsEmailAddresses($event_id);
+                $recipients = $event_mapper->getHostsEmailAddresses($event_id);
                 $emailService = new TalkClaimEmailService($this->config, $recipients, $event, $talk);
 
                 if (!defined('UNIT_TEST')) {
@@ -656,8 +656,8 @@ class TalksController extends BaseTalkController
             } elseif ($talk_mapper->thisUserHasAdminOn($talk_id)) {
                 $pending_talk_claim_mapper->assignTalkAsHost($talk_id, $speaker_id, $claim['ID'], $user_id);
                 //We need to send an email to the speaker asking for confirmation
-                $recipients   = [$user_mapper->getEmailByUserId($speaker_id)];
-                $username     = $data['username'];
+                $recipients = [$user_mapper->getEmailByUserId($speaker_id)];
+                $username = $data['username'];
                 $emailService = new TalkAssignEmailService($this->config, $recipients, $event, $talk, $username);
 
                 if (!defined('UNIT_TEST')) {
@@ -669,7 +669,7 @@ class TalksController extends BaseTalkController
         } elseif ($claim_exists === PendingTalkClaimMapper::SPEAKER_CLAIM) {
             //The host needs to approve
             if ($talk_mapper->thisUserHasAdminOn($talk_id)) {
-                $method     = $this->getRequestParameter($request, 'action', 'approve');
+                $method = $this->getRequestParameter($request, 'action', 'approve');
                 $recipients = [$user_mapper->getEmailByUserId($speaker_id)];
 
                 $success = $pending_talk_claim_mapper->approveClaimAsHost($talk_id, $speaker_id, $claim['ID'])
@@ -720,7 +720,7 @@ class TalksController extends BaseTalkController
     {
         return [
             'display_name' => trim($request->getParameter('display_name', '')),
-            'username'     => trim($request->getParameter('username', '')),
+            'username' => trim($request->getParameter('username', '')),
         ];
     }
 
@@ -741,11 +741,11 @@ class TalksController extends BaseTalkController
     public function removeApprovedSpeakerFromTalk(Request $request, PDO $db)
     {
         $this->checkLoggedIn($request);
-        $talk_id    = $this->getItemId($request);
+        $talk_id = $this->getItemId($request);
         $speaker_id = $request->url_elements[5];
 
         $talk_mapper = new TalkMapper($db, $request);
-        $talk        = $this->getTalkById($request, $db, $talk_id);
+        $talk = $this->getTalkById($request, $db, $talk_id);
 
         $speaker = $talk_mapper->isUserASpeakerOnTalk($talk_id, $speaker_id);
 
@@ -753,7 +753,7 @@ class TalksController extends BaseTalkController
             throw new Exception("Provided user is not a speaker on this talk", Http::NOT_FOUND);
         }
 
-        $is_admin   = $talk_mapper->thisUserHasAdminOn($talk_id);
+        $is_admin = $talk_mapper->thisUserHasAdminOn($talk_id);
         $is_speaker = $talk_mapper->isUserASpeakerOnTalk($talk_id, $request->user_id);
 
         if (!($is_admin || $is_speaker)) {
@@ -778,13 +778,13 @@ class TalksController extends BaseTalkController
     public function removeSpeakerForTalk(Request $request, PDO $db)
     {
         $this->checkLoggedIn($request);
-        $talk        = $this->getTalkById($request, $db);
+        $talk = $this->getTalkById($request, $db);
         $talk_mapper = $this->getTalkMapper($db, $request);
-        $talk_id     = $talk->ID;
+        $talk_id = $talk->ID;
 
-        $event_id     = $talk->event_id;
+        $event_id = $talk->event_id;
         $event_mapper = $this->getEventMapper($db, $request);
-        $event        = $event_mapper->getEventById($event_id);
+        $event = $event_mapper->getEventById($event_id);
 
         $is_admin = $talk_mapper->thisUserHasAdminOn($talk_id);
 
@@ -795,7 +795,7 @@ class TalksController extends BaseTalkController
         $data = $this->getLinkUserDataFromRequest($request);
 
         $user_mapper = $this->getUserMapper($db, $request);
-        $speaker_id  = $user_mapper->getUserIdFromUsername($data['username']);
+        $speaker_id = $user_mapper->getUserIdFromUsername($data['username']);
 
         if (!$speaker_id) {
             throw new Exception("Specified user not found", Http::NOT_FOUND);
@@ -816,12 +816,12 @@ class TalksController extends BaseTalkController
         }
 
         $pending_talk_claim_mapper = $this->getPendingTalkClaimMapper($db, $request);
-        $claim_exists              = $pending_talk_claim_mapper->claimExists($talk_id, $speaker_id, $claim['ID']);
+        $claim_exists = $pending_talk_claim_mapper->claimExists($talk_id, $speaker_id, $claim['ID']);
 
         if ($claim_exists !== PendingTalkClaimMapper::SPEAKER_CLAIM) {
             throw new Exception("There was a problem with the claim", Http::INTERNAL_SERVER_ERROR);
         }
-        $method     = $this->getRequestParameter($request, 'action', 'approve');
+        $method = $this->getRequestParameter($request, 'action', 'approve');
         $recipients = [$user_mapper->getEmailByUserId($speaker_id)];
 
         $success = $pending_talk_claim_mapper->rejectClaimAsHost($talk_id, $speaker_id, $claim['ID']);

--- a/src/Controller/TokenController.php
+++ b/src/Controller/TokenController.php
@@ -21,8 +21,8 @@ class TokenController extends BaseApiController
         // password for an access token. This is used by web2.
 
         $grantType = $request->getParameter('grant_type');
-        $username  = $request->getParameter('username');
-        $password  = $request->getParameter('password');
+        $username = $request->getParameter('username');
+        $password = $request->getParameter('password');
 
         // all fields are required or this makes no sense
         if (empty($grantType)) {
@@ -39,7 +39,7 @@ class TokenController extends BaseApiController
 
         // authenticate the user for web2
 
-        $clientId     = $request->getParameter('client_id');
+        $clientId = $request->getParameter('client_id');
         $clientSecret = $request->getParameter('client_secret');
 
         if (!$this->oauthModel->isClientPermittedPasswordGrant($clientId, $clientSecret)) {
@@ -54,7 +54,7 @@ class TokenController extends BaseApiController
         // generate a temporary access token and then redirect back to the callback
         $username = $request->getParameter('username');
         $password = $request->getParameter('password');
-        $result   = $this->oauthModel->createAccessTokenFromPassword(
+        $result = $this->oauthModel->createAccessTokenFromPassword(
             $clientId,
             $username,
             $password

--- a/src/Controller/TracksController.php
+++ b/src/Controller/TracksController.php
@@ -20,7 +20,7 @@ class TracksController extends BaseApiController
 
         if ($track_id) {
             $mapper = new TrackMapper($db, $request);
-            $list   = $mapper->getTrackById($track_id, $verbose);
+            $list = $mapper->getTrackById($track_id, $verbose);
 
             if (false === $list) {
                 throw new Exception('Track not found', Http::NOT_FOUND);
@@ -43,14 +43,14 @@ class TracksController extends BaseApiController
         $track_id = $this->getItemId($request);
 
         $track_mapper = new TrackMapper($db, $request);
-        $tracks       = $track_mapper->getTrackById($track_id, true);
+        $tracks = $track_mapper->getTrackById($track_id, true);
 
         if (!$tracks) {
             throw new Exception("Track not found", Http::NOT_FOUND);
         }
 
         $event_mapper = new EventMapper($db, $request);
-        $events       = $event_mapper->getEventByTrackId($track_id, true, false, false);
+        $events = $event_mapper->getEventByTrackId($track_id, true, false, false);
 
         if (!$events || ! $events[0]['ID']) {
             throw new Exception("Associated event not found", Http::NOT_FOUND);
@@ -62,7 +62,7 @@ class TracksController extends BaseApiController
         }
 
         // validate fields
-        $errors              = [];
+        $errors = [];
         $track['track_name'] = filter_var(
             $request->getParameter("track_name"),
             FILTER_SANITIZE_STRING,
@@ -105,14 +105,14 @@ class TracksController extends BaseApiController
         $track_id = $this->getItemId($request);
 
         $track_mapper = new TrackMapper($db, $request);
-        $tracks       = $track_mapper->getTrackById($track_id, true);
+        $tracks = $track_mapper->getTrackById($track_id, true);
 
         if (!$tracks) {
             throw new Exception("Track not found", Http::NOT_FOUND);
         }
 
         $event_mapper = new EventMapper($db, $request);
-        $events       = $event_mapper->getEventByTrackId($track_id, true, false, false);
+        $events = $event_mapper->getEventByTrackId($track_id, true, false, false);
 
         if (!$events || ! $events[0]['ID']) {
             throw new Exception("Associated event not found", Http::NOT_FOUND);

--- a/src/Controller/TwitterController.php
+++ b/src/Controller/TwitterController.php
@@ -25,8 +25,8 @@ class TwitterController extends BaseApiController
     public function getRequestToken(Request $request, PDO $db)
     {
         // only trusted clients can change account details
-        $clientId         = $request->getParameter('client_id');
-        $clientSecret     = $request->getParameter('client_secret');
+        $clientId = $request->getParameter('client_id');
+        $clientSecret = $request->getParameter('client_secret');
         $this->oauthModel = $request->getOauthModel($db);
 
         if (!$this->oauthModel->isClientPermittedPasswordGrant($clientId, $clientSecret)) {
@@ -35,7 +35,7 @@ class TwitterController extends BaseApiController
 
         $stack = HandlerStack::create();
         $oauth = new Oauth1([
-            'consumer_key'    => $this->config['twitter']['consumer_key'],
+            'consumer_key' => $this->config['twitter']['consumer_key'],
             'consumer_secret' => $this->config['twitter']['consumer_secret'],
         ]);
         $stack->push($oauth);
@@ -57,7 +57,7 @@ class TwitterController extends BaseApiController
 
         $requestTokenMapper = new TwitterRequestTokenMapper($db);
         // $tokens is instance of TwitterRequestTokenModelCollection
-        $tokens      = $requestTokenMapper->create($data['oauth_token'], $data['oauth_token_secret']);
+        $tokens = $requestTokenMapper->create($data['oauth_token'], $data['oauth_token_secret']);
         $output_list = $tokens->getOutputView($request);
         $request->getView()->setHeader('Location', $output_list['twitter_request_tokens'][0]['uri']);
         $request->getView()->setResponseCode(Http::CREATED);
@@ -78,8 +78,8 @@ class TwitterController extends BaseApiController
      */
     public function logUserIn(Request $request, PDO $db)
     {
-        $clientId         = $request->getParameter('client_id');
-        $clientSecret     = $request->getParameter('client_secret');
+        $clientId = $request->getParameter('client_id');
+        $clientSecret = $request->getParameter('client_secret');
         $this->oauthModel = $request->getOauthModel($db);
 
         if (!$this->oauthModel->isClientPermittedPasswordGrant($clientId, $clientSecret)) {
@@ -98,9 +98,9 @@ class TwitterController extends BaseApiController
         // exchange request token for access token
         $stack = HandlerStack::create();
         $oauth = new Oauth1([
-            'consumer_key'    => $this->config['twitter']['consumer_key'],
+            'consumer_key' => $this->config['twitter']['consumer_key'],
             'consumer_secret' => $this->config['twitter']['consumer_secret'],
-            'token'           => $request_token,
+            'token' => $request_token,
         ]);
         $stack->push($oauth);
         $client = new Client([
@@ -127,10 +127,10 @@ class TwitterController extends BaseApiController
             // try to create the user.
             $stack1 = HandlerStack::create();
             $oauth1 = new Oauth1([
-                'consumer_key'    => $this->config['twitter']['consumer_key'],
+                'consumer_key' => $this->config['twitter']['consumer_key'],
                 'consumer_secret' => $this->config['twitter']['consumer_secret'],
-                'token'           => $data['oauth_token'],
-                'token_secret'    => $data['oauth_token_secret'],
+                'token' => $data['oauth_token'],
+                'token_secret' => $data['oauth_token_secret'],
             ]);
             $stack1->push($oauth1);
             $client1 = new Client([

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -34,14 +34,14 @@ class UsersController extends BaseApiController
         $verbose = $this->getVerbosity($request);
 
         // pagination settings
-        $start          = $this->getStart($request);
+        $start = $this->getStart($request);
         $resultsperpage = $this->getResultsPerPage($request);
 
         if (isset($request->url_elements[4])) {
             switch ($request->url_elements[4]) {
                 case 'talks':
                     $talkMapper = new TalkMapper($db, $request);
-                    $talks       = $talkMapper->getTalksBySpeaker($userId, $resultsperpage, $start, $verbose);
+                    $talks = $talkMapper->getTalksBySpeaker($userId, $resultsperpage, $start, $verbose);
 
                     return $talks->getOutputView($request, $verbose);
                 case 'hosted':
@@ -85,7 +85,7 @@ class UsersController extends BaseApiController
                 FILTER_SANITIZE_STRING,
                 FILTER_FLAG_NO_ENCODE_QUOTES
             );
-            $list     = $mapper->getUserByUsername($username, $verbose);
+            $list = $mapper->getUserByUsername($username, $verbose);
 
             if ($list === false) {
                 throw new Exception('Username not found', Http::NOT_FOUND);
@@ -114,7 +114,7 @@ class UsersController extends BaseApiController
             switch ($request->url_elements[3]) {
                 case 'verifications':
                     $userMapper = new UserMapper($db, $request);
-                    $token       = filter_var($request->getParameter("token"), FILTER_SANITIZE_STRING);
+                    $token = filter_var($request->getParameter("token"), FILTER_SANITIZE_STRING);
 
                     if (empty($token)) {
                         throw new Exception("Verification token must be supplied", Http::BAD_REQUEST);
@@ -136,7 +136,7 @@ class UsersController extends BaseApiController
                     throw new InvalidArgumentException('Unknown Subrequest', Http::NOT_FOUND);
             }
         } else {
-            $user   = [];
+            $user = [];
             $errors = [];
 
             $userMapper = $this->getUserMapper($db, $request);
@@ -209,7 +209,7 @@ class UsersController extends BaseApiController
                 FILTER_SANITIZE_STRING,
                 FILTER_FLAG_NO_ENCODE_QUOTES
             );
-            $user['biography']        = filter_var(
+            $user['biography'] = filter_var(
                 trim($request->getParameter("biography")),
                 FILTER_SANITIZE_STRING,
                 FILTER_FLAG_NO_ENCODE_QUOTES
@@ -221,7 +221,7 @@ class UsersController extends BaseApiController
             }
 
             $userId = $userMapper->createUser($user);
-            $view    = $request->getView();
+            $view = $request->getView();
             $view->setHeader('Location', $request->base . $request->path_info . '/' . $userId);
             $view->setResponseCode(Http::CREATED);
 
@@ -240,7 +240,7 @@ class UsersController extends BaseApiController
             // Generate a verification token and email it to the user
             $token = $userMapper->generateEmailVerificationTokenForUserId($userId);
 
-            $recipients   = [$user['email']];
+            $recipients = [$user['email']];
             $emailService = $this->getUserRegistrationEmailService($this->config, $recipients, $token);
             $emailService->sendEmail();
         }
@@ -268,7 +268,7 @@ class UsersController extends BaseApiController
         if (!$userMapper->thisUserHasAdminOn($userId)) {
             throw new Exception("Could not update user", Http::BAD_REQUEST);
         }
-        $oauthModel  = $request->getOauthModel($db);
+        $oauthModel = $request->getOauthModel($db);
         $accessToken = $request->getAccessToken();
 
         // only trusted clients can change account details
@@ -277,7 +277,7 @@ class UsersController extends BaseApiController
         }
 
         // start building up a representation of the user
-        $user   = ["user_id" => $userId];
+        $user = ["user_id" => $userId];
         $errors = [];
 
         // start with passwords
@@ -415,7 +415,7 @@ class UsersController extends BaseApiController
         }
         // now check the password complies with our rules
         $userMapper = new UserMapper($db, $request);
-        $validity    = $userMapper->checkPasswordValidity($password);
+        $validity = $userMapper->checkPasswordValidity($password);
 
         if (true !== $validity) {
             // the password wasn't acceptable, tell the user why

--- a/src/Header.php
+++ b/src/Header.php
@@ -36,7 +36,7 @@ class Header
     public function __construct($header, $values = [], $glue = ',')
     {
         $this->header = trim($header);
-        $this->glue   = $glue;
+        $this->glue = $glue;
 
         foreach ((array) $values as $value) {
             foreach ((array) $value as $v) {
@@ -141,19 +141,19 @@ class Header
 
         foreach ($this->values as $value) {
             $parts = explode('=', $value);
-            $key   = ucwords($parts[0]);
+            $key = ucwords($parts[0]);
 
             if (count($parts) === 1) {
                 if (array_key_exists(0, $assocArray)) {
                     $assocArray[0][] = $parts[0];
                 } else {
-                    $assocArray[0]   = [];
+                    $assocArray[0] = [];
                     $assocArray[0][] = $parts[0];
                 }
             } elseif (array_key_exists($key, $assocArray)) {
                 $assocArray[$key][] = $parts[1];
             } else {
-                $assocArray[$key]   = [];
+                $assocArray[$key] = [];
                 $assocArray[$key][] = $parts[1];
             }
         }
@@ -163,7 +163,7 @@ class Header
 
     public function parseParams()
     {
-        $params   = $matches = [];
+        $params = $matches = [];
         $callback = [$this, 'trimHeader'];
 
         // Normalize the header into a single array and iterate over all values
@@ -174,7 +174,7 @@ class Header
                 if (!preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches)) {
                     continue;
                 }
-                $pieces           = array_map($callback, $matches[0]);
+                $pieces = array_map($callback, $matches[0]);
                 $part[$pieces[0]] = $pieces[1] ?? '';
             }
 

--- a/src/Model/ApiMapper.php
+++ b/src/Model/ApiMapper.php
@@ -30,7 +30,7 @@ class ApiMapper
         $this->_db = $db;
 
         if (isset($request)) {
-            $this->_request    = $request;
+            $this->_request = $request;
             $this->website_url = $request->getConfigValue('website_url');
         }
     }
@@ -117,7 +117,7 @@ class ApiMapper
         if (false !== $limitPos) {
             $sqlQuery = substr($sqlQuery, 0, $limitPos);
         }
-        $countSql  = sprintf(
+        $countSql = sprintf(
             'SELECT count(*) AS count FROM (%s) as counter',
             $sqlQuery
         );
@@ -136,20 +136,20 @@ class ApiMapper
     {
         $request = $this->_request;
 
-        $meta['count']     = count($list);
-        $meta['total']     = $total;
+        $meta['count'] = count($list);
+        $meta['total'] = $total;
         $meta['this_page'] = $request->base . $request->path_info . '?' .
                              http_build_query($request->paginationParameters);
-        $next_params       = $request->paginationParameters;
-        $prev_params       = $request->paginationParameters;
-        $counter_params    = $request->paginationParameters;
-        $firstOnNextPage   = $counter_params['start'] +
+        $next_params = $request->paginationParameters;
+        $prev_params = $request->paginationParameters;
+        $counter_params = $request->paginationParameters;
+        $firstOnNextPage = $counter_params['start'] +
                              $counter_params['resultsperpage'];
-        $firstOnThisPage   = $counter_params['start'];
+        $firstOnThisPage = $counter_params['start'];
 
         if ($firstOnNextPage < $total) {
             $next_params['start'] = $next_params['start'] + $next_params['resultsperpage'];
-            $meta['next_page']    = $request->base . $request->path_info . '?' .
+            $meta['next_page'] = $request->base . $request->path_info . '?' .
                                     http_build_query($next_params);
         }
 

--- a/src/Model/BaseModelCollection.php
+++ b/src/Model/BaseModelCollection.php
@@ -21,7 +21,7 @@ abstract class BaseModelCollection
     {
         $meta['count'] = count($this->list);
 
-        $meta['total']     = $this->total;
+        $meta['total'] = $this->total;
         $meta['this_page'] = $request->base . $request->path_info . '?' .
                              http_build_query($request->paginationParameters);
 
@@ -32,7 +32,7 @@ abstract class BaseModelCollection
 
         if ($firstOnNextPage < $this->total) {
             $next_params['start'] = $next_params['start'] + $next_params['resultsperpage'];
-            $meta['next_page']    = $request->base . $request->path_info . '?' . http_build_query($next_params);
+            $meta['next_page'] = $request->base . $request->path_info . '?' . http_build_query($next_params);
         }
 
         if (0 < $firstOnThisPage) {

--- a/src/Model/ClientMapper.php
+++ b/src/Model/ClientMapper.php
@@ -48,7 +48,7 @@ class ClientMapper extends ApiMapper
         $sql = 'SELECT * FROM oauth_consumers WHERE user_id = :user_id ';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':user_id' => $user_id
         ]);
@@ -58,7 +58,7 @@ class ClientMapper extends ApiMapper
         }
 
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        $total   = $this->getTotalCount($sql, [':user_id' => $user_id]);
+        $total = $this->getTotalCount($sql, [':user_id' => $user_id]);
         $results = $this->processResults($results);
 
         return new ClientModelCollection($results, $total);
@@ -77,9 +77,9 @@ class ClientMapper extends ApiMapper
         $sql = 'SELECT * FROM oauth_consumers WHERE user_id = :user_id and id = :client_id';
         $sql .= $this->buildLimit(1, 0);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
-            ':user_id'   => $userId,
+            ':user_id' => $userId,
             ':client_id' => $clientId,
         ]);
 
@@ -111,13 +111,13 @@ class ClientMapper extends ApiMapper
 
         $stmt = $this->_db->prepare($clientSql);
         $stmt->execute([
-            ':consumer_key'          => base64_encode(openssl_random_pseudo_bytes(48)),
-            ':consumer_secret'       => base64_encode(openssl_random_pseudo_bytes(48)),
-            ':created_date'          => (new DateTime())->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
-            ':user_id'               => $data['user_id'],
-            ':application'           => $data['name'],
-            ':description'           => $data['description'],
-            ':callback_url'          => $data['callback_url'],
+            ':consumer_key' => base64_encode(openssl_random_pseudo_bytes(48)),
+            ':consumer_secret' => base64_encode(openssl_random_pseudo_bytes(48)),
+            ':created_date' => (new DateTime())->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+            ':user_id' => $data['user_id'],
+            ':application' => $data['name'],
+            ':description' => $data['description'],
+            ':callback_url' => $data['callback_url'],
             ':enable_password_grant' => 1,
         ]);
 
@@ -148,10 +148,10 @@ class ClientMapper extends ApiMapper
         $stmt = $this->_db->prepare($clientSql);
 
         $result = $stmt->execute([
-            ':application'  => $data['name'],
-            ':description'  => $data['description'],
+            ':application' => $data['name'],
+            ':description' => $data['description'],
             ':callback_url' => $data['callback_url'],
-            ':client_id'    => $clientId,
+            ':client_id' => $clientId,
         ]);
 
         if (!$result) {

--- a/src/Model/ClientModel.php
+++ b/src/Model/ClientModel.php
@@ -23,8 +23,8 @@ class ClientModel extends BaseModel
         return [
             'consumer_key' => 'consumer_key',
             'created_date' => 'created_date',
-            'application'  => 'application',
-            'description'  => 'description',
+            'application' => 'application',
+            'description' => 'description',
             'callback_url' => 'callback_url',
         ];
     }
@@ -41,7 +41,7 @@ class ClientModel extends BaseModel
         $fields = $this->getDefaultFields();
 
         $fields['consumer_secret'] = 'consumer_secret';
-        $fields['user_id']         = 'user_id';
+        $fields['user_id'] = 'user_id';
 
         return $fields;
     }

--- a/src/Model/ClientModelCollection.php
+++ b/src/Model/ClientModelCollection.php
@@ -24,7 +24,7 @@ class ClientModelCollection extends BaseModelCollection
     public function __construct(array $data, $total)
     {
         $this->total = $total;
-        $this->list  = [];
+        $this->list = [];
 
         // hydrate the model objects if necessary and store to list
         foreach ($data as $item) {

--- a/src/Model/EventCommentMapper.php
+++ b/src/Model/EventCommentMapper.php
@@ -11,8 +11,8 @@ class EventCommentMapper extends ApiMapper
     {
         // warning, users added in build array
         return [
-            'rating'       => 'rating',
-            'comment'      => 'comment',
+            'rating' => 'rating',
+            'comment' => 'comment',
             'created_date' => 'date_made'
         ];
     }
@@ -20,9 +20,9 @@ class EventCommentMapper extends ApiMapper
     public function getVerboseFields()
     {
         return [
-            'rating'       => 'rating',
-            'comment'      => 'comment',
-            'source'       => 'source',
+            'rating' => 'rating',
+            'comment' => 'comment',
+            'source' => 'source',
             'created_date' => 'date_made',
         ];
     }
@@ -37,16 +37,16 @@ class EventCommentMapper extends ApiMapper
      */
     public function getEventCommentsByEventId($event_id, $resultsperpage, $start, $verbose = false)
     {
-        $sql      = $this->getBasicSQL();
-        $sql      .= 'and event_id = :event_id order by date_made desc ';
-        $sql      .= $this->buildLimit($resultsperpage, $start);
-        $stmt     = $this->_db->prepare($sql);
+        $sql = $this->getBasicSQL();
+        $sql .= 'and event_id = :event_id order by date_made desc ';
+        $sql .= $this->buildLimit($resultsperpage, $start);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':event_id' => $event_id
         ]);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, [':event_id' => $event_id]);
 
             return $this->transformResults($results, $verbose);
@@ -64,9 +64,9 @@ class EventCommentMapper extends ApiMapper
      */
     public function getCommentById($comment_id, $verbose = false, $include_hidden = false)
     {
-        $sql      = $this->getBasicSQL($include_hidden);
-        $sql      .= 'and ec.ID = :comment_id ';
-        $stmt     = $this->_db->prepare($sql);
+        $sql = $this->getBasicSQL($include_hidden);
+        $sql .= 'and ec.ID = :comment_id ';
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':comment_id' => $comment_id
         ]);
@@ -105,7 +105,7 @@ class EventCommentMapper extends ApiMapper
 
         return [
             'comments' => $list,
-            'meta'     => $this->getPaginationLinks($list, $total),
+            'meta' => $this->getPaginationLinks($list, $total),
         ];
     }
 
@@ -121,9 +121,9 @@ class EventCommentMapper extends ApiMapper
      */
     protected function formatOneComment($row, $verbose)
     {
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
-        $result  = []; // store formatted item here
+        $result = []; // store formatted item here
 
         if (true === $verbose) {
             $result['gravatar_hash'] = md5(strtolower($row['email']));
@@ -131,23 +131,23 @@ class EventCommentMapper extends ApiMapper
         // figure out user
         if ($row['user_id']) {
             $result['user_display_name'] = $row['full_name'];
-            $result['username']          = $row['username'];
-            $result['user_uri']          = $base . '/' . $version . '/users/'
+            $result['username'] = $row['username'];
+            $result['user_uri'] = $base . '/' . $version . '/users/'
                                            . $row['user_id'];
         } else {
             $result['user_display_name'] = $row['cname'];
         }
 
         // useful links
-        $result['comment_uri']         = $base . '/' . $version . '/event_comments/'
+        $result['comment_uri'] = $base . '/' . $version . '/event_comments/'
                                          . $row['ID'];
         $result['verbose_comment_uri'] = $base . '/' . $version . '/event_comments/'
                                          . $row['ID'] . '?verbose=yes';
-        $result['event_uri']           = $base . '/' . $version . '/events/'
+        $result['event_uri'] = $base . '/' . $version . '/events/'
                                          . $row['event_id'];
-        $result['event_comments_uri']  = $base . '/' . $version . '/events/'
+        $result['event_comments_uri'] = $base . '/' . $version . '/events/'
                                          . $row['event_id'] . '/comments';
-        $result['reported_uri']        = $base . '/' . $version . '/event_comments/'
+        $result['reported_uri'] = $base . '/' . $version . '/event_comments/'
                                          . $row['ID'] . '/reported';
 
         return $result;
@@ -177,8 +177,8 @@ class EventCommentMapper extends ApiMapper
         $dupe_stmt = $this->_db->prepare($dupe_sql);
         $dupe_stmt->execute([
             ':event_id' => $data['event_id'],
-            ':comment'  => $data['comment'],
-            ':user_id'  => $data['user_id'],
+            ':comment' => $data['comment'],
+            ':user_id' => $data['user_id'],
         ]);
 
         // only proceed if we didn't already find a row like this
@@ -190,14 +190,14 @@ class EventCommentMapper extends ApiMapper
                . 'source, date_made, active) '
                . 'values (:event_id, :rating, :comment, :user_id, :cname, :source, UNIX_TIMESTAMP(), 1)';
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':event_id' => $data['event_id'],
-            ':rating'   => $data['rating'],
-            ':comment'  => $data['comment'],
-            ':cname'    => $data['cname'],
-            ':user_id'  => $data['user_id'],
-            ':source'   => $data['source'],
+            ':rating' => $data['rating'],
+            ':comment' => $data['comment'],
+            ':cname' => $data['cname'],
+            ':user_id' => $data['user_id'],
+            ':source' => $data['source'],
         ]);
 
         return $this->_db->lastInsertId();
@@ -219,7 +219,7 @@ class EventCommentMapper extends ApiMapper
         $stmt = $this->_db->prepare($sql);
         $stmt->execute([
             ':event_id' => $event_id,
-            ':user_id'  => $user_id,
+            ':user_id' => $user_id,
         ]);
 
         if ($stmt->fetch()) {
@@ -267,15 +267,15 @@ class EventCommentMapper extends ApiMapper
             reporting_date = NOW()";
 
         $report_stmt = $this->_db->prepare($report_sql);
-        $result      = $report_stmt->execute([
+        $result = $report_stmt->execute([
             "event_comment_id" => $comment_id,
-            "user_id"          => $user_id
+            "user_id" => $user_id
         ]);
 
-        $hide_sql  = "update event_comments
+        $hide_sql = "update event_comments
             set active = 0 where ID = :event_comment_id";
         $hide_stmt = $this->_db->prepare($hide_sql);
-        $result    = $hide_stmt->execute(["event_comment_id" => $comment_id]);
+        $result = $hide_stmt->execute(["event_comment_id" => $comment_id]);
     }
 
     /**
@@ -306,13 +306,13 @@ class EventCommentMapper extends ApiMapper
             $sql .= " and rc.decision is null";
         }
 
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute(['event_id' => $event_id]);
 
         // need to also set the comment info
-        $list         = [];
-        $total        = 0;
-        $comment_sql  = $this->getBasicSQL(true)
+        $list = [];
+        $total = 0;
+        $comment_sql = $this->getBasicSQL(true)
                         . " and ec.ID = :comment_id";
         $comment_stmt = $this->_db->prepare($comment_sql);
 
@@ -322,9 +322,9 @@ class EventCommentMapper extends ApiMapper
 
             if ($comment_result && $comment = $comment_stmt->fetch(PDO::FETCH_ASSOC)) {
                 // work around the existing transform logic
-                $comment_array  = [$comment];
-                $comment_array  = parent::transformResults($comment_array, true);
-                $item           = current($comment_array);
+                $comment_array = [$comment];
+                $comment_array = parent::transformResults($comment_array, true);
+                $item = current($comment_array);
                 $row['comment'] = array_merge($item, $this->formatOneComment($comment, true));
             }
             $list[] = new EventCommentReportModel($row);
@@ -345,21 +345,21 @@ class EventCommentMapper extends ApiMapper
     {
         if (in_array($decision, ['approved', 'denied'])) {
             // record the decision
-            $sql  = 'update reported_event_comments set 
+            $sql = 'update reported_event_comments set 
                         decision = :decision,
                         deciding_user_id = :user_id,
                         deciding_date = NOW()
                     where event_comment_id = :comment_id';
             $stmt = $this->_db->prepare($sql);
             $stmt->execute([
-                'decision'   => $decision,
-                'user_id'    => $user_id,
+                'decision' => $decision,
+                'user_id' => $user_id,
                 'comment_id' => $comment_id,
             ]);
 
             if ($decision == 'denied') {
                 // the report is denied, therefore make the comment active again
-                $show_sql  = "update event_comments set active = 1 where ID = :comment_id";
+                $show_sql = "update event_comments set active = 1 where ID = :comment_id";
                 $show_stmt = $this->_db->prepare($show_sql);
                 $show_stmt->execute(["comment_id" => $comment_id]);
             }

--- a/src/Model/EventCommentReportModel.php
+++ b/src/Model/EventCommentReportModel.php
@@ -22,11 +22,11 @@ class EventCommentReportModel extends BaseModel
     public function getDefaultFields()
     {
         return [
-            'reporting_date'          => 'reporting_date',
-            'decision'                => 'decision',
-            'deciding_date'           => 'deciding_date',
+            'reporting_date' => 'reporting_date',
+            'decision' => 'decision',
+            'deciding_date' => 'deciding_date',
             'reporting_user_username' => 'reporting_username',
-            'deciding_user_username'  => 'deciding_username',
+            'deciding_user_username' => 'deciding_username',
         ];
     }
 
@@ -68,7 +68,7 @@ class EventCommentReportModel extends BaseModel
         $item = parent::getOutputView($request, $verbose);
 
         // add Hypermedia
-        $base    = $request->base;
+        $base = $request->base;
         $version = $request->version;
 
         $item['reporting_user_uri'] = $base . '/' . $version . '/users/' . $this->reporting_user_id;

--- a/src/Model/EventHostMapper.php
+++ b/src/Model/EventHostMapper.php
@@ -13,7 +13,7 @@ class EventHostMapper extends ApiMapper
     {
         return [
             'host_name' => 'host_name',
-            'host_uri'  => 'host_uri',
+            'host_uri' => 'host_uri',
         ];
     }
 
@@ -39,7 +39,7 @@ class EventHostMapper extends ApiMapper
         $sql .= ' order by host_name ';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':event_id' => $event_id
         ]);
@@ -48,7 +48,7 @@ class EventHostMapper extends ApiMapper
             return false;
         }
 
-        $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
         $results['total'] = $this->getTotalCount($sql, [':event_id' => $event_id]);
 
         return $this->transformResults($results, $verbose);
@@ -62,13 +62,13 @@ class EventHostMapper extends ApiMapper
      */
     public function addHostToEvent($event_id, $host_id)
     {
-        $sql  = 'INSERT INTO user_admin (uid, rid, rtype) VALUES (:host_id, :event_id, :type)';
+        $sql = 'INSERT INTO user_admin (uid, rid, rtype) VALUES (:host_id, :event_id, :type)';
         $stmt = $this->_db->prepare($sql);
 
         $response = $stmt->execute([
-            ':host_id'  => $host_id,
+            ':host_id' => $host_id,
             ':event_id' => $event_id,
-            ':type'     => 'event',
+            ':type' => 'event',
         ]);
 
         if (!$response) {
@@ -86,13 +86,13 @@ class EventHostMapper extends ApiMapper
      */
     public function removeHostFromEvent($host_id, $event_id)
     {
-        $sql  = 'DELETE FROM user_admin WHERE uid = :user_id AND rid = :event_id AND rtype = :type';
+        $sql = 'DELETE FROM user_admin WHERE uid = :user_id AND rid = :event_id AND rtype = :type';
         $stmt = $this->_db->prepare($sql);
 
         return $stmt->execute([
-            ':user_id'  => $host_id,
+            ':user_id' => $host_id,
             ':event_id' => $event_id,
-            ':type'     => 'event',
+            ':type' => 'event',
         ]);
     }
 
@@ -116,8 +116,8 @@ class EventHostMapper extends ApiMapper
     {
         $total = $results['total'];
         unset($results['total']);
-        $list    = parent::transformResults($results, $verbose);
-        $base    = $this->_request->base;
+        $list = parent::transformResults($results, $verbose);
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
         // add per-item links
@@ -132,12 +132,12 @@ class EventHostMapper extends ApiMapper
         foreach ($results as $key => $row) {
             // generate and store an inflected event name if there isn't one already
             $list[$key]['host_name'] = $row['host_name'];
-            $list[$key]['host_uri']  = $base . '/' . $version . '/users/' . $row['user_id'];
+            $list[$key]['host_uri'] = $base . '/' . $version . '/users/' . $row['user_id'];
         }
 
         return [
             'hosts' => $list,
-            'meta'  => $this->getPaginationLinks($list, $total),
+            'meta' => $this->getPaginationLinks($list, $total),
         ];
     }
 }

--- a/src/Model/EventMapper.php
+++ b/src/Model/EventMapper.php
@@ -22,24 +22,24 @@ class EventMapper extends ApiMapper
     public function getDefaultFields()
     {
         return [
-            'name'                 => 'event_name',
-            'url_friendly_name'    => 'url_friendly_name',
-            'start_date'           => 'event_start',
-            'end_date'             => 'event_end',
-            'description'          => 'event_desc',
-            'stub'                 => 'event_stub',
-            'href'                 => 'event_href',
-            'tz_continent'         => 'event_tz_cont',
-            'tz_place'             => 'event_tz_place',
-            'attendee_count'       => 'attendee_count',
-            'attending'            => 'attending',
+            'name' => 'event_name',
+            'url_friendly_name' => 'url_friendly_name',
+            'start_date' => 'event_start',
+            'end_date' => 'event_end',
+            'description' => 'event_desc',
+            'stub' => 'event_stub',
+            'href' => 'event_href',
+            'tz_continent' => 'event_tz_cont',
+            'tz_place' => 'event_tz_place',
+            'attendee_count' => 'attendee_count',
+            'attending' => 'attending',
             'event_average_rating' => 'avg_rating',
             'event_comments_count' => 'comment_count',
-            'tracks_count'         => 'track_count',
-            'talks_count'          => 'talk_count',
-            'icon'                 => 'event_icon',
-            'location'             => 'event_loc',
-            'rejection_reason'     => 'rejection_reason',
+            'tracks_count' => 'track_count',
+            'talks_count' => 'talk_count',
+            'icon' => 'event_icon',
+            'location' => 'event_loc',
+            'rejection_reason' => 'rejection_reason',
         ];
     }
 
@@ -53,32 +53,32 @@ class EventMapper extends ApiMapper
     public function getVerboseFields()
     {
         return [
-            'name'                 => 'event_name',
-            'url_friendly_name'    => 'url_friendly_name',
-            'start_date'           => 'event_start',
-            'end_date'             => 'event_end',
-            'description'          => 'event_desc',
-            'stub'                 => 'event_stub',
-            'href'                 => 'event_href',
-            'icon'                 => 'event_icon',
-            'latitude'             => 'event_lat',
-            'longitude'            => 'event_long',
-            'tz_continent'         => 'event_tz_cont',
-            'tz_place'             => 'event_tz_place',
-            'location'             => 'event_loc',
-            'contact_name'         => 'event_contact_name',
-            'hashtag'              => 'event_hashtag',
-            'attendee_count'       => 'attendee_count',
-            'attending'            => 'attending',
+            'name' => 'event_name',
+            'url_friendly_name' => 'url_friendly_name',
+            'start_date' => 'event_start',
+            'end_date' => 'event_end',
+            'description' => 'event_desc',
+            'stub' => 'event_stub',
+            'href' => 'event_href',
+            'icon' => 'event_icon',
+            'latitude' => 'event_lat',
+            'longitude' => 'event_long',
+            'tz_continent' => 'event_tz_cont',
+            'tz_place' => 'event_tz_place',
+            'location' => 'event_loc',
+            'contact_name' => 'event_contact_name',
+            'hashtag' => 'event_hashtag',
+            'attendee_count' => 'attendee_count',
+            'attending' => 'attending',
             'event_average_rating' => 'avg_rating',
-            'comments_enabled'     => 'comments_enabled',
+            'comments_enabled' => 'comments_enabled',
             'event_comments_count' => 'comment_count',
-            'tracks_count'         => 'track_count',
-            'talks_count'          => 'talk_count',
-            'cfp_start_date'       => 'event_cfp_start',
-            'cfp_end_date'         => 'event_cfp_end',
-            'cfp_url'              => 'event_cfp_url',
-            'rejection_reason'     => 'rejection_reason',
+            'tracks_count' => 'track_count',
+            'talks_count' => 'talk_count',
+            'cfp_start_date' => 'event_cfp_start',
+            'cfp_end_date' => 'event_cfp_end',
+            'cfp_url' => 'event_cfp_url',
+            'rejection_reason' => 'rejection_reason',
         ];
     }
 
@@ -140,7 +140,7 @@ class EventMapper extends ApiMapper
      */
     protected function getEvents($resultsperpage, $start, array $params = [])
     {
-        $data  = [];
+        $data = [];
         $order = " order by ";
         $where = "";
 
@@ -170,14 +170,14 @@ class EventMapper extends ApiMapper
         }
 
         if (array_key_exists("track_id", $params)) {
-            $sql              .= "right join event_track on event_track.event_id = events.ID and event_track.ID = :track_id";
+            $sql .= "right join event_track on event_track.event_id = events.ID and event_track.ID = :track_id";
             $data['track_id'] = $params['track_id'];
         }
 
         $sql .= ' where (events.private <> "y" OR events.private IS NULL) ';
 
         if (array_key_exists("event_id", $params)) {
-            $where            .= "and events.ID = :event_id ";
+            $where .= "and events.ID = :event_id ";
             $data["event_id"] = $params["event_id"];
         }
 
@@ -219,9 +219,9 @@ class EventMapper extends ApiMapper
 
                     break;
                 case "pending": // events to be approved
-                    $order  .= 'events.event_start';
+                    $order .= 'events.event_start';
                     $active = false;
-                    $where  .= ' and pending = 1';
+                    $where .= ' and pending = 1';
 
                     break;
 
@@ -240,14 +240,14 @@ class EventMapper extends ApiMapper
         }
 
         if (array_key_exists("stub", $params)) {
-            $where        .= ' and events.event_stub = :stub';
+            $where .= ' and events.event_stub = :stub';
             $data['stub'] = $params['stub'];
         }
 
         // fuzzy/partial match for title
         if (array_key_exists("title", $params)) {
-            $order         .= ', events.event_start desc';
-            $where         .= ' and LOWER(events.event_name) like :title';
+            $order .= ', events.event_start desc';
+            $where .= ' and LOWER(events.event_name) like :title';
             $data['title'] = "%" . strtolower($params['title']) . "%";
         }
 
@@ -262,7 +262,7 @@ class EventMapper extends ApiMapper
                     $where .= " OR ";
                 }
 
-                $where            .= "tags.tag_value = :tag" . $i;
+                $where .= "tags.tag_value = :tag" . $i;
                 $data["tag" . $i] = $tag;
                 $i++;
             }
@@ -271,12 +271,12 @@ class EventMapper extends ApiMapper
         }
 
         if (array_key_exists("startdate", $params)) {
-            $where             .= ' and events.event_start >= :startdate ';
+            $where .= ' and events.event_start >= :startdate ';
             $data["startdate"] = $params["startdate"];
         }
 
         if (array_key_exists("enddate", $params)) {
-            $where           .= ' and events.event_start < :enddate ';
+            $where .= ' and events.event_start < :enddate ';
             $data["enddate"] = $params["enddate"];
         }
 
@@ -286,7 +286,7 @@ class EventMapper extends ApiMapper
         if (array_key_exists("filter", $params) && $params['filter'] == 'all' && $start === null) {
             // How many events are there up to "now"?
             $this_sql = $sql . $where . ' and (events.event_start <' . (mktime(0, 0, 0)) . ')';
-            $start    = $this->getTotalCount($this_sql, $data);
+            $start = $this->getTotalCount($this_sql, $data);
 
             // store back into paginationParameters so that meta is correct
             $this->_request->paginationParameters['start'] = $start;
@@ -304,12 +304,12 @@ class EventMapper extends ApiMapper
         $sql .= $order;
 
         // limit clause
-        $sql      .= $this->buildLimit($resultsperpage, $start);
-        $stmt     = $this->_db->prepare($sql);
+        $sql .= $this->buildLimit($resultsperpage, $start);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute($data);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, $data);
 
             return $results;
@@ -349,7 +349,7 @@ class EventMapper extends ApiMapper
      */
     public function setUserAttendance($event_id, $user_id)
     {
-        $sql  = 'insert ignore into user_attend (uid,eid) values (:uid, :eid)';
+        $sql = 'insert ignore into user_attend (uid,eid) values (:uid, :eid)';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['uid' => $user_id, 'eid' => $event_id]);
 
@@ -366,7 +366,7 @@ class EventMapper extends ApiMapper
      */
     public function setUserNonAttendance($event_id, $user_id)
     {
-        $sql  = 'delete from user_attend where uid = :uid and eid = :eid';
+        $sql = 'delete from user_attend where uid = :uid and eid = :eid';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['uid' => $user_id, 'eid' => $event_id]);
 
@@ -397,7 +397,7 @@ class EventMapper extends ApiMapper
      */
     protected function isUserAttendingEvent($event_id, $user_id)
     {
-        $sql  = "select * from user_attend where eid = :event_id and uid = :user_id";
+        $sql = "select * from user_attend where eid = :event_id and uid = :user_id";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(["event_id" => $event_id, "user_id" => $user_id]);
 
@@ -411,8 +411,8 @@ class EventMapper extends ApiMapper
     {
         $total = $results['total'];
         unset($results['total']);
-        $list    = parent::transformResults($results, $verbose);
-        $base    = $this->_request->base;
+        $list = parent::transformResults($results, $verbose);
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
         // add per-item links
@@ -436,16 +436,16 @@ class EventMapper extends ApiMapper
                 if ($verbose) {
                     $list[$key]['talk_comments_count'] = $this->getTalkCommentCount($row['ID']);
                 }
-                $list[$key]['images']        = $this->getImages($row['ID']);
-                $list[$key]['tags']          = $this->getTags($row['ID']);
-                $list[$key]['uri']           = $base . '/' . $version . '/events/' . $row['ID'];
-                $list[$key]['verbose_uri']   = $base . '/' . $version . '/events/' . $row['ID'] . '?verbose=yes';
-                $list[$key]['comments_uri']  = $base . '/' . $version . '/events/' . $row['ID'] . '/comments';
-                $list[$key]['talks_uri']     = $base . '/' . $version . '/events/' . $row['ID'] . '/talks';
-                $list[$key]['tracks_uri']    = $base . '/' . $version . '/events/' . $row['ID'] . '/tracks';
+                $list[$key]['images'] = $this->getImages($row['ID']);
+                $list[$key]['tags'] = $this->getTags($row['ID']);
+                $list[$key]['uri'] = $base . '/' . $version . '/events/' . $row['ID'];
+                $list[$key]['verbose_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '?verbose=yes';
+                $list[$key]['comments_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/comments';
+                $list[$key]['talks_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/talks';
+                $list[$key]['tracks_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/tracks';
                 $list[$key]['attending_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/attending';
-                $list[$key]['images_uri']    = $base . '/' . $version . '/events/' . $row['ID'] . '/images';
-                $list[$key]['pending']       = $row['pending'];
+                $list[$key]['images_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/images';
+                $list[$key]['pending'] = $row['pending'];
 
                 if ($row['pending'] == 1 && $thisUserCanApproveEvents) {
                     $list[$key]['approval_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/approval';
@@ -458,18 +458,18 @@ class EventMapper extends ApiMapper
 
                 if ($verbose) {
                     if ($this->thisUserHasAdminOn($row['ID'])) {
-                        $list[$key]['reported_comments_uri']      = $base . '/' . $version . '/events/'
+                        $list[$key]['reported_comments_uri'] = $base . '/' . $version . '/events/'
                                                                     . $row['ID'] . '/comments/reported';
                         $list[$key]['reported_talk_comments_uri'] = $base . '/' . $version . '/events/'
                                                                     . $row['ID'] . '/talk_comments/reported';
-                        $list[$key]['pending_claims_uri']         = $base . '/' . $version . '/events/'
+                        $list[$key]['pending_claims_uri'] = $base . '/' . $version . '/events/'
                                                                     . $row['ID'] . '/claims';
                     }
                     $list[$key]['all_talk_comments_uri'] = $base . '/' . $version . '/events/'
                                                            . $row['ID'] . '/talk_comments';
-                    $list[$key]['hosts']                 = $this->getHosts($row['ID']);
+                    $list[$key]['hosts'] = $this->getHosts($row['ID']);
                 }
-                $list[$key]['hosts_uri']     = $base . '/' . $version . '/events/' . $row['ID'] . '/hosts';
+                $list[$key]['hosts_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/hosts';
                 $list[$key]['attendees_uri'] = $base . '/' . $version . '/events/' . $row['ID'] . '/attendees';
 
                 if ($verbose) {
@@ -481,7 +481,7 @@ class EventMapper extends ApiMapper
 
         return [
             'events' => $list,
-            'meta'   => $this->getPaginationLinks($list, $total),
+            'meta' => $this->getPaginationLinks($list, $total),
         ];
     }
 
@@ -494,10 +494,10 @@ class EventMapper extends ApiMapper
      */
     protected function getHosts($event_id)
     {
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
-        $host_sql  = $this->getHostSql();
+        $host_sql = $this->getHostSql();
         $host_stmt = $this->_db->prepare($host_sql);
         $host_stmt->execute(["event_id" => $event_id]);
         $hosts = $host_stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -511,7 +511,7 @@ class EventMapper extends ApiMapper
         foreach ($hosts as $person) {
             $retval[] = [
                 'host_name' => $person['full_name'],
-                'host_uri'  => $base . '/' . $version . '/users/' . $person['user_id'],
+                'host_uri' => $base . '/' . $version . '/users/' . $person['user_id'],
             ];
         }
 
@@ -540,10 +540,10 @@ class EventMapper extends ApiMapper
      */
     public function getHostsEmailAddresses($event_id)
     {
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
-        $host_sql  = 'select u.email'
+        $host_sql = 'select u.email'
                      . ' from user_admin a '
                      . ' inner join user u on u.ID = a.uid '
                      . ' where rid = :event_id and rtype="event" and (rcode!="pending" OR rcode is null)';
@@ -562,7 +562,7 @@ class EventMapper extends ApiMapper
      */
     protected function getTags($event_id)
     {
-        $tag_sql  = 'select tag_value as tag'
+        $tag_sql = 'select tag_value as tag'
                     . ' from tags_events te'
                     . ' inner join tags t on t.ID = te.tag_id'
                     . ' where te.event_id = :event_id';
@@ -628,7 +628,7 @@ class EventMapper extends ApiMapper
     public function getEventsAttendedByUser($user_id, $resultsperpage, $start, $verbose = false)
     {
         $data = ["user_id" => (int) $user_id];
-        $sql  = 'select events.*, '
+        $sql = 'select events.*, '
                 . '(select count(*) from user_attend where user_attend.eid = events.ID) as attendee_count, '
                 . 'abs(datediff(from_unixtime(events.event_start), from_unixtime(' .
                 mktime(0, 0, 0) . '))) as score, '
@@ -707,12 +707,12 @@ class EventMapper extends ApiMapper
      */
     public function isUserAHostOn($user_id, $event_id)
     {
-        $sql  = $this->getHostSql();
-        $sql  .= ' AND u.ID = :user_id';
+        $sql = $this->getHostSql();
+        $sql .= ' AND u.ID = :user_id';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute([
             "event_id" => $event_id,
-            "user_id"  => $user_id,
+            "user_id" => $user_id,
         ]);
 
         return ! empty($stmt->fetchAll());
@@ -727,7 +727,7 @@ class EventMapper extends ApiMapper
      */
     protected function getTalkCommentCount($event_id)
     {
-        $comment_sql  = 'select count(*) as comment_count from talk_comments tc '
+        $comment_sql = 'select count(*) as comment_count from talk_comments tc '
                         . 'inner join talks t on tc.talk_id = t.ID '
                         . 'inner join events e on t.event_id = e.ID '
                         . 'where e.ID = :event_id';
@@ -751,9 +751,9 @@ class EventMapper extends ApiMapper
      */
     protected function generateInflectedName($name, $event_id, $start_date)
     {
-        $date           = new DateTime($start_date);
+        $date = new DateTime($start_date);
         $inflected_name = $this->inflect($name);
-        $name_choices   = [
+        $name_choices = [
             $inflected_name,
             $inflected_name . $date->format('-Y'),
             $inflected_name . $date->format('-Y-m'),
@@ -770,7 +770,7 @@ class EventMapper extends ApiMapper
             try {
                 $result = $stmt->execute([
                     "inflected_name" => $inflected_name,
-                    "event_id"       => $event_id,
+                    "event_id" => $event_id,
                 ]);
 
                 return $inflected_name;
@@ -833,7 +833,7 @@ class EventMapper extends ApiMapper
         // comma separate all pairs and add to SQL string
         $sql .= implode(', ', $pairs);
 
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute($event);
 
         if ($result) {
@@ -872,8 +872,8 @@ class EventMapper extends ApiMapper
 
         // get the list of column to API field name for all valid fields
         $fields = $this->getVerboseFields();
-        $items  = [];
-        $pairs  = [];
+        $items = [];
+        $pairs = [];
 
         foreach ($fields as $api_name => $column_name) {
             // We don't change any activation stuff here!!
@@ -882,7 +882,7 @@ class EventMapper extends ApiMapper
             }
 
             if (array_key_exists($api_name, $event)) {
-                $pairs[]          = "$column_name = :$api_name";
+                $pairs[] = "$column_name = :$api_name";
                 $items[$api_name] = $event[$api_name];
             }
         }
@@ -914,7 +914,7 @@ class EventMapper extends ApiMapper
      */
     public function addUserAsHost($event_id, $user_id)
     {
-        $sql  = "insert into user_admin set rtype = 'event', rid = :event_id, uid = :user_id";
+        $sql = "insert into user_admin set rtype = 'event', rid = :event_id, uid = :user_id";
         $stmt = $this->_db->prepare($sql);
 
         return $stmt->execute(["event_id" => $event_id, "user_id" => $user_id]);
@@ -930,7 +930,7 @@ class EventMapper extends ApiMapper
      */
     public function removeUserAsHost($event_id, $user_id)
     {
-        $sql  = "delete from user_admin where rtype = 'event' and rid = :event_id and uid = :user_id";
+        $sql = "delete from user_admin where rtype = 'event' and rid = :event_id and uid = :user_id";
         $stmt = $this->_db->prepare($sql);
 
         return $stmt->execute(["event_id" => $event_id, "user_id" => $user_id]);
@@ -945,7 +945,7 @@ class EventMapper extends ApiMapper
      */
     public function cacheTalkCount($event_id)
     {
-        $sql  = "UPDATE events e SET talk_count = (SELECT COUNT(*) FROM talks t WHERE t.event_id = e.ID) " .
+        $sql = "UPDATE events e SET talk_count = (SELECT COUNT(*) FROM talks t WHERE t.event_id = e.ID) " .
                 "WHERE e.ID = :event_id;";
         $stmt = $this->_db->prepare($sql);
 
@@ -961,7 +961,7 @@ class EventMapper extends ApiMapper
      */
     public function cacheCommentCount($event_id)
     {
-        $sql  = "UPDATE events e SET comment_count = " .
+        $sql = "UPDATE events e SET comment_count = " .
                 "(SELECT COUNT(*) FROM event_comments ec WHERE ec.event_id = e.ID) WHERE e.ID = :event_id;";
         $stmt = $this->_db->prepare($sql);
 
@@ -977,7 +977,7 @@ class EventMapper extends ApiMapper
      */
     public function cacheTrackCount($event_id)
     {
-        $sql  = "UPDATE events e SET track_count = (SELECT COUNT(*) FROM event_track et WHERE et.event_id = e.ID) " .
+        $sql = "UPDATE events e SET track_count = (SELECT COUNT(*) FROM event_track et WHERE et.event_id = e.ID) " .
                 "WHERE e.ID = :event_id;";
         $stmt = $this->_db->prepare($sql);
 
@@ -998,7 +998,7 @@ class EventMapper extends ApiMapper
                . 'from events '
                . 'where events.ID = :event_id ';
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(["event_id" => $event_id]);
 
         if ($response) {
@@ -1021,9 +1021,9 @@ class EventMapper extends ApiMapper
                . 'from events '
                . 'where pending = 1 and (events.private <> "y" OR events.private IS NULL)';
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute();
-        $result   = $stmt->fetch();
+        $result = $stmt->fetch();
 
         return $result['count'];
     }
@@ -1044,9 +1044,9 @@ class EventMapper extends ApiMapper
                . 'where e.pending = 1 AND ua.rtype="event" '
                . 'AND ua.uid = :user_id ';
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(["user_id" => $user_id]);
-        $result   = $stmt->fetch();
+        $result = $stmt->fetch();
 
         return $result['count'];
     }
@@ -1067,16 +1067,16 @@ class EventMapper extends ApiMapper
      */
     public function setTags($event_id, array $tags)
     {
-        $deleteAllEventTagsSql  = 'DELETE FROM tags_events WHERE event_id = :event_id;';
+        $deleteAllEventTagsSql = 'DELETE FROM tags_events WHERE event_id = :event_id;';
         $deleteAllEventTagsStmt = $this->_db->prepare($deleteAllEventTagsSql);
 
-        $checkForTagSql  = 'SELECT ID FROM tags WHERE tag_value = :tag;';
+        $checkForTagSql = 'SELECT ID FROM tags WHERE tag_value = :tag;';
         $checkForTagStmt = $this->_db->prepare($checkForTagSql);
 
-        $addTagToDbSql  = 'INSERT INTO tags SET tag_value = :tag;';
+        $addTagToDbSql = 'INSERT INTO tags SET tag_value = :tag;';
         $addTagToDbStmt = $this->_db->prepare($addTagToDbSql);
 
-        $addTagToEventSql  = 'INSERT INTO tags_events SET tag_id = :tag_id, event_id = :event_id;';
+        $addTagToEventSql = 'INSERT INTO tags_events SET tag_id = :tag_id, event_id = :event_id;';
         $addTagToEventStmt = $this->_db->prepare($addTagToEventSql);
 
         // remove all existing tags for the event
@@ -1086,7 +1086,7 @@ class EventMapper extends ApiMapper
         foreach ($tags as $tag) {
             // Check whether the tag already exists in the tag-list
             $result = $checkForTagStmt->execute(['tag' => $tag]);
-            $tagId  = $checkForTagStmt->fetchColumn(0);
+            $tagId = $checkForTagStmt->fetchColumn(0);
 
             if (!$tagId) {
                 // If not, add the event to the tag list
@@ -1110,17 +1110,17 @@ class EventMapper extends ApiMapper
      */
     public function approve($event_id, $reviewing_user_id)
     {
-        $sql      = "select ID from events where pending = 1 and active = 0 and ID = :event_id";
-        $stmt     = $this->_db->prepare($sql);
+        $sql = "select ID from events where pending = 1 and active = 0 and ID = :event_id";
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(["event_id" => $event_id]);
-        $result   = $stmt->fetch();
+        $result = $stmt->fetch();
 
         if ($result === false) {
             // Event either doesn't exist or is not pending
             return false;
         }
 
-        $sql  = "update events set pending = 0, active = 1, reviewer_id = :reviewing_user_id where ID = :event_id";
+        $sql = "update events set pending = 0, active = 1, reviewer_id = :reviewing_user_id where ID = :event_id";
         $stmt = $this->_db->prepare($sql);
 
         return $stmt->execute(["event_id" => $event_id, "reviewing_user_id" => $reviewing_user_id]);
@@ -1137,16 +1137,16 @@ class EventMapper extends ApiMapper
      */
     public function reject($event_id, $reviewing_user_id, string $reason)
     {
-        $sql      = "select ID from events where pending = 1 and active = 0 and ID = :event_id";
-        $stmt     = $this->_db->prepare($sql);
+        $sql = "select ID from events where pending = 1 and active = 0 and ID = :event_id";
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(["event_id" => $event_id]);
-        $result   = $stmt->fetch();
+        $result = $stmt->fetch();
 
         if ($result === false) {
             return false;
         }
 
-        $sql  = "update events set pending = 0, active = 0, reviewer_id = :reviewing_user_id, "
+        $sql = "update events set pending = 0, active = 0, reviewer_id = :reviewing_user_id, "
             . "rejection_reason = :rejection_reason where ID = :event_id";
         $stmt = $this->_db->prepare($sql);
 
@@ -1166,7 +1166,7 @@ class EventMapper extends ApiMapper
      */
     public function getImages($event_id)
     {
-        $image_sql  = 'select i.type, i.url, i.width, i.height'
+        $image_sql = 'select i.type, i.url, i.width, i.height'
                       . ' from event_images i '
                       . ' where i.event_id = :event_id';
         $image_stmt = $this->_db->prepare($image_sql);
@@ -1196,7 +1196,7 @@ class EventMapper extends ApiMapper
      */
     public function removeImages($event_id)
     {
-        $sql  = 'delete from event_images'
+        $sql = 'delete from event_images'
                 . ' where event_id = :event_id';
         $stmt = $this->_db->prepare($sql);
 
@@ -1220,21 +1220,21 @@ class EventMapper extends ApiMapper
      */
     public function saveNewImage($event_id, $filename, $width, $height, $type)
     {
-        $sql    = 'insert into event_images set '
+        $sql = 'insert into event_images set '
                   . 'event_id = :event_id, width = :width, height = :height, '
                   . 'url = :url, type = :type';
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute([
             "event_id" => $event_id,
-            "type"     => $type,
-            "width"    => $width,
-            "height"   => $height,
-            "url"      => $this->website_url . "/inc/img/event_icons/" . $filename,
+            "type" => $type,
+            "width" => $width,
+            "height" => $height,
+            "url" => $this->website_url . "/inc/img/event_icons/" . $filename,
         ]);
 
         // for small images, update the old table too
         if ($type == "small") {
-            $legacy_sql  = 'update events set event_icon = :filename where ID = :event_id';
+            $legacy_sql = 'update events set event_icon = :filename where ID = :event_id';
             $legacy_stmt = $this->_db->prepare($legacy_sql);
             $legacy_stmt->execute(["event_id" => $event_id, "filename" => $filename]);
         }

--- a/src/Model/LanguageMapper.php
+++ b/src/Model/LanguageMapper.php
@@ -74,19 +74,19 @@ class LanguageMapper extends ApiMapper
 
         $list = parent::transformResults($results, $verbose);
 
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
         if (is_array($list) && count($list)) {
             foreach ($results as $key => $row) {
-                $list[$key]['uri']         = $base . '/' . $version . '/languages/' . $row['ID'];
+                $list[$key]['uri'] = $base . '/' . $version . '/languages/' . $row['ID'];
                 $list[$key]['verbose_uri'] = $base . '/' . $version . '/languages/' . $row['ID'] . '?verbose=yes';
             }
         }
 
         return [
             'languages' => $list,
-            'meta'      => $this->getPaginationLinks($list, $total)
+            'meta' => $this->getPaginationLinks($list, $total)
         ];
     }
 
@@ -104,7 +104,7 @@ class LanguageMapper extends ApiMapper
 
         if (count($params) > 0) {
             $value = reset($params);
-            $key   = key($params);
+            $key = key($params);
 
             $sql .= 'where l.' . $key . ' = :' . $key . ' ';
 
@@ -118,11 +118,11 @@ class LanguageMapper extends ApiMapper
         $sql .= 'order by l.lang_name ';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute($params);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, $params);
 
             return $results;

--- a/src/Model/OAuthModel.php
+++ b/src/Model/OAuthModel.php
@@ -75,14 +75,14 @@ class OAuthModel
      */
     public function verifyAccessToken($token)
     {
-        $sql  = 'select id, user_id from oauth_access_tokens'
+        $sql = 'select id, user_id from oauth_access_tokens'
                 . ' where access_token=:access_token';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(["access_token" => $token]);
         $result = $stmt->fetch();
 
         // log that we used this token
-        $update_sql  = 'update oauth_access_tokens '
+        $update_sql = 'update oauth_access_tokens '
                        . ' set last_used_date = NOW()'
                        . ' where id = :id';
         $update_stmt = $this->_db->prepare($update_sql);
@@ -129,7 +129,7 @@ class OAuthModel
      */
     protected function getUserId($username, $password)
     {
-        $sql  = 'SELECT ID, password, email, verified FROM user
+        $sql = 'SELECT ID, password, email, verified FROM user
             WHERE username=:username';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(["username" => $username]);
@@ -172,7 +172,7 @@ class OAuthModel
      */
     public function createAccessToken($consumer_key, $user_id)
     {
-        $hash        = $this->generateToken();
+        $hash = $this->generateToken();
         $accessToken = substr($hash, 0, 16);
 
         $sql = "INSERT INTO oauth_access_tokens set
@@ -182,12 +182,12 @@ class OAuthModel
                 last_used_date = NOW()
                 ";
 
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute(
             [
                 'access_token' => $accessToken,
                 'consumer_key' => $consumer_key,
-                'user_id'      => $user_id,
+                'user_id' => $user_id,
             ]
         );
 
@@ -208,7 +208,7 @@ class OAuthModel
      */
     public function generateToken()
     {
-        $fp      = fopen('/dev/urandom', 'rb');
+        $fp = fopen('/dev/urandom', 'rb');
         $entropy = fread($fp, 32);
         fclose($fp);
 
@@ -234,7 +234,7 @@ class OAuthModel
             $stmt->execute(
                 [
                     'consumer_key' => $clientId,
-                    'expiry_date'  => date('Y-m-d', strtotime('-1 day'))
+                    'expiry_date' => date('Y-m-d', strtotime('-1 day'))
                 ]
             );
         }
@@ -251,7 +251,7 @@ class OAuthModel
      */
     public function getConsumerName($token)
     {
-        $sql  = 'select at.consumer_key, c.id, c.application '
+        $sql = 'select at.consumer_key, c.id, c.application '
                 . 'from oauth_access_tokens at '
                 . 'left join oauth_consumers c using (consumer_key) '
                 . 'where at.access_token=:access_token ';
@@ -279,7 +279,7 @@ class OAuthModel
      */
     public function isClientPermittedPasswordGrant($key, $secret)
     {
-        $sql  = 'select c.enable_password_grant from '
+        $sql = 'select c.enable_password_grant from '
                 . 'oauth_consumers c '
                 . 'where c.consumer_key=:key '
                 . 'and c.consumer_secret=:secret '
@@ -304,7 +304,7 @@ class OAuthModel
      */
     public function isAccessTokenPermittedPasswordGrant($token)
     {
-        $sql  = 'select c.enable_password_grant from '
+        $sql = 'select c.enable_password_grant from '
                 . 'oauth_consumers c '
                 . 'inner join oauth_access_tokens at using (consumer_key) '
                 . 'where at.access_token = :token '
@@ -331,7 +331,7 @@ class OAuthModel
      */
     public function reverifyUserPassword($userId, $password)
     {
-        $sql  = 'SELECT ID, password FROM user
+        $sql = 'SELECT ID, password FROM user
             WHERE ID = :user_id
             AND verified = 1';
         $stmt = $this->_db->prepare($sql);
@@ -418,8 +418,8 @@ class OAuthModel
         if (
             !$stmt->execute([
                 'screen_name' => $values['screen_name'],
-                'name'        => $values['name'],
-                'email'       => $values['email'],
+                'name' => $values['name'],
+                'email' => $values['email'],
             ])
         ) {
             throw new Exception('Something went wrong');
@@ -482,7 +482,7 @@ class OAuthModel
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(
             [
-                "email"    => $email,
+                "email" => $email,
                 'fullName' => $fullName,
                 'userName' => $userName
             ]

--- a/src/Model/PendingTalkClaimMapper.php
+++ b/src/Model/PendingTalkClaimMapper.php
@@ -24,7 +24,7 @@ class PendingTalkClaimMapper extends ApiMapper
     public function getDefaultFields()
     {
         return [
-            "talk_id"    => "username",
+            "talk_id" => "username",
             "speaker_id" => "full_name",
         ];
     }
@@ -39,10 +39,10 @@ class PendingTalkClaimMapper extends ApiMapper
     public function getVerboseFields()
     {
         return [
-            "talk_id"          => "username",
-            "speaker_id"       => "full_name",
-            "date_added"       => "date_added",
-            "claim_id"         => "claim_id",
+            "talk_id" => "username",
+            "speaker_id" => "full_name",
+            "date_added" => "date_added",
+            "claim_id" => "claim_id",
             "user_approved_at" => "user_approved_at",
             "host_approved_at" => "host_approved_at",
         ];
@@ -59,7 +59,7 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function claimTalkAsSpeaker($talk_id, $speaker_id, $claim_id)
     {
-        $sql  = 'insert into pending_talk_claims 
+        $sql = 'insert into pending_talk_claims 
                     (talk_id,submitted_by,speaker_id,date_added,claim_id,user_approved_at) 
                   values
                     (:talk_id,:submitted_by,:speaker_id,UNIX_TIMESTAMP(),:claim_id,NOW())
@@ -68,10 +68,10 @@ class PendingTalkClaimMapper extends ApiMapper
 
         return $stmt->execute(
             [
-                'talk_id'      => $talk_id,
+                'talk_id' => $talk_id,
                 'submitted_by' => $speaker_id,
-                'speaker_id'   => $speaker_id,
-                'claim_id'     => $claim_id
+                'speaker_id' => $speaker_id,
+                'claim_id' => $claim_id
             ]
         );
     }
@@ -88,7 +88,7 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function assignTalkAsHost($talk_id, $speaker_id, $claim_id, $user_id)
     {
-        $sql  = 'insert into pending_talk_claims 
+        $sql = 'insert into pending_talk_claims 
                     (talk_id,submitted_by,speaker_id,date_added,claim_id,host_approved_at) 
                   values
                     (:talk_id,:submitted_by,:speaker_id,UNIX_TIMESTAMP(),:claim_id,NOW())
@@ -97,10 +97,10 @@ class PendingTalkClaimMapper extends ApiMapper
 
         return $stmt->execute(
             [
-                'talk_id'      => $talk_id,
+                'talk_id' => $talk_id,
                 'submitted_by' => $user_id,
-                'speaker_id'   => $speaker_id,
-                'claim_id'     => $claim_id
+                'speaker_id' => $speaker_id,
+                'claim_id' => $claim_id
             ]
         );
     }
@@ -114,16 +114,16 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function claimExists($talk_id, $speaker_id, $claim_id)
     {
-        $sql      = 'select * from pending_talk_claims WHERE 
+        $sql = 'select * from pending_talk_claims WHERE 
                   talk_id = :talk_id AND claim_id = :claim_id AND speaker_id = :speaker_id
                   LIMIT 1
                ';
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(
             [
-                'talk_id'    => $talk_id,
+                'talk_id' => $talk_id,
                 'speaker_id' => $speaker_id,
-                'claim_id'   => $claim_id
+                'claim_id' => $claim_id
             ]
         );
 
@@ -157,7 +157,7 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function approveAssignmentAsSpeaker($talk_id, $speaker_id, $claim_id)
     {
-        $sql  = 'update pending_talk_claims SET user_approved_at = NOW() WHERE 
+        $sql = 'update pending_talk_claims SET user_approved_at = NOW() WHERE 
                   talk_id = :talk_id AND claim_id = :claim_id 
                   AND speaker_id = :speaker_id AND user_approved_at IS NULL
                   LIMIT 1
@@ -166,9 +166,9 @@ class PendingTalkClaimMapper extends ApiMapper
 
         return $stmt->execute(
             [
-                'talk_id'    => $talk_id,
+                'talk_id' => $talk_id,
                 'speaker_id' => $speaker_id,
-                'claim_id'   => $claim_id
+                'claim_id' => $claim_id
             ]
         );
     }
@@ -182,7 +182,7 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function approveClaimAsHost($talk_id, $speaker_id, $claim_id)
     {
-        $sql  = 'update pending_talk_claims SET host_approved_at = NOW() WHERE 
+        $sql = 'update pending_talk_claims SET host_approved_at = NOW() WHERE 
                   talk_id = :talk_id AND claim_id = :claim_id 
                   AND speaker_id = :speaker_id AND host_approved_at IS NULL
                   LIMIT 1
@@ -191,9 +191,9 @@ class PendingTalkClaimMapper extends ApiMapper
 
         return $stmt->execute(
             [
-                'talk_id'    => $talk_id,
+                'talk_id' => $talk_id,
                 'speaker_id' => $speaker_id,
-                'claim_id'   => $claim_id
+                'claim_id' => $claim_id
             ]
         );
     }
@@ -207,7 +207,7 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function rejectClaimAsHost($talk_id, $speaker_id, $claim_id)
     {
-        $sql  = 'DELETE FROM pending_talk_claims
+        $sql = 'DELETE FROM pending_talk_claims
                   WHERE
                   talk_id = :talk_id AND claim_id = :claim_id
                   AND speaker_id = :speaker_id AND host_approved_at IS NULL
@@ -217,9 +217,9 @@ class PendingTalkClaimMapper extends ApiMapper
 
         return $stmt->execute(
             [
-                'talk_id'    => $talk_id,
+                'talk_id' => $talk_id,
                 'speaker_id' => $speaker_id,
-                'claim_id'   => $claim_id
+                'claim_id' => $claim_id
             ]
         );
     }
@@ -231,22 +231,22 @@ class PendingTalkClaimMapper extends ApiMapper
      */
     public function getPendingClaimsByEventId($event_id)
     {
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
-        $sql      = 'select c.*, s.speaker_name from pending_talk_claims c
+        $sql = 'select c.*, s.speaker_name from pending_talk_claims c
                     inner join talks t on t.ID = c.talk_id
                     inner join talk_speaker s on s.ID = c.claim_id
                     where t.event_id = :event_id and
                     (host_approved_at IS NULL or user_approved_at IS NULL)';
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(['event_id' => $event_id]);
 
         if (!$response || $stmt->rowCount() < 1) {
             return false;
         }
 
-        $list   = [];
+        $list = [];
         $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
         foreach ($result as $row) {
@@ -254,10 +254,10 @@ class PendingTalkClaimMapper extends ApiMapper
 
             $list[] = new PendingTalkClaimModel(
                 [
-                    'date_added'        => $date->format("c"),
-                    'display_name'      => $row['speaker_name'],
-                    'talk_uri'          => $base . '/' . $version . '/talks/' . $row['talk_id'],
-                    'speaker_uri'       => $base . '/' . $version . '/users/' . $row['speaker_id'],
+                    'date_added' => $date->format("c"),
+                    'display_name' => $row['speaker_name'],
+                    'talk_uri' => $base . '/' . $version . '/talks/' . $row['talk_id'],
+                    'speaker_uri' => $base . '/' . $version . '/users/' . $row['speaker_id'],
                     'approve_claim_uri' => $base . '/' . $version . '/talks/' . $row['talk_id'] . '/speakers'
                 ]
             );

--- a/src/Model/PendingTalkClaimModel.php
+++ b/src/Model/PendingTalkClaimModel.php
@@ -19,10 +19,10 @@ class PendingTalkClaimModel extends BaseModel
     public function getDefaultFields()
     {
         return [
-            'date_added'   => 'date_added',
+            'date_added' => 'date_added',
             'display_name' => 'display_name',
-            'speaker_uri'  => 'speaker_uri',
-            'talk_uri'     => 'talk_uri',
+            'speaker_uri' => 'speaker_uri',
+            'talk_uri' => 'talk_uri',
         ];
     }
 
@@ -55,7 +55,7 @@ class PendingTalkClaimModel extends BaseModel
         $item = parent::getOutputView($request, $verbose);
 
         // add Hypermedia
-        $base    = $request->base;
+        $base = $request->base;
         $version = $request->version;
 
         return $item;

--- a/src/Model/PendingTalkClaimModelCollection.php
+++ b/src/Model/PendingTalkClaimModelCollection.php
@@ -22,7 +22,7 @@ class PendingTalkClaimModelCollection extends BaseModelCollection
      */
     public function __construct(array $data, $total)
     {
-        $this->list  = [];
+        $this->list = [];
         $this->total = $total;
 
         // hydrate the model objects if necessary and store to list

--- a/src/Model/TalkCommentMapper.php
+++ b/src/Model/TalkCommentMapper.php
@@ -13,12 +13,12 @@ class TalkCommentMapper extends ApiMapper
     public function getDefaultFields()
     {
         return [
-            'rating'            => 'rating',
-            'comment'           => 'comment',
+            'rating' => 'rating',
+            'comment' => 'comment',
             'user_display_name' => 'full_name',
-            'username'          => 'username',
-            'talk_title'        => 'talk_title',
-            'created_date'      => 'date_made'
+            'username' => 'username',
+            'talk_title' => 'talk_title',
+            'created_date' => 'date_made'
         ];
     }
 
@@ -28,13 +28,13 @@ class TalkCommentMapper extends ApiMapper
     public function getVerboseFields()
     {
         return [
-            'rating'            => 'rating',
-            'comment'           => 'comment',
+            'rating' => 'rating',
+            'comment' => 'comment',
             'user_display_name' => 'full_name',
-            'username'          => 'username',
-            'talk_title'        => 'talk_title',
-            'source'            => 'source',
-            'created_date'      => 'date_made',
+            'username' => 'username',
+            'talk_title' => 'talk_title',
+            'source' => 'source',
+            'created_date' => 'date_made',
         ];
     }
 
@@ -52,14 +52,14 @@ class TalkCommentMapper extends ApiMapper
         $sql .= 'and talk_id = :talk_id';
         $sql .= ' order by tc.date_made';
 
-        $sql      .= $this->buildLimit($resultsperpage, $start);
-        $stmt     = $this->_db->prepare($sql);
+        $sql .= $this->buildLimit($resultsperpage, $start);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':talk_id' => $talk_id
         ]);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, [':talk_id' => $talk_id]);
 
             return $this->transformResults($results, $verbose);
@@ -86,13 +86,13 @@ class TalkCommentMapper extends ApiMapper
 
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':event_id' => $event_id
         ]);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, [':event_id' => $event_id]);
 
             return $this->transformResults($results, $verbose);
@@ -119,13 +119,13 @@ class TalkCommentMapper extends ApiMapper
 
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':user_id' => $user_id
         ]);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, [':user_id' => $user_id]);
 
             return $this->transformResults($results, $verbose);
@@ -143,9 +143,9 @@ class TalkCommentMapper extends ApiMapper
      */
     public function getCommentById($comment_id, $verbose = false, $include_hidden = false)
     {
-        $sql      = $this->getBasicSQL($include_hidden);
-        $sql      .= ' and tc.ID = :comment_id ';
-        $stmt     = $this->_db->prepare($sql);
+        $sql = $this->getBasicSQL($include_hidden);
+        $sql .= ' and tc.ID = :comment_id ';
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':comment_id' => $comment_id
         ]);
@@ -184,7 +184,7 @@ class TalkCommentMapper extends ApiMapper
 
         return [
             'comments' => $list,
-            'meta'     => $this->getPaginationLinks($list, $total),
+            'meta' => $this->getPaginationLinks($list, $total),
         ];
     }
 
@@ -196,7 +196,7 @@ class TalkCommentMapper extends ApiMapper
      */
     protected function formatOneComment(array $row, $verbose)
     {
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
         $result = []; // we're building up a value to return
@@ -204,11 +204,11 @@ class TalkCommentMapper extends ApiMapper
         if (true === $verbose) {
             $result['gravatar_hash'] = md5(strtolower($row['email']));
         }
-        $result['uri']               = $base . '/' . $version . '/talk_comments/' . $row['ID'];
-        $result['verbose_uri']       = $base . '/' . $version . '/talk_comments/' . $row['ID'] . '?verbose=yes';
-        $result['talk_uri']          = $base . '/' . $version . '/talks/' . $row['talk_id'];
+        $result['uri'] = $base . '/' . $version . '/talk_comments/' . $row['ID'];
+        $result['verbose_uri'] = $base . '/' . $version . '/talk_comments/' . $row['ID'] . '?verbose=yes';
+        $result['talk_uri'] = $base . '/' . $version . '/talks/' . $row['talk_id'];
         $result['talk_comments_uri'] = $base . '/' . $version . '/talks/' . $row['talk_id'] . '/comments';
-        $result['reported_uri']      = $base . '/' . $version . '/talk_comments/' . $row['ID'] . '/reported';
+        $result['reported_uri'] = $base . '/' . $version . '/talk_comments/' . $row['ID'] . '/reported';
 
         if ($row['user_id']) {
             $result['user_uri'] = $base . '/' . $version . '/users/' . $row['user_id'];
@@ -270,14 +270,14 @@ class TalkCommentMapper extends ApiMapper
                . 'values (:talk_id, :rating, :comment, :user_id, :source, UNIX_TIMESTAMP(), '
                . ':private, 1)';
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':talk_id' => $data['talk_id'],
-            ':rating'  => $data['rating'],
+            ':rating' => $data['rating'],
             ':comment' => $data['comment'],
             ':user_id' => $data['user_id'],
             ':private' => $data['private'],
-            ':source'  => $data['source'],
+            ':source' => $data['source'],
         ]);
 
         return $this->_db->lastInsertId();
@@ -348,15 +348,15 @@ class TalkCommentMapper extends ApiMapper
             reporting_date = NOW()";
 
         $report_stmt = $this->_db->prepare($report_sql);
-        $result      = $report_stmt->execute([
+        $result = $report_stmt->execute([
             "talk_comment_id" => $comment_id,
-            "user_id"         => $user_id
+            "user_id" => $user_id
         ]);
 
-        $hide_sql  = "update talk_comments
+        $hide_sql = "update talk_comments
             set active = 0 where ID = :talk_comment_id";
         $hide_stmt = $this->_db->prepare($hide_sql);
-        $result    = $hide_stmt->execute(["talk_comment_id" => $comment_id]);
+        $result = $hide_stmt->execute(["talk_comment_id" => $comment_id]);
     }
 
     /**
@@ -388,13 +388,13 @@ class TalkCommentMapper extends ApiMapper
             $sql .= " and rc.decision is null";
         }
 
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute(['event_id' => $event_id]);
 
         // need to also set the comment info
-        $list         = [];
-        $total        = 0;
-        $comment_sql  = $this->getBasicSQL(true)
+        $list = [];
+        $total = 0;
+        $comment_sql = $this->getBasicSQL(true)
                         . " and tc.ID = :comment_id";
         $comment_stmt = $this->_db->prepare($comment_sql);
 
@@ -404,9 +404,9 @@ class TalkCommentMapper extends ApiMapper
 
             if ($comment_result && $comment = $comment_stmt->fetch(PDO::FETCH_ASSOC)) {
                 // work around the existing transform logic
-                $comment_array  = [$comment];
-                $comment_array  = parent::transformResults($comment_array, true);
-                $item           = current($comment_array);
+                $comment_array = [$comment];
+                $comment_array = parent::transformResults($comment_array, true);
+                $item = current($comment_array);
                 $row['comment'] = array_merge($item, $this->formatOneComment($comment, true));
             }
             $list[] = new TalkCommentReportModel($row);
@@ -427,21 +427,21 @@ class TalkCommentMapper extends ApiMapper
     {
         if (in_array($decision, ['approved', 'denied'])) {
             // record the decision
-            $sql  = 'update reported_talk_comments set 
+            $sql = 'update reported_talk_comments set 
                         decision = :decision,
                         deciding_user_id = :user_id,
                         deciding_date = NOW()
                     where talk_comment_id = :comment_id';
             $stmt = $this->_db->prepare($sql);
             $stmt->execute([
-                'decision'   => $decision,
-                'user_id'    => $user_id,
+                'decision' => $decision,
+                'user_id' => $user_id,
                 'comment_id' => $comment_id,
             ]);
 
             if ($decision == 'denied') {
                 // the report is denied, therefore make the comment active again
-                $show_sql  = "update talk_comments set active = 1 where ID = :comment_id";
+                $show_sql = "update talk_comments set active = 1 where ID = :comment_id";
                 $show_stmt = $this->_db->prepare($show_sql);
                 $show_stmt->execute(["comment_id" => $comment_id]);
             }
@@ -455,8 +455,8 @@ class TalkCommentMapper extends ApiMapper
      */
     public function getRawComment($comment_id)
     {
-        $sql      = "select tc.* from talk_comments tc where tc.ID = :comment_id";
-        $stmt     = $this->_db->prepare($sql);
+        $sql = "select tc.* from talk_comments tc where tc.ID = :comment_id";
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([':comment_id' => $comment_id]);
 
         if ($response) {
@@ -478,18 +478,18 @@ class TalkCommentMapper extends ApiMapper
      */
     public function updateCommentBody($comment_id, $new_comment_body)
     {
-        $sql  = "update talk_comments set comment = :new_comment_body where ID = :comment_id";
+        $sql = "update talk_comments set comment = :new_comment_body where ID = :comment_id";
         $stmt = $this->_db->prepare($sql);
 
         return $stmt->execute([
             "new_comment_body" => $new_comment_body,
-            "comment_id"       => $comment_id
+            "comment_id" => $comment_id
         ]);
     }
 
     public function deleteCommentsForUser(int $userId): void
     {
-        $sql       = 'delete from talk_comments where talk_comments.user_id = :user_id';
+        $sql = 'delete from talk_comments where talk_comments.user_id = :user_id';
         $statement = $this->_db->prepare($sql);
 
         $statement->execute(['user_id' => $userId]);

--- a/src/Model/TalkCommentReportModel.php
+++ b/src/Model/TalkCommentReportModel.php
@@ -23,11 +23,11 @@ class TalkCommentReportModel extends BaseModel
     public function getDefaultFields()
     {
         return [
-            'reporting_date'          => 'reporting_date',
-            'decision'                => 'decision',
-            'deciding_date'           => 'deciding_date',
+            'reporting_date' => 'reporting_date',
+            'decision' => 'decision',
+            'deciding_date' => 'deciding_date',
             'reporting_user_username' => 'reporting_username',
-            'deciding_user_username'  => 'deciding_username',
+            'deciding_user_username' => 'deciding_username',
         ];
     }
 
@@ -71,7 +71,7 @@ class TalkCommentReportModel extends BaseModel
         $item = parent::getOutputView($request, $verbose);
 
         // add Hypermedia
-        $base    = $request->base;
+        $base = $request->base;
         $version = $request->version;
 
         $item['reporting_user_uri'] = $base . '/' . $version . '/users/' . $this->reporting_user_id;
@@ -80,7 +80,7 @@ class TalkCommentReportModel extends BaseModel
             $item['deciding_user_uri'] = $base . '/' . $version . '/users/' . $this->deciding_user_id;
         }
         $item['event_uri'] = $base . '/' . $version . '/events/' . $this->event_id;
-        $item['talk_uri']  = $base . '/' . $version . '/talks/' . $this->talk_id;
+        $item['talk_uri'] = $base . '/' . $version . '/talks/' . $this->talk_id;
 
         return $item;
     }

--- a/src/Model/TalkCommentReportModelCollection.php
+++ b/src/Model/TalkCommentReportModelCollection.php
@@ -22,7 +22,7 @@ class TalkCommentReportModelCollection extends BaseModelCollection
      */
     public function __construct(array $data, $total)
     {
-        $this->list  = [];
+        $this->list = [];
         $this->total = $total;
 
         // hydrate the model objects if necessary and store to list

--- a/src/Model/TalkMapper.php
+++ b/src/Model/TalkMapper.php
@@ -25,7 +25,7 @@ class TalkMapper extends ApiMapper
         }
 
         if (count($results)) {
-            $base    = $this->_request->base;
+            $base = $this->_request->base;
             $version = $this->_request->version;
 
             foreach ($results as $key => $row) {
@@ -58,7 +58,7 @@ class TalkMapper extends ApiMapper
 
                 // add speakers & tracks
                 $results[$key]['speakers'] = $this->getSpeakers($row['ID']);
-                $results[$key]['tracks']   = $this->getTracks($row['ID']);
+                $results[$key]['tracks'] = $this->getTracks($row['ID']);
             }
         }
 
@@ -81,14 +81,14 @@ class TalkMapper extends ApiMapper
         $sql .= ' order by t.date_given';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':event_id' => $event_id
         ]);
 
         if ($response) {
             $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-            $total   = $this->getTotalCount($sql, [':event_id' => $event_id]);
+            $total = $this->getTotalCount($sql, [':event_id' => $event_id]);
             $results = $this->processResults($results);
 
             foreach ($results as &$talk) {
@@ -111,9 +111,9 @@ class TalkMapper extends ApiMapper
      */
     public function getTalkById($talk_id, $verbose = false)
     {
-        $sql      = $this->getBasicSQL();
-        $sql      .= ' and t.ID = :talk_id';
-        $stmt     = $this->_db->prepare($sql);
+        $sql = $this->getBasicSQL();
+        $sql .= ' and t.ID = :talk_id';
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(["talk_id" => $talk_id]);
 
         if ($response) {
@@ -153,12 +153,12 @@ class TalkMapper extends ApiMapper
             ':title' => "%" . strtolower($keyword) . "%"
         ];
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute($data);
 
         if ($response) {
             $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-            $total   = $this->getTotalCount($sql, $data);
+            $total = $this->getTotalCount($sql, $data);
 
             $results = $this->processResults($results);
 
@@ -191,7 +191,7 @@ class TalkMapper extends ApiMapper
      */
     public function setUserStarred($talk_id, $user_id)
     {
-        $sql  = 'insert into user_talk_star (uid,tid) values (:uid, :tid)';
+        $sql = 'insert into user_talk_star (uid,tid) values (:uid, :tid)';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['uid' => $user_id, 'tid' => $talk_id]);
 
@@ -208,7 +208,7 @@ class TalkMapper extends ApiMapper
      */
     public function setUserNonStarred($talk_id, $user_id)
     {
-        $sql  = 'delete from user_talk_star where uid = :uid and tid = :tid';
+        $sql = 'delete from user_talk_star where uid = :uid and tid = :tid';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['uid' => $user_id, 'tid' => $talk_id]);
 
@@ -251,10 +251,10 @@ class TalkMapper extends ApiMapper
      */
     protected function getSpeakers($talk_id)
     {
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
-        $speaker_sql  = 'select ts.*, user.full_name from talk_speaker ts '
+        $speaker_sql = 'select ts.*, user.full_name from talk_speaker ts '
                         . 'left join user on user.ID = ts.speaker_id '
                         . 'where ts.talk_id = :talk_id and ts.status IS NULL';
         $speaker_stmt = $this->_db->prepare($speaker_sql);
@@ -272,7 +272,7 @@ class TalkMapper extends ApiMapper
 
             if ($person['full_name']) {
                 $entry['speaker_name'] = $person['full_name'];
-                $entry['speaker_uri']  = $base . '/' . $version . '/users/' . $person['speaker_id'];
+                $entry['speaker_uri'] = $base . '/' . $version . '/users/' . $person['speaker_id'];
             } else {
                 $entry['speaker_name'] = $person['speaker_name'];
             }
@@ -289,9 +289,9 @@ class TalkMapper extends ApiMapper
      */
     protected function getTracks($talk_id)
     {
-        $base       = $this->_request->base;
-        $version    = $this->_request->version;
-        $track_sql  = 'select et.ID,et.track_name '
+        $base = $this->_request->base;
+        $version = $this->_request->version;
+        $track_sql = 'select et.ID,et.track_name '
                       . 'from talk_track tt '
                       . 'inner join event_track et on et.ID = tt.track_id '
                       . 'where tt.talk_id = :talk_id';
@@ -307,11 +307,11 @@ class TalkMapper extends ApiMapper
 
         foreach ($tracks as $track) {
             // Make the track_uri
-            $track_uri        = $base . '/' . $version . '/tracks/' . $track['ID'];
+            $track_uri = $base . '/' . $version . '/tracks/' . $track['ID'];
             $remove_track_uri = $base . '/' . $version . '/talks/' . $talk_id . '/tracks/' . $track['ID'];
-            $retval[]         = [
-                'track_name'       => $track['track_name'],
-                'track_uri'        => $track_uri,
+            $retval[] = [
+                'track_name' => $track['track_name'],
+                'track_uri' => $track_uri,
                 'remove_track_uri' => $remove_track_uri,
             ];
         }
@@ -349,14 +349,14 @@ class TalkMapper extends ApiMapper
                . 'order by t.date_given desc';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':user_id' => $user_id
         ]);
 
         if ($response) {
             $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-            $total   = $this->getTotalCount($sql, [':user_id' => $user_id]);
+            $total = $this->getTotalCount($sql, [':user_id' => $user_id]);
             $results = $this->processResults($results);
 
             if ($verbose) {
@@ -400,16 +400,16 @@ class TalkMapper extends ApiMapper
               :date, :duration)
          ';
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
-            ':event_id'         => $data['event_id'],
-            ':talk_title'       => $data['title'],
+            ':event_id' => $data['event_id'],
+            ':talk_title' => $data['title'],
             ':talk_description' => $data['description'],
-            ':language'         => $data['language'],
-            ':date'             => $data['date'],
-            ':duration'         => $data['duration'],
+            ':language' => $data['language'],
+            ':date' => $data['date'],
+            ':duration' => $data['duration'],
         ]);
-        $talk_id  = $this->_db->lastInsertId();
+        $talk_id = $this->_db->lastInsertId();
 
         if (0 == $talk_id) {
             throw new Exception('There has been an error storing the talk');
@@ -449,24 +449,24 @@ class TalkMapper extends ApiMapper
 
         // get the list of columns => data key-name
         $fields = [
-            'event_id'    => 'event_id',
-            'title'       => 'talk_title',
+            'event_id' => 'event_id',
+            'title' => 'talk_title',
             'description' => 'talk_desc',
-            'date'        => 'date_given',
-            'duration'    => 'duration',
+            'date' => 'date_given',
+            'duration' => 'duration',
             'slides_link' => 'slides_link',
         ];
-        $items  = [];
-        $pairs  = [];
+        $items = [];
+        $pairs = [];
 
         foreach ($fields as $api_name => $column_name) {
             if (array_key_exists($api_name, $data)) {
-                $pairs[]          = "$column_name = :$api_name";
+                $pairs[] = "$column_name = :$api_name";
                 $items[$api_name] = $data[$api_name];
             }
         }
         // language is special as we need to select the ID from lang
-        $pairs[]           = 'lang = (select ID from lang where lang_name = :language)';
+        $pairs[] = 'lang = (select ID from lang where lang_name = :language)';
         $items['language'] = $data['language'];
 
         // add talk_id for where clause
@@ -503,7 +503,7 @@ class TalkMapper extends ApiMapper
      */
     public function setType($talk_id, $type_id)
     {
-        $cat_sql  = 'select id from talk_cat where talk_id = :talk_id and cat_id = :type_id';
+        $cat_sql = 'select id from talk_cat where talk_id = :talk_id and cat_id = :type_id';
         $cat_stmt = $this->_db->prepare($cat_sql);
         $cat_stmt->execute([
             ':talk_id' => $talk_id,
@@ -515,13 +515,13 @@ class TalkMapper extends ApiMapper
         }
 
         // remove any other types set for this talk as we only support one type per talk
-        $cat_sql  = 'delete from talk_cat where talk_id = :talk_id';
+        $cat_sql = 'delete from talk_cat where talk_id = :talk_id';
         $cat_stmt = $this->_db->prepare($cat_sql);
         $cat_stmt->execute([
             ':talk_id' => $talk_id,
         ]);
 
-        $cat_sql  = 'insert into talk_cat (talk_id, cat_id) values (:talk_id, :type_id)';
+        $cat_sql = 'insert into talk_cat (talk_id, cat_id) values (:talk_id, :type_id)';
         $cat_stmt = $this->_db->prepare($cat_sql);
 
         return $cat_stmt->execute([
@@ -547,7 +547,7 @@ class TalkMapper extends ApiMapper
     public function updateSpeakersOnTalk($talk_id, array $speakers)
     {
         // get the current speakers
-        $sql  = 'select '
+        $sql = 'select '
                 . 'if(ts.speaker_id,user.full_name, ts.speaker_name) as val '
                 . 'from talk_speaker AS ts '
                 . 'left join user on user.ID = ts.speaker_id '
@@ -557,15 +557,15 @@ class TalkMapper extends ApiMapper
         $current_speakers = $stmt->fetchAll(PDO::FETCH_COLUMN);
         // add the speakers that aren't already attached to the talk
         $new_speakers = array_diff($speakers, $current_speakers);
-        $sql          = "insert into talk_speaker
+        $sql = "insert into talk_speaker
                     (talk_id, speaker_name, status)
                 values
                     (:talk_id, :speaker_name, NULL)";
-        $stmt         = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
 
         foreach ($new_speakers as $name) {
             $params = [
-                'talk_id'      => $talk_id,
+                'talk_id' => $talk_id,
                 'speaker_name' => $name,
             ];
             $stmt->execute($params);
@@ -574,14 +574,14 @@ class TalkMapper extends ApiMapper
         // remove speakers that are currently attached to the talk, but not
         // in the list provided
         $speakers_to_delete = array_diff($current_speakers, $speakers);
-        $sql                = "delete from talk_speaker WHERE
+        $sql = "delete from talk_speaker WHERE
                     talk_id = :talk_id
                     and speaker_name = :speaker_name";
-        $stmt               = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
 
         foreach ($speakers_to_delete as $name) {
             $params = [
-                'talk_id'      => $talk_id,
+                'talk_id' => $talk_id,
                 'speaker_name' => $name,
             ];
             $stmt->execute($params);
@@ -598,7 +598,7 @@ class TalkMapper extends ApiMapper
      */
     protected function hasUserStarredTalk($talk_id, $user_id)
     {
-        $sql  = "select * from user_talk_star where tid = :talk_id and uid = :user_id";
+        $sql = "select * from user_talk_star where tid = :talk_id and uid = :user_id";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(["talk_id" => $talk_id, "user_id" => $user_id]);
         $result = $stmt->fetch();
@@ -646,7 +646,7 @@ class TalkMapper extends ApiMapper
      */
     public function isUserASpeakerOnTalk($talk_id, $user_id)
     {
-        $sql  = "select ID from talk_speaker where talk_id = :talk_id and speaker_id = :user_id";
+        $sql = "select ID from talk_speaker where talk_id = :talk_id and speaker_id = :user_id";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(["talk_id" => (int) $talk_id, "user_id" => (int) $user_id]);
 
@@ -697,7 +697,7 @@ class TalkMapper extends ApiMapper
         $sql = "update talks set stub = :stub
             where ID = :talk_id";
 
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute(["stub" => $stub, "talk_id" => $talk_id]);
 
         return $result;
@@ -717,7 +717,7 @@ class TalkMapper extends ApiMapper
     {
         // Try to store without a suffix
         $inflected_title = $this->inflect($title);
-        $result          = $this->storeInflectedTitle($inflected_title, $talk_id);
+        $result = $this->storeInflectedTitle($inflected_title, $talk_id);
 
         if ($result) {
             return $inflected_title;
@@ -725,7 +725,7 @@ class TalkMapper extends ApiMapper
 
         // If that doesn't work, try to store with the talk ID tacked on
         $inflected_title .= '-' . $talk_id;
-        $result          = $this->storeInflectedTitle($inflected_title, $talk_id);
+        $result = $this->storeInflectedTitle($inflected_title, $talk_id);
 
         if ($result) {
             return $inflected_title;
@@ -758,7 +758,7 @@ class TalkMapper extends ApiMapper
         try {
             $result = $stmt->execute([
                 "inflected_title" => $inflected_title,
-                "talk_id"         => $talk_id
+                "talk_id" => $talk_id
             ]);
         } catch (Exception $e) {
             return false;
@@ -774,7 +774,7 @@ class TalkMapper extends ApiMapper
      */
     public function getSpeakerEmailsByTalkId($talk_id)
     {
-        $speaker_sql  = 'select user.email, user.ID from talk_speaker ts '
+        $speaker_sql = 'select user.email, user.ID from talk_speaker ts '
                         . 'left join user on user.ID = ts.speaker_id '
                         . 'where ts.talk_id = :talk_id and ts.status IS NULL '
                         . 'and email IS NOT null';
@@ -805,7 +805,7 @@ class TalkMapper extends ApiMapper
             }
 
             // is user an event admin?
-            $sql  = 'select a.uid as user_id, u.full_name'
+            $sql = 'select a.uid as user_id, u.full_name'
                     . ' from user_admin a '
                     . ' inner join user u on u.ID = a.uid '
                     . ' inner join talks t on t.event_id = rid '
@@ -839,18 +839,18 @@ class TalkMapper extends ApiMapper
     {
         $params = [
             'track_id' => $track_id,
-            'talk_id'  => $talk_id,
+            'talk_id' => $talk_id,
         ];
 
         // is this link in the database already?
-        $sql  = 'select ID from talk_track where track_id = :track_id and talk_id = :talk_id';
+        $sql = 'select ID from talk_track where track_id = :track_id and talk_id = :talk_id';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute($params);
         $talk_track_id = $stmt->fetchColumn();
 
         if ($talk_track_id === false) {
             // insert new row as not in database
-            $sql  = 'insert into talk_track (track_id, talk_id) values (:track_id, :talk_id)';
+            $sql = 'insert into talk_track (track_id, talk_id) values (:track_id, :talk_id)';
             $stmt = $this->_db->prepare($sql);
             $stmt->execute($params);
 
@@ -870,10 +870,10 @@ class TalkMapper extends ApiMapper
     {
         $params = [
             'track_id' => $track_id,
-            'talk_id'  => $talk_id,
+            'talk_id' => $talk_id,
         ];
 
-        $sql  = 'delete from talk_track where track_id = :track_id and talk_id = :talk_id';
+        $sql = 'delete from talk_track where track_id = :track_id and talk_id = :talk_id';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute($params);
     }
@@ -928,7 +928,7 @@ class TalkMapper extends ApiMapper
             return false;
         }
 
-        $sql  = "DELETE FROM talks WHERE ID = :talk_id";
+        $sql = "DELETE FROM talks WHERE ID = :talk_id";
         $stmt = $this->_db->prepare($sql);
 
         if (!$stmt->execute(["talk_id" => $talk_id])) {
@@ -950,7 +950,7 @@ class TalkMapper extends ApiMapper
      */
     public function getSpeakerFromTalk($talk_id, $display_name)
     {
-        $speaker_sql  = 'select ts.* from talk_speaker ts '
+        $speaker_sql = 'select ts.* from talk_speaker ts '
                         . 'where ts.talk_id = :talk_id and ts.speaker_name = :display_name';
         $speaker_stmt = $this->_db->prepare($speaker_sql);
         $speaker_stmt->execute(["talk_id" => $talk_id, "display_name" => $display_name]);
@@ -965,11 +965,11 @@ class TalkMapper extends ApiMapper
      */
     public function removeApprovedSpeakerFromTalk($talk_id, $speaker_id)
     {
-        $sql  = 'update talk_speaker set speaker_id = null where talk_id = :talk_id and speaker_id = :speaker_id';
+        $sql = 'update talk_speaker set speaker_id = null where talk_id = :talk_id and speaker_id = :speaker_id';
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(
             [
-                'talk_id'    => $talk_id,
+                'talk_id' => $talk_id,
                 'speaker_id' => $speaker_id,
             ]
         );
@@ -999,7 +999,7 @@ class TalkMapper extends ApiMapper
      */
     public function assignTalkToSpeaker($talk_id, $claim_id, $speaker_id, $speaker_name)
     {
-        $sql  = 'update talk_speaker
+        $sql = 'update talk_speaker
                 SET speaker_id = :speaker_id,
                 speaker_name = :speaker_name
                 WHERE ID = :claim_id AND talk_id = :talk_id';
@@ -1007,9 +1007,9 @@ class TalkMapper extends ApiMapper
 
         return $stmt->execute(
             [
-                'speaker_id'   => $speaker_id,
-                'talk_id'      => $talk_id,
-                'claim_id'     => $claim_id,
+                'speaker_id' => $speaker_id,
+                'talk_id' => $talk_id,
+                'claim_id' => $claim_id,
                 'speaker_name' => $speaker_name
             ]
         );
@@ -1042,7 +1042,7 @@ class TalkMapper extends ApiMapper
         ];
 
         if (is_numeric($link_id)) {
-            $sql               .= "and tl.ID = :link_id";
+            $sql .= "and tl.ID = :link_id";
             $params['link_id'] = $link_id;
         }
 
@@ -1062,7 +1062,7 @@ class TalkMapper extends ApiMapper
         $links = $this->getTalkMediaLinks($talk[0]['ID']);
 
         foreach ($links as $link) {
-            $talk                    = $this->handleBackwardsCompatibleMedia($talk, $link);
+            $talk = $this->handleBackwardsCompatibleMedia($talk, $link);
             $talk[0]['talk_media'][] = [$link['display_name'] => $link['url']];
         }
 
@@ -1137,9 +1137,9 @@ class TalkMapper extends ApiMapper
         $stmt->execute(
             [
                 'display_name' => $display_name,
-                'link_id'      => $link_id,
-                'talk_id'      => $talk_id,
-                'url'          => $url,
+                'link_id' => $link_id,
+                'talk_id' => $talk_id,
+                'url' => $url,
             ]
         );
 
@@ -1170,9 +1170,9 @@ class TalkMapper extends ApiMapper
 
         $stmt->execute(
             [
-                'talk_id'      => $talk_id,
+                'talk_id' => $talk_id,
                 'display_name' => $display_name,
-                'url'          => $url,
+                'url' => $url,
             ]
         );
 

--- a/src/Model/TalkModel.php
+++ b/src/Model/TalkModel.php
@@ -24,19 +24,19 @@ class TalkModel extends BaseModel
     public function getDefaultFields()
     {
         return [
-            'id'                      => 'ID',
-            'talk_title'              => 'talk_title',
+            'id' => 'ID',
+            'talk_title' => 'talk_title',
             'url_friendly_talk_title' => 'url_friendly_talk_title',
-            'talk_description'        => 'talk_desc',
-            'type'                    => 'talk_type',
-            'start_date'              => 'date_given',
-            'duration'                => 'duration',
-            'stub'                    => 'stub',
-            'average_rating'          => 'avg_rating',
-            'comments_enabled'        => 'comments_enabled',
-            'comment_count'           => 'comment_count',
-            'starred'                 => 'starred',
-            'starred_count'           => 'starred_count',
+            'talk_description' => 'talk_desc',
+            'type' => 'talk_type',
+            'start_date' => 'date_given',
+            'duration' => 'duration',
+            'stub' => 'stub',
+            'average_rating' => 'avg_rating',
+            'comments_enabled' => 'comments_enabled',
+            'comment_count' => 'comment_count',
+            'starred' => 'starred',
+            'starred_count' => 'starred_count',
         ];
     }
 
@@ -52,8 +52,8 @@ class TalkModel extends BaseModel
         $fields = $this->getDefaultFields();
 
         $fields['slides_link'] = 'slides_link';
-        $fields['talk_media']  = 'talk_media';
-        $fields['language']    = 'lang_name';
+        $fields['talk_media'] = 'talk_media';
+        $fields['language'] = 'lang_name';
         $fields['user_rating'] = 'user_rating';
 
         return $fields;
@@ -71,7 +71,7 @@ class TalkModel extends BaseModel
     {
         return [
             'speakers' => 'speakers',
-            'tracks'   => 'tracks',
+            'tracks' => 'tracks',
         ];
     }
 
@@ -88,19 +88,19 @@ class TalkModel extends BaseModel
         $item = parent::getOutputView($request, $verbose);
 
         // add Hypermedia
-        $base    = $request->base;
+        $base = $request->base;
         $version = $request->version;
 
-        $item['uri']                  = $base . '/' . $version . '/talks/' . $this->ID;
-        $item['verbose_uri']          = $base . '/' . $version . '/talks/' . $this->ID . '?verbose=yes';
-        $item['website_uri']          = $this->getWebsiteUrl($request->getConfigValue('website_url'));
-        $item['starred_uri']          = $base . '/' . $version . '/talks/' . $this->ID . '/starred';
-        $item['tracks_uri']           = $base . '/' . $version . '/talks/' . $this->ID . '/tracks';
-        $item['comments_uri']         = $base . '/' . $version . '/talks/' . $this->ID . '/comments';
+        $item['uri'] = $base . '/' . $version . '/talks/' . $this->ID;
+        $item['verbose_uri'] = $base . '/' . $version . '/talks/' . $this->ID . '?verbose=yes';
+        $item['website_uri'] = $this->getWebsiteUrl($request->getConfigValue('website_url'));
+        $item['starred_uri'] = $base . '/' . $version . '/talks/' . $this->ID . '/starred';
+        $item['tracks_uri'] = $base . '/' . $version . '/talks/' . $this->ID . '/tracks';
+        $item['comments_uri'] = $base . '/' . $version . '/talks/' . $this->ID . '/comments';
         $item['verbose_comments_uri'] = $base . '/' . $version . '/talks/' . $this->ID
                                         . '/comments?verbose=yes';
-        $item['event_uri']            = $base . '/' . $version . '/events/' . $this->event_id;
-        $item['speakers_uri']         = $base . '/' . $version . '/talks/' . $this->ID . '/speakers';
+        $item['event_uri'] = $base . '/' . $version . '/events/' . $this->event_id;
+        $item['speakers_uri'] = $base . '/' . $version . '/talks/' . $this->ID . '/speakers';
 
         return $item;
     }

--- a/src/Model/TalkModelCollection.php
+++ b/src/Model/TalkModelCollection.php
@@ -23,7 +23,7 @@ class TalkModelCollection extends BaseModelCollection
      */
     public function __construct(array $data, $total)
     {
-        $this->list  = [];
+        $this->list = [];
         $this->total = $total;
 
         // hydrate the model objects if necessary and store to list

--- a/src/Model/TalkTypeMapper.php
+++ b/src/Model/TalkTypeMapper.php
@@ -12,7 +12,7 @@ class TalkTypeMapper extends ApiMapper
     public function getDefaultFields()
     {
         return [
-            'title'       => 'cat_title',
+            'title' => 'cat_title',
             'description' => 'cat_desc',
         ];
     }
@@ -23,7 +23,7 @@ class TalkTypeMapper extends ApiMapper
     public function getVerboseFields()
     {
         return [
-            'title'       => 'cat_title',
+            'title' => 'cat_title',
             'description' => 'cat_desc',
         ];
     }
@@ -77,7 +77,7 @@ class TalkTypeMapper extends ApiMapper
 
         if (count($params) > 0) {
             $value = reset($params);
-            $key   = key($params);
+            $key = key($params);
 
             $sql .= 'where c.' . $key . ' = :' . $key . ' ';
 
@@ -91,11 +91,11 @@ class TalkTypeMapper extends ApiMapper
         $sql .= 'order by c.ID ';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute($params);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, $params);
 
             return $results;
@@ -114,19 +114,19 @@ class TalkTypeMapper extends ApiMapper
 
         $list = parent::transformResults($results, $verbose);
 
-        $base    = $this->_request->base;
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
         if (is_array($list) && count($list)) {
             foreach ($results as $key => $row) {
-                $list[$key]['uri']         = $base . '/' . $version . '/talk_types/' . $row['ID'];
+                $list[$key]['uri'] = $base . '/' . $version . '/talk_types/' . $row['ID'];
                 $list[$key]['verbose_uri'] = $base . '/' . $version . '/talk_types/' . $row['ID'] . '?verbose=yes';
             }
         }
 
         return [
             'talk_types' => $list,
-            'meta'       => $this->getPaginationLinks($list, $total)
+            'meta' => $this->getPaginationLinks($list, $total)
         ];
     }
 
@@ -137,7 +137,7 @@ class TalkTypeMapper extends ApiMapper
      */
     public function getTalkTypesLookupList()
     {
-        $sql  = "select ID, cat_title from categories";
+        $sql = "select ID, cat_title from categories";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute();
 

--- a/src/Model/TokenMapper.php
+++ b/src/Model/TokenMapper.php
@@ -50,7 +50,7 @@ class TokenMapper extends ApiMapper
                . 'WHERE a.user_id = :user_id ';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':user_id' => $user_id
         ]);
@@ -60,7 +60,7 @@ class TokenMapper extends ApiMapper
         }
 
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        $total   = $this->getTotalCount($sql, [':user_id' => $user_id]);
+        $total = $this->getTotalCount($sql, [':user_id' => $user_id]);
         $results = $this->processResults($results);
 
         return new TokenModelCollection($results, $total);
@@ -84,7 +84,7 @@ class TokenMapper extends ApiMapper
                . 'WHERE a.user_id = :user_id AND b.can_be_revoked = 1';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':user_id' => $user_id
         ]);
@@ -94,7 +94,7 @@ class TokenMapper extends ApiMapper
         }
 
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        $total   = $this->getTotalCount($sql, [':user_id' => $user_id]);
+        $total = $this->getTotalCount($sql, [':user_id' => $user_id]);
         $results = $this->processResults($results);
 
         return new TokenModelCollection($results, $total);
@@ -117,9 +117,9 @@ class TokenMapper extends ApiMapper
                . 'WHERE a.user_id = :user_id AND a.id = :token_id';
         $sql .= $this->buildLimit(1, 0);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
-            ':user_id'  => $user_id,
+            ':user_id' => $user_id,
             ':token_id' => $token_id,
         ]);
 
@@ -150,9 +150,9 @@ class TokenMapper extends ApiMapper
                . 'WHERE a.user_id = :user_id AND a.id = :token_id AND b.can_be_revoked = 1';
         $sql .= $this->buildLimit(1, 0);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
-            ':user_id'  => $user_id,
+            ':user_id' => $user_id,
             ':token_id' => $token_id,
         ]);
 
@@ -202,7 +202,7 @@ class TokenMapper extends ApiMapper
                . 'WHERE a.access_token = :token';
         $sql .= $this->buildLimit(1, 0);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':token' => $accessToken,
         ]);

--- a/src/Model/TokenModel.php
+++ b/src/Model/TokenModel.php
@@ -21,10 +21,10 @@ class TokenModel extends BaseModel
     public function getDefaultFields()
     {
         return [
-            'token'             => 'id',
-            'application'       => 'application',
-            'created_date'      => 'created_date',
-            'last_used_date'    => 'last_used_date',
+            'token' => 'id',
+            'application' => 'application',
+            'created_date' => 'created_date',
+            'last_used_date' => 'last_used_date',
             'application_owner' => 'full_name',
         ];
     }

--- a/src/Model/TokenModelCollection.php
+++ b/src/Model/TokenModelCollection.php
@@ -23,7 +23,7 @@ class TokenModelCollection extends BaseModelCollection
      */
     public function __construct(array $data, $total)
     {
-        $this->list  = [];
+        $this->list = [];
         $this->total = $total;
 
         // hydrate the model objects if necessary and store to list

--- a/src/Model/TrackMapper.php
+++ b/src/Model/TrackMapper.php
@@ -13,9 +13,9 @@ class TrackMapper extends ApiMapper
     public function getDefaultFields()
     {
         return [
-            'track_name'        => 'track_name',
+            'track_name' => 'track_name',
             'track_description' => 'track_desc',
-            'talks_count'       => 'talks_count',
+            'talks_count' => 'talks_count',
         ];
     }
 
@@ -25,9 +25,9 @@ class TrackMapper extends ApiMapper
     public function getVerboseFields()
     {
         return [
-            'track_name'        => 'track_name',
+            'track_name' => 'track_name',
             'track_description' => 'track_desc',
-            'talks_count'       => 'talks_count',
+            'talks_count' => 'talks_count',
         ];
     }
 
@@ -46,13 +46,13 @@ class TrackMapper extends ApiMapper
         $sql .= ' order by t.track_name';
         $sql .= $this->buildLimit($resultsperpage, $start);
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':event_id' => $event_id
         ]);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, [':event_id' => $event_id]);
 
             return $this->transformResults($results, $verbose);
@@ -68,22 +68,22 @@ class TrackMapper extends ApiMapper
     {
         $total = $results['total'];
         unset($results['total']);
-        $list    = parent::transformResults($results, $verbose);
-        $base    = $this->_request->base;
+        $list = parent::transformResults($results, $verbose);
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
         // loop again and add links specific to this item
         if (is_array($list) && count($list)) {
             foreach ($results as $key => $row) {
-                $list[$key]['uri']         = $base . '/' . $version . '/tracks/' . $row['ID'];
+                $list[$key]['uri'] = $base . '/' . $version . '/tracks/' . $row['ID'];
                 $list[$key]['verbose_uri'] = $base . '/' . $version . '/tracks/' . $row['ID'] . '?verbose=yes';
-                $list[$key]['event_uri']   = $base . '/' . $version . '/events/' . $row['event_id'];
+                $list[$key]['event_uri'] = $base . '/' . $version . '/events/' . $row['event_id'];
             }
         }
 
         return [
             'tracks' => $list,
-            'meta'   => $this->getPaginationLinks($list, $total),
+            'meta' => $this->getPaginationLinks($list, $total),
         ];
     }
 
@@ -95,9 +95,9 @@ class TrackMapper extends ApiMapper
      */
     public function getTrackById($track_id, $verbose = false)
     {
-        $sql      = $this->getBasicSQL();
-        $sql      .= ' where t.ID = :track_id';
-        $stmt     = $this->_db->prepare($sql);
+        $sql = $this->getBasicSQL();
+        $sql .= ' where t.ID = :track_id';
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(["track_id" => $track_id]);
 
         if ($response) {
@@ -139,20 +139,20 @@ class TrackMapper extends ApiMapper
             }
 
             if (array_key_exists($api_name, $data)) {
-                $column_names[]         = $column_name;
-                $placeholders[]         = ':' . $api_name;
+                $column_names[] = $column_name;
+                $placeholders[] = ':' . $api_name;
                 $data_values[$api_name] = $data[$api_name];
             }
         }
 
         // we also need to store the event_id
-        $column_names[]          = 'event_id';
-        $placeholders[]          = ':event_id';
+        $column_names[] = 'event_id';
+        $placeholders[] = ':event_id';
         $data_values['event_id'] = $event_id;
 
         // insert row
-        $sql  = 'insert into event_track (' . implode(', ', $column_names) . ') ';
-        $sql  .= 'values (' . implode(', ', $placeholders) . ')';
+        $sql = 'insert into event_track (' . implode(', ', $column_names) . ') ';
+        $sql .= 'values (' . implode(', ', $placeholders) . ')';
         $stmt = $this->_db->prepare($sql);
 
         try {
@@ -201,8 +201,8 @@ class TrackMapper extends ApiMapper
 
         // get the list of column to API field name for all valid fields
         $fields = $this->getVerboseFields();
-        $items  = [];
-        $pairs  = [];
+        $items = [];
+        $pairs = [];
 
         foreach ($fields as $api_name => $column_name) {
             // We don't change any activation stuff here!!
@@ -211,7 +211,7 @@ class TrackMapper extends ApiMapper
             }
 
             if (array_key_exists($api_name, $data)) {
-                $pairs[]          = "$column_name = :$api_name";
+                $pairs[] = "$column_name = :$api_name";
                 $items[$api_name] = $data[$api_name];
             }
         }
@@ -241,12 +241,12 @@ class TrackMapper extends ApiMapper
     public function deleteEventTrack($track_id)
     {
         // delete talk associations
-        $sql  = "delete from event_track where ID = :track_id";
+        $sql = "delete from event_track where ID = :track_id";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['track_id' => $track_id]);
 
         // delete track
-        $sql  = "delete from talk_track where track_id = :track_id";
+        $sql = "delete from talk_track where track_id = :track_id";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute(['track_id' => $track_id]);
     }

--- a/src/Model/TwitterRequestTokenMapper.php
+++ b/src/Model/TwitterRequestTokenMapper.php
@@ -14,18 +14,18 @@ class TwitterRequestTokenMapper extends ApiMapper
      */
     public function create($token, $secret)
     {
-        $sql      = 'insert into twitter_request_tokens '
+        $sql = 'insert into twitter_request_tokens '
                     . 'set token=:token, secret=:secret';
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
-            ':token'  => $token,
+            ':token' => $token,
             ':secret' => $secret
         ]);
 
         if ($response) {
             $token_id = $this->_db->lastInsertId();
 
-            $select_sql  = "select ID, token, secret from twitter_request_tokens "
+            $select_sql = "select ID, token, secret from twitter_request_tokens "
                            . "where ID = :id";
             $select_stmt = $this->_db->prepare($select_sql);
             $select_stmt->execute([":id" => $token_id]);
@@ -44,9 +44,9 @@ class TwitterRequestTokenMapper extends ApiMapper
      */
     public function delete($token)
     {
-        $sql      = 'delete from twitter_request_tokens '
+        $sql = 'delete from twitter_request_tokens '
                     . 'where token=:token';
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute([
             ':token' => $token,
         ]);

--- a/src/Model/TwitterRequestTokenModel.php
+++ b/src/Model/TwitterRequestTokenModel.php
@@ -35,7 +35,7 @@ class TwitterRequestTokenModel extends BaseModel
     protected function getVerboseFields()
     {
         return [
-            'token'  => 'token',
+            'token' => 'token',
             'secret' => 'secret',
         ];
     }
@@ -53,10 +53,10 @@ class TwitterRequestTokenModel extends BaseModel
         $item = parent::getOutputView($request, $verbose);
 
         // add Hypermedia
-        $base    = $request->base;
+        $base = $request->base;
         $version = $request->version;
 
-        $item['uri']         = $base . '/' . $version . '/twitter/request_tokens/' . $this->ID;
+        $item['uri'] = $base . '/' . $version . '/twitter/request_tokens/' . $this->ID;
         $item['verbose_uri'] = $base . '/' . $version . '/twitter/request_tokens/' . $this->ID . '?verbose=yes';
 
         return $item;

--- a/src/Model/UserMapper.php
+++ b/src/Model/UserMapper.php
@@ -21,9 +21,9 @@ class UserMapper extends ApiMapper
     public function getDefaultFields()
     {
         return [
-            "username"         => "username",
-            "full_name"        => "full_name",
-            "biography"        => "biography",
+            "username" => "username",
+            "full_name" => "full_name",
+            "biography" => "biography",
             "twitter_username" => "twitter_username"
         ];
     }
@@ -38,11 +38,11 @@ class UserMapper extends ApiMapper
     public function getVerboseFields()
     {
         return [
-            "username"         => "username",
-            "full_name"        => "full_name",
+            "username" => "username",
+            "full_name" => "full_name",
             "twitter_username" => "twitter_username",
-            "biography"        => "biography",
-            "trusted"          => "trusted"
+            "biography" => "biography",
+            "trusted" => "trusted"
         ];
     }
 
@@ -85,7 +85,7 @@ class UserMapper extends ApiMapper
         $response = $stmt->execute($data);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, $data);
 
             if ($results) {
@@ -123,11 +123,11 @@ class UserMapper extends ApiMapper
             ':keyword' => '%' . strtolower($keyword) . '%',
         ];
 
-        $stmt     = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute($data);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, $data);
 
             return $this->transformResults($results, $verbose);
@@ -141,7 +141,7 @@ class UserMapper extends ApiMapper
      */
     public function getSiteAdminEmails()
     {
-        $sql  = 'select email from user where admin = 1';
+        $sql = 'select email from user where admin = 1';
         $stmt = $this->_db->prepare($sql);
 
         $response = $stmt->execute();
@@ -192,7 +192,7 @@ class UserMapper extends ApiMapper
         $response = $stmt->execute();
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql);
 
             return $results;
@@ -210,7 +210,7 @@ class UserMapper extends ApiMapper
      */
     public function getUserList($resultsperpage, $start, $verbose = false)
     {
-        $order   = 'user.ID';
+        $order = 'user.ID';
         $results = $this->getUsers($resultsperpage, $start, null, $order);
 
         if (is_array($results)) {
@@ -230,7 +230,7 @@ class UserMapper extends ApiMapper
      */
     public function getUsersAttendingEventId($event_id, $resultsperpage, $start, $verbose)
     {
-        $where   = "ua.eid = " . $event_id;
+        $where = "ua.eid = " . $event_id;
         $results = $this->getUsers($resultsperpage, $start, $where);
 
         if (is_array($results)) {
@@ -248,8 +248,8 @@ class UserMapper extends ApiMapper
         $total = $results['total'];
         unset($results['total']);
 
-        $list    = parent::transformResults($results, $verbose);
-        $base    = $this->_request->base;
+        $list = parent::transformResults($results, $verbose);
+        $base = $this->_request->base;
         $version = $this->_request->version;
 
         // add per-item links
@@ -281,13 +281,13 @@ class UserMapper extends ApiMapper
                         $list[$key]['admin'] = $row['admin'];
                     }
                 }
-                $list[$key]['uri']                 = $base . '/' . $version . '/users/' . $row['ID'];
-                $list[$key]['verbose_uri']         = $base . '/' . $version . '/users/' . $row['ID'] . '?verbose=yes';
-                $list[$key]['website_uri']         = $this->website_url . '/user/' . $row['username'];
-                $list[$key]['talks_uri']           = $base . '/' . $version . '/users/' . $row['ID'] . '/talks/';
+                $list[$key]['uri'] = $base . '/' . $version . '/users/' . $row['ID'];
+                $list[$key]['verbose_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '?verbose=yes';
+                $list[$key]['website_uri'] = $this->website_url . '/user/' . $row['username'];
+                $list[$key]['talks_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '/talks/';
                 $list[$key]['attended_events_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '/attended/';
-                $list[$key]['hosted_events_uri']   = $base . '/' . $version . '/users/' . $row['ID'] . '/hosted/';
-                $list[$key]['talk_comments_uri']   = $base . '/' . $version . '/users/' . $row['ID']
+                $list[$key]['hosted_events_uri'] = $base . '/' . $version . '/users/' . $row['ID'] . '/hosted/';
+                $list[$key]['talk_comments_uri'] = $base . '/' . $version . '/users/' . $row['ID']
                                                      . '/talk_comments/';
 
                 if ($verbose && isset($this->_request->user_id)) {
@@ -298,7 +298,7 @@ class UserMapper extends ApiMapper
 
         return [
             'users' => $list,
-            'meta'  => $this->getPaginationLinks($list, $total),
+            'meta' => $this->getPaginationLinks($list, $total),
         ];
     }
 
@@ -364,7 +364,7 @@ class UserMapper extends ApiMapper
     public function createUser($user)
     {
         // Sanity check: ensure all mandatory fields are present.
-        $mandatory_fields          = [
+        $mandatory_fields = [
             'username',
             'full_name',
             'email',
@@ -384,7 +384,7 @@ class UserMapper extends ApiMapper
         // create list of column to API field name for all valid fields
         $fields = $this->getVerboseFields();
         // add the fields that we don't expose for users
-        $fields["email"]    = "email";
+        $fields["email"] = "email";
         $fields["password"] = "password";
 
         $pairs = [];
@@ -398,7 +398,7 @@ class UserMapper extends ApiMapper
         // comma separate all pairs and add to SQL string
         $sql .= implode(', ', $pairs);
 
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute($user);
 
         if ($result) {
@@ -430,7 +430,7 @@ class UserMapper extends ApiMapper
         $response = $stmt->execute($data);
 
         if ($response) {
-            $results          = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $results['total'] = $this->getTotalCount($sql, $data);
 
             if ($results) {
@@ -478,7 +478,7 @@ class UserMapper extends ApiMapper
         $stmt = $this->_db->prepare($sql);
         $data = [
             "user_id" => $user_id,
-            "token"   => $token
+            "token" => $token
         ];
 
         $response = $stmt->execute($data);
@@ -504,7 +504,7 @@ class UserMapper extends ApiMapper
                       . "where token = :token";
 
         $select_stmt = $this->_db->prepare($select_sql);
-        $data        = [
+        $data = [
             "token" => $token
         ];
 
@@ -546,8 +546,8 @@ class UserMapper extends ApiMapper
         $sql = "select ID from user "
                . "where email = :email and active = 1";
 
-        $data     = ["email" => $email];
-        $stmt     = $this->_db->prepare($sql);
+        $data = ["email" => $email];
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute($data);
 
         if ($response) {
@@ -635,7 +635,7 @@ class UserMapper extends ApiMapper
     public function editUser(array $user, $userId)
     {
         // Sanity check: ensure all mandatory fields are present.
-        $mandatory_fields          = [
+        $mandatory_fields = [
             'full_name',
             'email',
         ];
@@ -650,7 +650,7 @@ class UserMapper extends ApiMapper
 
         // encode the password
         if (isset($user['password'])) {
-            $user['password']   = password_hash(md5($user['password']), PASSWORD_DEFAULT);
+            $user['password'] = password_hash(md5($user['password']), PASSWORD_DEFAULT);
             $fields["password"] = "password";
         }
 
@@ -671,7 +671,7 @@ class UserMapper extends ApiMapper
         $sql .= implode(', ', $pairs);
         $sql .= " where ID = :user_id ";
 
-        $stmt   = $this->_db->prepare($sql);
+        $stmt = $this->_db->prepare($sql);
         $result = $stmt->execute($user);
 
         if ($result) {
@@ -692,8 +692,8 @@ class UserMapper extends ApiMapper
     {
         $sql = "select ID from user where username = :username";
 
-        $data     = ["username" => $username];
-        $stmt     = $this->_db->prepare($sql);
+        $data = ["username" => $username];
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute($data);
 
         if ($response) {
@@ -717,8 +717,8 @@ class UserMapper extends ApiMapper
      */
     public function getEmailByUserId($user_id)
     {
-        $sql      = "select email from user where ID = :user_id";
-        $stmt     = $this->_db->prepare($sql);
+        $sql = "select email from user where ID = :user_id";
+        $stmt = $this->_db->prepare($sql);
         $response = $stmt->execute(["user_id" => $user_id]);
 
         if ($response) {
@@ -751,7 +751,7 @@ class UserMapper extends ApiMapper
         $stmt = $this->_db->prepare($sql);
         $data = [
             "user_id" => $user_id,
-            "token"   => $token
+            "token" => $token
         ];
 
         $response = $stmt->execute($data);
@@ -780,7 +780,7 @@ class UserMapper extends ApiMapper
                       . "where token = :token";
 
         $select_stmt = $this->_db->prepare($select_sql);
-        $data        = ["token" => $token];
+        $data = ["token" => $token];
 
         $response = $select_stmt->execute($data);
 
@@ -794,10 +794,10 @@ class UserMapper extends ApiMapper
                 $update_sql = "update user set password = :password "
                               . "where ID = :user_id";
 
-                $update_stmt     = $this->_db->prepare($update_sql);
-                $update_data     = [
+                $update_stmt = $this->_db->prepare($update_sql);
+                $update_data = [
                     "password" => password_hash(md5($password), PASSWORD_DEFAULT),
-                    "user_id"  => $user_id
+                    "user_id" => $user_id
                 ];
                 $update_response = $update_stmt->execute($update_data);
 
@@ -835,32 +835,32 @@ class UserMapper extends ApiMapper
 
         try {
             // Delete the user
-            $sql  = "delete from user where ID = :user_id";
+            $sql = "delete from user where ID = :user_id";
             $stmt = $this->_db->prepare($sql);
             $stmt->execute(["user_id" => $user_id]);
 
             // Unassign any talks
-            $sql  = "update talk_speaker SET speaker_id = 0, status = NULL WHERE speaker_id = :speaker_id";
+            $sql = "update talk_speaker SET speaker_id = 0, status = NULL WHERE speaker_id = :speaker_id";
             $stmt = $this->_db->prepare($sql);
             $stmt->execute(["speaker_id" => $user_id]);
 
             // Remove any pending talk claims
-            $sql  = "delete from pending_talk_claims where speaker_id = :speaker_id";
+            $sql = "delete from pending_talk_claims where speaker_id = :speaker_id";
             $stmt = $this->_db->prepare($sql);
             $stmt->execute(["speaker_id" => $user_id]);
 
             // Anonymise any comments
-            $sql  = "update talk_comments SET user_id = 0 WHERE user_id = :user_id";
+            $sql = "update talk_comments SET user_id = 0 WHERE user_id = :user_id";
             $stmt = $this->_db->prepare($sql);
             $stmt->execute(["user_id" => $user_id]);
 
             // Remove any starred talks
-            $sql  = "delete from user_talk_star where uid = :user_id";
+            $sql = "delete from user_talk_star where uid = :user_id";
             $stmt = $this->_db->prepare($sql);
             $stmt->execute(["user_id" => $user_id]);
 
             // Remove user attendence
-            $sql  = "delete from user_attend where uid = :user_id";
+            $sql = "delete from user_attend where uid = :user_id";
             $stmt = $this->_db->prepare($sql);
             $stmt->execute(["user_id" => $user_id]);
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -161,9 +161,9 @@ class Request
             $header = new Header('X-Forwarded-For', $_SERVER['HTTP_X_FORWARDED_FOR'], ',');
             $header->parseParams();
             $elementArray = $header->buildEntityArray();
-            $ipAddress    = count($elementArray) ? $elementArray[0][0] : null;
+            $ipAddress = count($elementArray) ? $elementArray[0][0] : null;
         }
-        $this->clientIP        = $ipAddress;
+        $this->clientIP = $ipAddress;
         $this->clientUserAgent = $userAgent;
     }
 
@@ -364,7 +364,7 @@ class Request
                 throw new InvalidArgumentException('Unknown Authorization Header Received', Http::BAD_REQUEST);
             }
             $oauth_model = $this->getOauthModel($db);
-            $user_id     = $oauth_model->verifyAccessToken($oauth_pieces[1]);
+            $user_id = $oauth_model->verifyAccessToken($oauth_pieces[1]);
             $this->setUserId($user_id);
             $this->setAccessToken($oauth_pieces[1]);
 
@@ -574,7 +574,7 @@ class Request
      */
     public function setPathInfo($pathInfo)
     {
-        $this->path_info    = $pathInfo;
+        $this->path_info = $pathInfo;
         $this->url_elements = explode('/', $pathInfo);
 
         return $this;

--- a/src/Router/ApiRouter.php
+++ b/src/Router/ApiRouter.php
@@ -44,7 +44,7 @@ class ApiRouter extends BaseRouter
         $k = array_keys($routers);
         rsort($k);
         $this->latestVersion = current($k);
-        $this->routers       = $routers;
+        $this->routers = $routers;
     }
 
     /**

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -120,7 +120,7 @@ class Route
     public function dispatch(Request $request, $db, ContainerInterface $container)
     {
         $className = $this->getController();
-        $method    = $this->getAction();
+        $method = $this->getAction();
 
         if (!$container->has($className)) {
             throw new RuntimeException('Unknown controller ' . $request->url_elements[2], Http::BAD_REQUEST);

--- a/src/Router/VersionedRouter.php
+++ b/src/Router/VersionedRouter.php
@@ -41,7 +41,7 @@ class VersionedRouter extends BaseRouter
     {
         parent::__construct($config);
         $this->version = $version;
-        $this->rules   = $rules;
+        $this->rules = $rules;
     }
 
     /**

--- a/src/Service/BaseEmailService.php
+++ b/src/Service/BaseEmailService.php
@@ -58,7 +58,7 @@ abstract class BaseEmailService
             ->setUsername($config['email']['smtp']['username'])
             ->setPassword($config['email']['smtp']['password']);
 
-        $this->mailer  = new Swift_Mailer($transport);
+        $this->mailer = new Swift_Mailer($transport);
         $this->message = new Swift_Message();
 
         if (

--- a/src/Service/CommentReportedEmailService.php
+++ b/src/Service/CommentReportedEmailService.php
@@ -18,9 +18,9 @@ class CommentReportedEmailService extends BaseEmailService
         parent::__construct($config, $recipients);
 
         // this email needs comment info
-        $this->comment     = $comment['comments'][0];
+        $this->comment = $comment['comments'][0];
         $this->website_url = $config['website_url'];
-        $this->event       = $event['events'][0];
+        $this->event = $event['events'][0];
     }
 
     public function sendEmail()
@@ -43,11 +43,11 @@ class CommentReportedEmailService extends BaseEmailService
 
         $replacements = [
             "eventName" => $this->event['name'],
-            "title"     => $this->comment['talk_title'],
-            "rating"    => $this->comment['rating'],
-            "comment"   => $this->comment['comment'],
-            "byline"    => $byLine,
-            "link"      => $this->linkToReportedCommentsForEvent()
+            "title" => $this->comment['talk_title'],
+            "rating" => $this->comment['rating'],
+            "comment" => $this->comment['comment'],
+            "byline" => $byLine,
+            "link" => $this->linkToReportedCommentsForEvent()
         ];
 
         $messageBody = $this->parseEmail("commentReported.md", $replacements);

--- a/src/Service/ContactEmailService.php
+++ b/src/Service/ContactEmailService.php
@@ -32,7 +32,7 @@ class ContactEmailService extends BaseEmailService
         array_unshift($replyTo, $data['email']);
         $this->setReplyTo($replyTo);
 
-        $replacements                = $data;
+        $replacements = $data;
         $replacements["website_url"] = $this->website_url;
 
         $messageBody = $this->parseEmail("contact.md", $replacements);

--- a/src/Service/EventApprovedEmailService.php
+++ b/src/Service/EventApprovedEmailService.php
@@ -14,7 +14,7 @@ class EventApprovedEmailService extends BaseEmailService
         // set up the common stuff first
         parent::__construct($config, $recipients);
 
-        $this->event       = $event;
+        $this->event = $event;
         $this->website_url = $config['website_url'];
     }
 
@@ -22,14 +22,14 @@ class EventApprovedEmailService extends BaseEmailService
     {
         $this->setSubject('Event approved');
 
-        $date         = new DateTime($this->event['start_date']);
+        $date = new DateTime($this->event['start_date']);
         $replacements = [
-            "title"        => $this->event['name'],
-            "description"  => $this->event['description'],
-            "date"         => $date->format('jS M, Y'),
+            "title" => $this->event['name'],
+            "description" => $this->event['description'],
+            "date" => $date->format('jS M, Y'),
             "contact_name" => $this->event['contact_name'],
-            "website_url"  => $this->website_url,
-            "event_url"    => $this->website_url . '/event/' . $this->event['url_friendly_name'],
+            "website_url" => $this->website_url,
+            "event_url" => $this->website_url . '/event/' . $this->event['url_friendly_name'],
         ];
 
         $messageBody = $this->parseEmail("eventApproved.md", $replacements);

--- a/src/Service/EventCommentReportedEmailService.php
+++ b/src/Service/EventCommentReportedEmailService.php
@@ -14,8 +14,8 @@ class EventCommentReportedEmailService extends BaseEmailService
         parent::__construct($config, $recipients);
 
         // this email needs comment info
-        $this->comment     = $comment['comments'][0];
-        $this->event       = $event['events'][0];
+        $this->comment = $comment['comments'][0];
+        $this->event = $event['events'][0];
         $this->website_url = $config['website_url'];
     }
 
@@ -44,11 +44,11 @@ class EventCommentReportedEmailService extends BaseEmailService
         }
 
         $replacements = [
-            "name"    => $this->event['name'],
-            "rating"  => $rating,
+            "name" => $this->event['name'],
+            "rating" => $rating,
             "comment" => $this->comment['comment'],
-            "byline"  => $byLine,
-            "link"    => $this->linkToReportedCommentsForEvent()
+            "byline" => $byLine,
+            "link" => $this->linkToReportedCommentsForEvent()
         ];
 
         $messageBody = $this->parseEmail("eventCommentReported.md", $replacements);

--- a/src/Service/EventRejectedEmailService.php
+++ b/src/Service/EventRejectedEmailService.php
@@ -14,7 +14,7 @@ class EventRejectedEmailService extends BaseEmailService
         // set up the common stuff first
         parent::__construct($config, $recipients);
 
-        $this->event       = $event;
+        $this->event = $event;
         $this->website_url = $config['website_url'];
     }
 
@@ -22,15 +22,15 @@ class EventRejectedEmailService extends BaseEmailService
     {
         $this->setSubject('Event Rejected');
 
-        $date         = new DateTime($this->event['start_date']);
+        $date = new DateTime($this->event['start_date']);
         $replacements = [
-            "title"        => $this->event['name'],
-            "description"  => $this->event['description'],
-            "reason"       => $this->event['rejection_reason'],
-            "date"         => $date->format('jS M, Y'),
+            "title" => $this->event['name'],
+            "description" => $this->event['description'],
+            "reason" => $this->event['rejection_reason'],
+            "date" => $date->format('jS M, Y'),
             "contact_name" => $this->event['contact_name'],
-            "website_url"  => $this->website_url,
-            "event_url"    => $this->website_url . '/event/' . $this->event['url_friendly_name'] . '/edit',
+            "website_url" => $this->website_url,
+            "event_url" => $this->website_url . '/event/' . $this->event['url_friendly_name'] . '/edit',
         ];
 
         $messageBody = $this->parseEmail("eventRejected.md", $replacements);

--- a/src/Service/EventSubmissionEmailService.php
+++ b/src/Service/EventSubmissionEmailService.php
@@ -26,7 +26,7 @@ class EventSubmissionEmailService extends BaseEmailService
         parent::__construct($config, $recipients);
 
         // this email needs event info
-        $this->event       = $event;
+        $this->event = $event;
         $this->website_url = $config['website_url'];
 
         $this->count = $count;
@@ -39,11 +39,11 @@ class EventSubmissionEmailService extends BaseEmailService
         $date = new DateTime($this->event['start_date']);
 
         $replacements = [
-            "title"        => $this->event['name'],
-            "description"  => $this->event['description'],
-            "date"         => $date->format('jS M, Y'),
+            "title" => $this->event['name'],
+            "description" => $this->event['description'],
+            "date" => $date->format('jS M, Y'),
             "contact_name" => $this->event['contact_name'],
-            "website_url"  => $this->website_url,
+            "website_url" => $this->website_url,
         ];
 
         if ($this->count) {

--- a/src/Service/SpamCheckService.php
+++ b/src/Service/SpamCheckService.php
@@ -26,7 +26,7 @@ class SpamCheckService implements SpamCheckServiceInterface
     {
         $this->httpClient = $httpClient;
         $this->akismetUrl = 'https://' . $apiKey . '.rest.akismet.com';
-        $this->blog       = $blog;
+        $this->blog = $blog;
     }
 
     /**

--- a/src/Service/TalkAssignEmailService.php
+++ b/src/Service/TalkAssignEmailService.php
@@ -27,10 +27,10 @@ class TalkAssignEmailService extends BaseEmailService
         parent::__construct($config, $recipients);
 
         // this email needs comment info
-        $this->talk        = $talk;
+        $this->talk = $talk;
         $this->website_url = $config['website_url'];
-        $this->event       = $event['events'][0];
-        $this->username    = $username;
+        $this->event = $event['events'][0];
+        $this->username = $username;
     }
 
     public function sendEmail()
@@ -40,7 +40,7 @@ class TalkAssignEmailService extends BaseEmailService
         $replacements = [
             "eventName" => $this->event['name'],
             "talkTitle" => $this->talk->talk_title,
-            "link"      => $this->linkToEditUserPage()
+            "link" => $this->linkToEditUserPage()
         ];
 
         $messageBody = $this->parseEmail("talkAssigned.md", $replacements);

--- a/src/Service/TalkClaimApprovedEmailService.php
+++ b/src/Service/TalkClaimApprovedEmailService.php
@@ -16,8 +16,8 @@ class TalkClaimApprovedEmailService extends BaseEmailService
         parent::__construct($config, $recipients);
 
         $this->website_url = $config['website_url'];
-        $this->talk        = $talk;
-        $this->event       = $event['events'][0];
+        $this->talk = $talk;
+        $this->event = $event['events'][0];
     }
 
     public function sendEmail()
@@ -27,7 +27,7 @@ class TalkClaimApprovedEmailService extends BaseEmailService
         $replacements = [
             "eventName" => $this->event['name'],
             "talkTitle" => $this->talk->talk_title,
-            "talkUri"   => $this->talk->getWebsiteUrl($this->website_url),
+            "talkUri" => $this->talk->getWebsiteUrl($this->website_url),
         ];
 
         $messageBody = $this->parseEmail("talkClaimApproved.md", $replacements);

--- a/src/Service/TalkClaimEmailService.php
+++ b/src/Service/TalkClaimEmailService.php
@@ -16,9 +16,9 @@ class TalkClaimEmailService extends BaseEmailService
         parent::__construct($config, $recipients);
 
         // this email needs comment info
-        $this->talk        = $talk;
+        $this->talk = $talk;
         $this->website_url = $config['website_url'];
-        $this->event       = $event['events'][0];
+        $this->event = $event['events'][0];
     }
 
     public function sendEmail()
@@ -28,7 +28,7 @@ class TalkClaimEmailService extends BaseEmailService
         $replacements = [
             "eventName" => $this->event['name'],
             "talkTitle" => $this->talk->talk_title,
-            "link"      => $this->linkToPendingClaimsForEvent()
+            "link" => $this->linkToPendingClaimsForEvent()
         ];
 
         $messageBody = $this->parseEmail("talkClaimed.md", $replacements);

--- a/src/Service/TalkClaimRejectedEmailService.php
+++ b/src/Service/TalkClaimRejectedEmailService.php
@@ -15,7 +15,7 @@ class TalkClaimRejectedEmailService extends BaseEmailService
         // set up the common stuff first
         parent::__construct($config, $recipients);
 
-        $this->talk  = $talk;
+        $this->talk = $talk;
         $this->event = $event['events'][0];
     }
 

--- a/src/Service/TalkCommentEmailService.php
+++ b/src/Service/TalkCommentEmailService.php
@@ -16,9 +16,9 @@ class TalkCommentEmailService extends BaseEmailService
         parent::__construct($config, $recipients);
 
         // this email needs talk and comment info
-        $this->talk    = $talk;
+        $this->talk = $talk;
         $this->comment = $comment['comments'][0];
-        $this->config  = $config;
+        $this->config = $config;
     }
 
     public function sendEmail()
@@ -36,11 +36,11 @@ class TalkCommentEmailService extends BaseEmailService
         }
 
         $replacements = [
-            "title"   => $this->talk->talk_title,
-            "rating"  => $this->comment['rating'],
+            "title" => $this->talk->talk_title,
+            "rating" => $this->comment['rating'],
             "comment" => $this->comment['comment'],
-            "url"     => $this->talk->getWebsiteUrl($this->config['website_url']),
-            "byline"  => $byLine
+            "url" => $this->talk->getWebsiteUrl($this->config['website_url']),
+            "byline" => $byLine
         ];
 
         $messageBody = $this->parseEmail("commentTalk.md", $replacements);

--- a/src/Service/UserPasswordResetEmailService.php
+++ b/src/Service/UserPasswordResetEmailService.php
@@ -25,8 +25,8 @@ class UserPasswordResetEmailService extends BaseEmailService
         // set up the common stuff first
         parent::__construct($config, $recipients);
 
-        $this->user        = $user;
-        $this->token       = $token;
+        $this->user = $user;
+        $this->token = $token;
         $this->website_url = $config['website_url'];
     }
 
@@ -35,10 +35,10 @@ class UserPasswordResetEmailService extends BaseEmailService
         $this->setSubject('Resetting your joind.in password');
 
         $replacements = [
-            "full_name"   => $this->user['full_name'],
-            "username"    => $this->user['username'],
+            "full_name" => $this->user['full_name'],
+            "username" => $this->user['username'],
             "website_url" => $this->website_url,
-            "token"       => $this->token,
+            "token" => $this->token,
         ];
 
         $messageBody = $this->parseEmail("userPasswordReset.md", $replacements);

--- a/src/Service/UserRegistrationEmailService.php
+++ b/src/Service/UserRegistrationEmailService.php
@@ -20,7 +20,7 @@ class UserRegistrationEmailService extends BaseEmailService
         // set up the common stuff first
         parent::__construct($config, $recipients);
 
-        $this->token       = $token;
+        $this->token = $token;
         $this->website_url = $config['website_url'];
     }
 
@@ -29,7 +29,7 @@ class UserRegistrationEmailService extends BaseEmailService
         $this->setSubject('Welcome to joind.in');
 
         $replacements = [
-            "token"       => $this->token,
+            "token" => $this->token,
             "website_url" => $this->website_url,
         ];
 

--- a/src/Service/UserUsernameReminderEmailService.php
+++ b/src/Service/UserUsernameReminderEmailService.php
@@ -17,7 +17,7 @@ class UserUsernameReminderEmailService extends BaseEmailService
         // set up the common stuff first
         parent::__construct($config, $recipients);
 
-        $this->user        = $user;
+        $this->user = $user;
         $this->website_url = $config['website_url'];
     }
 
@@ -26,8 +26,8 @@ class UserUsernameReminderEmailService extends BaseEmailService
         $this->setSubject('Your joind.in username');
 
         $replacements = [
-            "full_name"   => $this->user['full_name'],
-            "username"    => $this->user['username'],
+            "full_name" => $this->user['full_name'],
+            "username" => $this->user['username'],
             "website_url" => $this->website_url,
         ];
 

--- a/src/View/ApiView.php
+++ b/src/View/ApiView.php
@@ -16,9 +16,9 @@ class ApiView
 
     public function __construct(array $headers = [], $responseCode = Http::OK, $noRender = false)
     {
-        $this->headers      = $headers;
+        $this->headers = $headers;
         $this->responseCode = $responseCode;
-        $this->noRender     = $noRender;
+        $this->noRender = $noRender;
     }
 
     /**

--- a/src/config/routes/2.1.php
+++ b/src/config/routes/2.1.php
@@ -22,584 +22,584 @@ use Joindin\Api\Request;
 
 return [
     [
-        'path'       => '/events(/[^/]+)*/hosts',
+        'path' => '/events(/[^/]+)*/hosts',
         'controller' => EventHostsController::class,
-        'action'     => 'listHosts',
-        'verbs'      => [
+        'action' => 'listHosts',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/events/[\\d]+/hosts',
+        'path' => '/events/[\\d]+/hosts',
         'controller' => EventHostsController::class,
-        'action'     => 'addHost',
-        'verbs'      => [
+        'action' => 'addHost',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/events/[\\d]+/hosts/[\\d]+',
+        'path' => '/events/[\\d]+/hosts/[\\d]+',
         'controller' => EventHostsController::class,
-        'action'     => 'removeHostFromEvent',
-        'verbs'      => [
+        'action' => 'removeHostFromEvent',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/events(/[^/]+)*/comments/reported',
+        'path' => '/events(/[^/]+)*/comments/reported',
         'controller' => EventCommentsController::class,
-        'action'     => 'getReported',
-        'verbs'      => [
+        'action' => 'getReported',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/events(/[\\d]+)/talk_comments/reported',
+        'path' => '/events(/[\\d]+)/talk_comments/reported',
         'controller' => TalkCommentsController::class,
-        'action'     => 'getReported',
-        'verbs'      => [
+        'action' => 'getReported',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/events/(\\d+)/claims$',
+        'path' => '/events/(\\d+)/claims$',
         'controller' => EventsController::class,
-        'action'     => 'pendingClaims',
-        'verbs'      => [
+        'action' => 'pendingClaims',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/events(/[\\d]+)/images',
+        'path' => '/events(/[\\d]+)/images',
         'controller' => EventImagesController::class,
-        'action'     => 'listImages',
-        'verbs'      => [
+        'action' => 'listImages',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/events(/[^/]+)*/?$',
+        'path' => '/events(/[^/]+)*/?$',
         'controller' => EventsController::class,
-        'action'     => 'getAction',
-        'verbs'      => [
+        'action' => 'getAction',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/events/(\\d+)/tracks$',
+        'path' => '/events/(\\d+)/tracks$',
         'controller' => EventsController::class,
-        'action'     => 'createTrack',
-        'verbs'      => [
+        'action' => 'createTrack',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/events/(\\d+)/approval$',
+        'path' => '/events/(\\d+)/approval$',
         'controller' => EventsController::class,
-        'action'     => 'approveAction',
-        'verbs'      => [
+        'action' => 'approveAction',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/events/(\\d+)/approval$',
+        'path' => '/events/(\\d+)/approval$',
         'controller' => EventsController::class,
-        'action'     => 'rejectAction',
-        'verbs'      => [
+        'action' => 'rejectAction',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/events(/[^/]+)*/comments',
+        'path' => '/events(/[^/]+)*/comments',
         'controller' => EventCommentsController::class,
-        'action'     => 'createComment',
-        'verbs'      => [
+        'action' => 'createComment',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/events(/[\\d]+)/images',
+        'path' => '/events(/[\\d]+)/images',
         'controller' => EventImagesController::class,
-        'action'     => 'createImage',
-        'verbs'      => [
+        'action' => 'createImage',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/events(/[\\d]+)/images',
+        'path' => '/events(/[\\d]+)/images',
         'controller' => EventImagesController::class,
-        'action'     => 'deleteImage',
-        'verbs'      => [
+        'action' => 'deleteImage',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/events(/[\\d]+)/talks',
+        'path' => '/events(/[\\d]+)/talks',
         'controller' => TalksController::class,
-        'action'     => 'createTalkAction',
-        'verbs'      => [
+        'action' => 'createTalkAction',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/events(/[^/]+)*/?$',
+        'path' => '/events(/[^/]+)*/?$',
         'controller' => EventsController::class,
-        'action'     => 'postAction',
-        'verbs'      => [
+        'action' => 'postAction',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/events(/[^/]+)*/?$',
+        'path' => '/events(/[^/]+)*/?$',
         'controller' => EventsController::class,
-        'action'     => 'putAction',
-        'verbs'      => [
+        'action' => 'putAction',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/events(/[^/]+)*/?$',
+        'path' => '/events(/[^/]+)*/?$',
         'controller' => EventsController::class,
-        'action'     => 'deleteAction',
-        'verbs'      => [
+        'action' => 'deleteAction',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/links/?$',
+        'path' => '/talks(/[\\d]+)/links/?$',
         'controller' => TalkLinkController::class,
-        'action'     => 'getTalkLinks',
-        'verbs'      => [
+        'action' => 'getTalkLinks',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/links/?$',
+        'path' => '/talks(/[\\d]+)/links/?$',
         'controller' => TalkLinkController::class,
-        'action'     => 'addTalkLink',
-        'verbs'      => [
+        'action' => 'addTalkLink',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/links(/[\\d]+)$',
+        'path' => '/talks(/[\\d]+)/links(/[\\d]+)$',
         'controller' => TalkLinkController::class,
-        'action'     => 'getTalkLink',
-        'verbs'      => [
+        'action' => 'getTalkLink',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/links(/[\\d]+)$',
+        'path' => '/talks(/[\\d]+)/links(/[\\d]+)$',
         'controller' => TalkLinkController::class,
-        'action'     => 'removeTalkLink',
-        'verbs'      => [
+        'action' => 'removeTalkLink',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/links(/[\\d]+)$',
+        'path' => '/talks(/[\\d]+)/links(/[\\d]+)$',
         'controller' => TalkLinkController::class,
-        'action'     => 'updateTalkLink',
-        'verbs'      => [
+        'action' => 'updateTalkLink',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/speakers/?$',
+        'path' => '/talks(/[\\d]+)/speakers/?$',
         'controller' => TalksController::class,
-        'action'     => 'getSpeakersForTalk',
-        'verbs'      => [
+        'action' => 'getSpeakersForTalk',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/speakers/?$',
+        'path' => '/talks(/[\\d]+)/speakers/?$',
         'controller' => TalksController::class,
-        'action'     => 'setSpeakerForTalk',
-        'verbs'      => [
+        'action' => 'setSpeakerForTalk',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/speakers/?$',
+        'path' => '/talks(/[\\d]+)/speakers/?$',
         'controller' => TalksController::class,
-        'action'     => 'removeSpeakerForTalk',
-        'verbs'      => [
+        'action' => 'removeSpeakerForTalk',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)$',
+        'path' => '/talks(/[\\d]+)$',
         'controller' => TalksController::class,
-        'action'     => 'editTalk',
-        'verbs'      => [
+        'action' => 'editTalk',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/talks/?$',
+        'path' => '/talks/?$',
         'controller' => TalksController::class,
-        'action'     => 'getTalkByKeyWord',
-        'verbs'      => [
+        'action' => 'getTalkByKeyWord',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talks/[\\d]+/comments/?$',
+        'path' => '/talks/[\\d]+/comments/?$',
         'controller' => TalksController::class,
-        'action'     => 'getTalkComments',
-        'verbs'      => [
+        'action' => 'getTalkComments',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talks/[\\d]+/starred/?$',
+        'path' => '/talks/[\\d]+/starred/?$',
         'controller' => TalksController::class,
-        'action'     => 'getTalkStarred',
-        'verbs'      => [
+        'action' => 'getTalkStarred',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talks/[\\d]+/?$',
+        'path' => '/talks/[\\d]+/?$',
         'controller' => TalksController::class,
-        'action'     => 'getAction',
-        'verbs'      => [
+        'action' => 'getAction',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/tracks$',
+        'path' => '/talks(/[\\d]+)/tracks$',
         'controller' => TalksController::class,
-        'action'     => 'addTrackToTalk',
-        'verbs'      => [
+        'action' => 'addTrackToTalk',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/tracks(/[\\d]+)$',
+        'path' => '/talks(/[\\d]+)/tracks(/[\\d]+)$',
         'controller' => TalksController::class,
-        'action'     => 'removeTrackFromTalk',
-        'verbs'      => [
+        'action' => 'removeTrackFromTalk',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/talks(/[^/]+)*/?$',
+        'path' => '/talks(/[^/]+)*/?$',
         'controller' => TalksController::class,
-        'action'     => 'postAction',
-        'verbs'      => [
+        'action' => 'postAction',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/talks(/[\\d]+)/speakers(/[\\d]+)$',
+        'path' => '/talks(/[\\d]+)/speakers(/[\\d]+)$',
         'controller' => TalksController::class,
-        'action'     => 'removeApprovedSpeakerFromTalk',
-        'verbs'      => [
+        'action' => 'removeApprovedSpeakerFromTalk',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/talks/[\\d]+/starred/?$',
+        'path' => '/talks/[\\d]+/starred/?$',
         'controller' => TalksController::class,
-        'action'     => 'removeStarFromTalk',
-        'verbs'      => [
+        'action' => 'removeStarFromTalk',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/talks/[\\d]+/?$',
+        'path' => '/talks/[\\d]+/?$',
         'controller' => TalksController::class,
-        'action'     => 'deleteTalk',
-        'verbs'      => [
+        'action' => 'deleteTalk',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/token(/[^/]+)*/?$',
+        'path' => '/token(/[^/]+)*/?$',
         'controller' => TokenController::class,
-        'action'     => 'postAction',
-        'verbs'      => [
+        'action' => 'postAction',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/token/?$',
+        'path' => '/token/?$',
         'controller' => TokenController::class,
-        'action'     => 'listTokensForUser',
-        'verbs'      => [
+        'action' => 'listTokensForUser',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/token(/[^/]+)/?$',
+        'path' => '/token(/[^/]+)/?$',
         'controller' => TokenController::class,
-        'action'     => 'getToken',
-        'verbs'      => [
+        'action' => 'getToken',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/token(/[^/]+)*/?$',
+        'path' => '/token(/[^/]+)*/?$',
         'controller' => TokenController::class,
-        'action'     => 'revokeToken',
-        'verbs'      => [
+        'action' => 'revokeToken',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/tracks(/[^/]+)*/?$',
+        'path' => '/tracks(/[^/]+)*/?$',
         'controller' => TracksController::class,
-        'action'     => 'getAction',
-        'verbs'      => [
+        'action' => 'getAction',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/tracks(/[\\d]+)/?$',
+        'path' => '/tracks(/[\\d]+)/?$',
         'controller' => TracksController::class,
-        'action'     => 'editTrack',
-        'verbs'      => [
+        'action' => 'editTrack',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/tracks(/[\\d]+)/?$',
+        'path' => '/tracks(/[\\d]+)/?$',
         'controller' => TracksController::class,
-        'action'     => 'deleteTrack',
-        'verbs'      => [
+        'action' => 'deleteTrack',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/users/passwords$',
+        'path' => '/users/passwords$',
         'controller' => UsersController::class,
-        'action'     => 'passwordReset',
-        'verbs'      => [
+        'action' => 'passwordReset',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/users(/[0-9]+)/trusted?$',
+        'path' => '/users(/[0-9]+)/trusted?$',
         'controller' => UsersController::class,
-        'action'     => 'setTrusted',
-        'verbs'      => [
+        'action' => 'setTrusted',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/users(/[^/]+)*/?$',
+        'path' => '/users(/[^/]+)*/?$',
         'controller' => UsersController::class,
-        'action'     => 'getAction',
-        'verbs'      => [
+        'action' => 'getAction',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/users(/[^/]+)*/?$',
+        'path' => '/users(/[^/]+)*/?$',
         'controller' => UsersController::class,
-        'action'     => 'postAction',
-        'verbs'      => [
+        'action' => 'postAction',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/users(/[^/]+)*/?$',
+        'path' => '/users(/[^/]+)*/?$',
         'controller' => UsersController::class,
-        'action'     => 'deleteUser',
-        'verbs'      => [
+        'action' => 'deleteUser',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/users(/[0-9]+)/?$',
+        'path' => '/users(/[0-9]+)/?$',
         'controller' => UsersController::class,
-        'action'     => 'updateUser',
-        'verbs'      => [
+        'action' => 'updateUser',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/users/[0-9]+/talk_comments',
+        'path' => '/users/[0-9]+/talk_comments',
         'controller' => UsersController::class,
-        'action'     => 'deleteTalkComments',
-        'verbs'      => [
+        'action' => 'deleteTalkComments',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/event_comments(/[^/]+)*/?$',
+        'path' => '/event_comments(/[^/]+)*/?$',
         'controller' => EventCommentsController::class,
-        'action'     => 'getComments',
-        'verbs'      => [
+        'action' => 'getComments',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/event_comments(/[^/]+)*/reported?$',
+        'path' => '/event_comments(/[^/]+)*/reported?$',
         'controller' => EventCommentsController::class,
-        'action'     => 'reportComment',
-        'verbs'      => [
+        'action' => 'reportComment',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/event_comments(/[^/]+)*/reported?$',
+        'path' => '/event_comments(/[^/]+)*/reported?$',
         'controller' => EventCommentsController::class,
-        'action'     => 'moderateReportedComment',
-        'verbs'      => [
+        'action' => 'moderateReportedComment',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/talk_comments(/[^/]+)*/?$',
+        'path' => '/talk_comments(/[^/]+)*/?$',
         'controller' => TalkCommentsController::class,
-        'action'     => 'getComments',
-        'verbs'      => [
+        'action' => 'getComments',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talk_comments(/[^/]+)*/?$',
+        'path' => '/talk_comments(/[^/]+)*/?$',
         'controller' => TalkCommentsController::class,
-        'action'     => 'updateComment',
-        'verbs'      => [
+        'action' => 'updateComment',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/emails/verifications',
+        'path' => '/emails/verifications',
         'controller' => EmailsController::class,
-        'action'     => 'verifications',
-        'verbs'      => [
+        'action' => 'verifications',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/emails/reminders/username',
+        'path' => '/emails/reminders/username',
         'controller' => EmailsController::class,
-        'action'     => 'usernameReminder',
-        'verbs'      => [
+        'action' => 'usernameReminder',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/emails/reminders/password',
+        'path' => '/emails/reminders/password',
         'controller' => EmailsController::class,
-        'action'     => 'passwordReset',
-        'verbs'      => [
+        'action' => 'passwordReset',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/twitter/request_token',
+        'path' => '/twitter/request_token',
         'controller' => TwitterController::class,
-        'action'     => 'getRequestToken',
-        'verbs'      => [
+        'action' => 'getRequestToken',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/twitter/token',
+        'path' => '/twitter/token',
         'controller' => TwitterController::class,
-        'action'     => 'logUserIn',
-        'verbs'      => [
+        'action' => 'logUserIn',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/languages?$',
+        'path' => '/languages?$',
         'controller' => LanguagesController::class,
-        'action'     => 'getAllLanguages',
-        'verbs'      => [
+        'action' => 'getAllLanguages',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/languages(/[0-9]+)?/?$',
+        'path' => '/languages(/[0-9]+)?/?$',
         'controller' => LanguagesController::class,
-        'action'     => 'getLanguage',
-        'verbs'      => [
+        'action' => 'getLanguage',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/contact',
+        'path' => '/contact',
         'controller' => ContactController::class,
-        'action'     => 'contact',
-        'verbs'      => [
+        'action' => 'contact',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/talk_types/?$',
+        'path' => '/talk_types/?$',
         'controller' => TalkTypesController::class,
-        'action'     => 'getAllTalkTypes',
-        'verbs'      => [
+        'action' => 'getAllTalkTypes',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/talk_types(/[0-9]+)?/?$',
+        'path' => '/talk_types(/[0-9]+)?/?$',
         'controller' => TalkTypesController::class,
-        'action'     => 'getTalkType',
-        'verbs'      => [
+        'action' => 'getTalkType',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/facebook/token',
+        'path' => '/facebook/token',
         'controller' => FacebookController::class,
-        'action'     => 'logUserIn',
-        'verbs'      => [
+        'action' => 'logUserIn',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/applications$',
+        'path' => '/applications$',
         'controller' => ApplicationsController::class,
-        'action'     => 'listApplications',
-        'verbs'      => [
+        'action' => 'listApplications',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/applications$',
+        'path' => '/applications$',
         'controller' => ApplicationsController::class,
-        'action'     => 'createApplication',
-        'verbs'      => [
+        'action' => 'createApplication',
+        'verbs' => [
             Request::HTTP_POST,
         ],
     ],
     [
-        'path'       => '/applications(/[0-9]+)$',
+        'path' => '/applications(/[0-9]+)$',
         'controller' => ApplicationsController::class,
-        'action'     => 'getApplication',
-        'verbs'      => [
+        'action' => 'getApplication',
+        'verbs' => [
             Request::HTTP_GET,
         ],
     ],
     [
-        'path'       => '/applications(/[0-9]+)$',
+        'path' => '/applications(/[0-9]+)$',
         'controller' => ApplicationsController::class,
-        'action'     => 'editApplication',
-        'verbs'      => [
+        'action' => 'editApplication',
+        'verbs' => [
             Request::HTTP_PUT,
         ],
     ],
     [
-        'path'       => '/applications(/[0-9]+)$',
+        'path' => '/applications(/[0-9]+)$',
         'controller' => ApplicationsController::class,
-        'action'     => 'deleteApplication',
-        'verbs'      => [
+        'action' => 'deleteApplication',
+        'verbs' => [
             Request::HTTP_DELETE,
         ],
     ],
     [
-        'path'       => '/?$',
+        'path' => '/?$',
         'controller' => DefaultController::class,
-        'action'     => 'handle',
+        'action' => 'handle',
     ],
 ];

--- a/tests/ContainerFactoryTest.php
+++ b/tests/ContainerFactoryTest.php
@@ -14,14 +14,14 @@ final class ContainerFactoryTest extends TestCase
     private $config = [
         'akismet' => [
             'apiKey' => 'key',
-            'blog'   => 'blog'
+            'blog' => 'blog'
         ],
         'email' => [
             'contact' => 'excample@example.com',
             'from' => 'example@example.com',
             'smtp' => [
-                'host'     => 'localhost',
-                'port'     => 25,
+                'host' => 'localhost',
+                'port' => 25,
                 'username' => 'username',
                 'password' => 'ChangeMeSeymourChangeMe',
                 'security' => null,

--- a/tests/Controller/ContactControllerTest.php
+++ b/tests/Controller/ContactControllerTest.php
@@ -108,17 +108,17 @@ final class ContactControllerTest extends TestCase
             //Client cannot use the contactform
             [
                 'isClientPermittedPasswordGrant' => false,
-                'returnValueMap'                 => [],
-                'isCommentAcceptable'            => false,
-                'exceptedException'              => 'Exception',
-                'expectedExceptionMessage'       => 'This client cannot perform this action',
-                'emailShouldBeSent'              => false,
-                'spamShouldBeChecked'            => false
+                'returnValueMap' => [],
+                'isCommentAcceptable' => false,
+                'exceptedException' => 'Exception',
+                'expectedExceptionMessage' => 'This client cannot perform this action',
+                'emailShouldBeSent' => false,
+                'spamShouldBeChecked' => false
             ],
             //Not all required fields are set
             [
                 'isClientPermittedPasswordGrant' => true,
-                'returnValueMap'                 => [
+                'returnValueMap' => [
                     ['client_id', '', 'client_id'],
                     ['client_secret', '', 'client_secret'],
                     ['name', '', ''],
@@ -126,14 +126,14 @@ final class ContactControllerTest extends TestCase
                     ['subject', '', ''],
                     ['comment', '', '']
                 ],
-                'isCommentAcceptable'            => false,
-                'exceptedException'              => Exception::class,
-                'expectedExceptionMessage'       => "The fields 'name', 'email', 'subject', 'comment' are required",
+                'isCommentAcceptable' => false,
+                'exceptedException' => Exception::class,
+                'expectedExceptionMessage' => "The fields 'name', 'email', 'subject', 'comment' are required",
             ],
             //Spamcheck fails
             [
                 'isClientPermittedPasswordGrant' => true,
-                'returnValueMap'                 => [
+                'returnValueMap' => [
                     ['client_id', '', 'client_id'],
                     ['client_secret', '', 'client_secret'],
                     ['name', '', 'name'],
@@ -142,15 +142,15 @@ final class ContactControllerTest extends TestCase
                     ['comment', '', 'comment']
                 ],
 
-                'isCommentAcceptable'      => false,
-                'exceptedException'        => Exception::class,
+                'isCommentAcceptable' => false,
+                'exceptedException' => Exception::class,
                 'expectedExceptionMessage' => 'Comment failed spam check',
-                'spamShouldBeChecked'            => true,
+                'spamShouldBeChecked' => true,
             ],
             //Email is sent without spamcheck
             [
                 'isClientPermittedPasswordGrant' => true,
-                'returnValueMap'                 => [
+                'returnValueMap' => [
                     ['client_id', '', 'client_id'],
                     ['client_secret', '', 'client_secret'],
                     ['name', '', 'name'],
@@ -158,16 +158,16 @@ final class ContactControllerTest extends TestCase
                     ['subject', '', 'subject'],
                     ['comment', '', 'comment']
                 ],
-                'isCommentAcceptable'            => true,
-                'exceptedException'              => null,
-                'expectedExceptionMessage'       => null,
-                'spamShouldBeChecked'            => true,
-                'emailShouldBeSent'              => true
+                'isCommentAcceptable' => true,
+                'exceptedException' => null,
+                'expectedExceptionMessage' => null,
+                'spamShouldBeChecked' => true,
+                'emailShouldBeSent' => true
             ],
             //All is good email should be sent
             [
                 'isClientPermittedPasswordGrant' => true,
-                'returnValueMap'                 => [
+                'returnValueMap' => [
                     ['client_id', '', 'client_id'],
                     ['client_secret', '', 'client_secret'],
                     ['name', '', 'name'],
@@ -175,11 +175,11 @@ final class ContactControllerTest extends TestCase
                     ['subject', '', 'subject'],
                     ['comment', '', 'comment']
                 ],
-                'isCommentAcceptable'            => true,
-                'exceptedException'              => null,
-                'expectedExceptionMessage'       => null,
-                'spamShouldBeChecked'            => true,
-                'emailShouldBeSent'              => true
+                'isCommentAcceptable' => true,
+                'exceptedException' => null,
+                'expectedExceptionMessage' => null,
+                'spamShouldBeChecked' => true,
+                'emailShouldBeSent' => true
             ]
         ];
     }

--- a/tests/Controller/EventHostsControllerTest.php
+++ b/tests/Controller/EventHostsControllerTest.php
@@ -24,7 +24,7 @@ final class EventHostsControllerTest extends TestCase
         $controller = new EventHostsController();
 
         $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $db      = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
+        $db = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
 
         $controller->addHost($request, $db);
     }
@@ -57,9 +57,9 @@ final class EventHostsControllerTest extends TestCase
 
         $controller->setEventMapper($em);
 
-        $request               = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
+        $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
         $request->url_elements = [3 => 'foo'];
-        $request->user_id      = 2;
+        $request->user_id = 2;
 
         $db = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
 

--- a/tests/Controller/TalkLinkControllerTest.php
+++ b/tests/Controller/TalkLinkControllerTest.php
@@ -254,8 +254,8 @@ final class TalkLinkControllerTest extends TalkBase
 
         $this->request->user_id = 2;
         $this->request->parameters = [
-            'username'      => 'janebloggs',
-            'display_name'  =>  'P Sherman'
+            'username' => 'janebloggs',
+            'display_name' => 'P Sherman'
         ];
 
         $this->talks_controller = new TalkLinkController();

--- a/tests/Controller/TalksControllerDeleteTest.php
+++ b/tests/Controller/TalksControllerDeleteTest.php
@@ -46,8 +46,8 @@ final class TalksControllerDeleteTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
         ];
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
@@ -96,8 +96,8 @@ final class TalksControllerDeleteTest extends TalkBase
 
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
         ];
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
@@ -135,8 +135,8 @@ final class TalksControllerDeleteTest extends TalkBase
 
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
         ];
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
@@ -162,8 +162,8 @@ final class TalksControllerDeleteTest extends TalkBase
 
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
         ];
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();

--- a/tests/Controller/TalksControllerTest.php
+++ b/tests/Controller/TalksControllerTest.php
@@ -26,9 +26,9 @@ final class TalksControllerTest extends TalkBase
         $this->config = [
             'email' => [
                 'from' => 'source@example.com',
-                'smtp'           => [
-                    'host'     => 'localhost',
-                    'port'     => 25,
+                'smtp' => [
+                    'host' => 'localhost',
+                    'port' => 25,
                     'username' => 'username',
                     'password' => 'ChangeMeSeymourChangeMe',
                     'security' => null
@@ -130,7 +130,7 @@ final class TalksControllerTest extends TalkBase
 
         $request->user_id = 2;
         $request->parameters = [
-            'display_name'  => 'Jane Bloggs'
+            'display_name' => 'Jane Bloggs'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -171,7 +171,7 @@ final class TalksControllerTest extends TalkBase
 
         $request->user_id = 2;
         $request->parameters = [
-            'username'  => 'janebloggs'
+            'username' => 'janebloggs'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -212,8 +212,8 @@ final class TalksControllerTest extends TalkBase
 
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'janebloggs',
-            'display_name'  =>  'P Sherman'
+            'username' => 'janebloggs',
+            'display_name' => 'P Sherman'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -257,8 +257,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'janebloggs',
-            'display_name'  => 'P Sherman'
+            'username' => 'janebloggs',
+            'display_name' => 'P Sherman'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -305,8 +305,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman'
+            'username' => 'psherman',
+            'display_name' => 'P Sherman'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -371,8 +371,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman'
+            'username' => 'psherman',
+            'display_name' => 'P Sherman'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -419,8 +419,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'janebloggs',
-            'display_name'  => 'Jane Bloggs'
+            'username' => 'janebloggs',
+            'display_name' => 'Jane Bloggs'
         ];
 
         $talks_controller = new TalksController(
@@ -484,8 +484,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman'
+            'username' => 'psherman',
+            'display_name' => 'P Sherman'
         ];
 
         $talks_controller = new TalksController(
@@ -554,8 +554,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'janebloggs',
-            'display_name'  => 'Jane Bloggs'
+            'username' => 'janebloggs',
+            'display_name' => 'Jane Bloggs'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -618,8 +618,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'janebloggs',
-            'display_name'  => 'Jane Bloggs'
+            'username' => 'janebloggs',
+            'display_name' => 'Jane Bloggs'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -682,8 +682,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman'
+            'username' => 'psherman',
+            'display_name' => 'P Sherman'
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -737,8 +737,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'janebloggs',
-            'display_name'  => 'Jane Bloggs',
+            'username' => 'janebloggs',
+            'display_name' => 'Jane Bloggs',
         ];
 
         $talks_controller = new TalksController(new NullSpamCheckService());
@@ -801,8 +801,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
         ];
 
         $talks_controller = new TalksController(
@@ -876,8 +876,8 @@ final class TalksControllerTest extends TalkBase
 
         $request->user_id = $commenterId;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
             'comment' => 'Test Comment',
             'rating' => '3',
         ];
@@ -1012,8 +1012,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 1;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
             'rating' => '3',
         ];
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
@@ -1042,8 +1042,8 @@ final class TalksControllerTest extends TalkBase
         );
         $request->user_id = 1;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
             'comment' => 'Test Comment',
         ];
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
@@ -1073,8 +1073,8 @@ final class TalksControllerTest extends TalkBase
 
         $request->user_id = 2;
         $request->parameters = [
-            'username'      => 'psherman',
-            'display_name'  => 'P Sherman',
+            'username' => 'psherman',
+            'display_name' => 'P Sherman',
         ];
 
         $talks_controller = new TalksController(
@@ -1175,7 +1175,7 @@ final class TalksControllerTest extends TalkBase
         );
 
         $request->parameters = [
-            'verbose'      => 'yes',
+            'verbose' => 'yes',
         ];
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();
@@ -1282,7 +1282,7 @@ final class TalksControllerTest extends TalkBase
         );
 
         $request->parameters = [
-            'title'      => 'linux',
+            'title' => 'linux',
         ];
 
         $db = $this->getMockBuilder(mockPDO::class)->getMock();

--- a/tests/Controller/TokenControllerTest.php
+++ b/tests/Controller/TokenControllerTest.php
@@ -18,7 +18,7 @@ final class TokenControllerTest extends TestCase
     public function setup(): void
     {
         $this->request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $this->pdo     = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
+        $this->pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testThatDeletingATokenWithoutLoginThrowsException()

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -10,7 +10,7 @@ final class HeaderTest extends TestCase
     public function testParseParamsWithEmbededSeparator()
     {
         $headerStr = 'For=10.0.0.1,For=10.0.0.2;user-agent="test;test;test;test";For=10.0.0.3';
-        $header    = new Header('Forwarded', $headerStr, ';');
+        $header = new Header('Forwarded', $headerStr, ';');
 
         $header->parseParams();
         $this->assertEquals(3, $header->count());
@@ -19,7 +19,7 @@ final class HeaderTest extends TestCase
     public function testParseParamsWithTwoGlues()
     {
         $headerStr = 'For=10.0.0.1,For=10.0.0.2;user-agent="test;test;test;test";For=10.0.0.3;user-agent="secondLevel;some date"';
-        $header    = new Header('Forwarded', $headerStr, ';');
+        $header = new Header('Forwarded', $headerStr, ';');
 
         $header->parseParams();
         $header->setGlue(',');
@@ -41,7 +41,7 @@ final class HeaderTest extends TestCase
     {
         $headerStr = 'For=10.0.0.1;user-agent="test;test;test;test";For=10.0.0.2;user-agent="secondLevel;
         some date";for=10.0.0.3;user-agent="thirdLevel"';
-        $header    = new Header('Forwarded', $headerStr, ';');
+        $header = new Header('Forwarded', $headerStr, ';');
 
         $header->parseParams();
         $header->setGlue(',');
@@ -54,7 +54,7 @@ final class HeaderTest extends TestCase
     public function testBuildEntityArrayWithValueOnly()
     {
         $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
-        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header = new Header('X-Forwarded-For', $headerStr, ',');
         $header->parseParams();
         $this->assertEquals(3, $header->count());
         $partsArray = $header->toArray();
@@ -68,7 +68,7 @@ final class HeaderTest extends TestCase
      */
     public function getNameReturnsTheHeaderName()
     {
-        $name   = uniqid('headername', true);
+        $name = uniqid('headername', true);
         $header = new Header($name, '', ',');
         $this->assertEquals($name, $header->getName());
     }
@@ -78,7 +78,7 @@ final class HeaderTest extends TestCase
      */
     public function getGlueReturnsGlueValue()
     {
-        $glue   = uniqid('glue', true);
+        $glue = uniqid('glue', true);
         $header = new Header('X-Forwarded-For', '', $glue);
         $this->assertEquals($glue, $header->getGlue());
     }
@@ -89,7 +89,7 @@ final class HeaderTest extends TestCase
     public function getIteratorWorks()
     {
         $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
-        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header = new Header('X-Forwarded-For', $headerStr, ',');
         $header->parseParams();
         $iterator = $header->getIterator();
 
@@ -109,7 +109,7 @@ final class HeaderTest extends TestCase
     public function toStringWorks()
     {
         $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
-        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header = new Header('X-Forwarded-For', $headerStr, ',');
         $this->assertEquals($headerStr, (string) $header);
         $header->parseParams();
         $this->assertEquals('10.0.0.1, 10.0.0.2, 10.0.0.3', (string) $header);
@@ -121,7 +121,7 @@ final class HeaderTest extends TestCase
     public function removeValueWorks()
     {
         $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
-        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header = new Header('X-Forwarded-For', $headerStr, ',');
         $header->parseParams();
         $header->removeValue('10.0.0.2');
         $this->assertEquals(['10.0.0.1', '10.0.0.3'], $header->toArray());
@@ -133,7 +133,7 @@ final class HeaderTest extends TestCase
     public function hasValueReturnsTrueIfValueFound()
     {
         $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
-        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header = new Header('X-Forwarded-For', $headerStr, ',');
         $header->parseParams();
         $this->assertTrue($header->hasValue('10.0.0.1'));
         $this->assertTrue($header->hasValue('10.0.0.2'));
@@ -146,7 +146,7 @@ final class HeaderTest extends TestCase
     public function hasValueReturnsFalseIfValueNotFound()
     {
         $headerStr = '10.0.0.1,10.0.0.2,10.0.0.3';
-        $header    = new Header('X-Forwarded-For', $headerStr, ',');
+        $header = new Header('X-Forwarded-For', $headerStr, ',');
         $header->parseParams();
         $this->assertFalse($header->hasValue('10.0.0.4'));
     }
@@ -157,7 +157,7 @@ final class HeaderTest extends TestCase
     public function setNameCanBeUsedAfterHeadersAreCreated()
     {
         $headerStr = 'application/json';
-        $header    = new Header('Accept', $headerStr, '/');
+        $header = new Header('Accept', $headerStr, '/');
         $this->assertEquals('Accept', $header->getName());
         $header->setName('Content-Type');
         $this->assertEquals('Content-Type', $header->getName());
@@ -173,7 +173,7 @@ final class HeaderTest extends TestCase
         $headerChunks = [
             ';abc',
         ];
-        $header       = new Header('Foo', $headerChunks, ';');
+        $header = new Header('Foo', $headerChunks, ';');
         $header->parseParams();
         $header->setGlue('=');
         $header->parseParams();

--- a/tests/Model/ApiMapperTest.php
+++ b/tests/Model/ApiMapperTest.php
@@ -20,7 +20,7 @@ final class ApiMapperTest extends TestCase
 
     public function setup(): void
     {
-        $this->pdo     = $this->getMockBuilder(PDO::class)
+        $this->pdo = $this->getMockBuilder(PDO::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->request = $this->getMockBuilder(Request::class)
@@ -63,16 +63,16 @@ final class ApiMapperTest extends TestCase
                 [
                     [
                         'event_start_date' => '2016-09-19T05:54:18+00:00',
-                        'event_tz_place'   => null,
-                        'event_tz_cont'    => null,
-                        'name'             => null,
+                        'event_tz_place' => null,
+                        'event_tz_cont' => null,
+                        'name' => null,
                     ],
                 ],
                 [
                     [
                         'event_start_date' => 1474264458,
-                        'event_tz_place'   => null,
-                        'event_tz_cont'    => null,
+                        'event_tz_place' => null,
+                        'event_tz_cont' => null,
                     ]
                 ]
             ],
@@ -80,16 +80,16 @@ final class ApiMapperTest extends TestCase
                 [
                     [
                         'event_start_date' => '2016-09-19T07:54:18+02:00',
-                        'event_tz_place'   => 'Berlin',
-                        'event_tz_cont'    => 'Europe',
-                        'name'             => null,
+                        'event_tz_place' => 'Berlin',
+                        'event_tz_cont' => 'Europe',
+                        'name' => null,
                     ]
                 ],
                 [
                     [
                         'event_start_date' => 1474264458,
-                        'event_tz_place'   => 'Berlin',
-                        'event_tz_cont'    => 'Europe',
+                        'event_tz_place' => 'Berlin',
+                        'event_tz_cont' => 'Europe',
                     ]
                 ]
             ],
@@ -101,10 +101,10 @@ final class ApiMapperTest extends TestCase
         $mapper = new TestApiMapper($this->pdo, $this->request);
 
         $this->assertEquals([
-            'event_tz_place'   => 'event_tz_place',
-            'event_tz_cont'    => 'event_tz_cont',
+            'event_tz_place' => 'event_tz_place',
+            'event_tz_cont' => 'event_tz_cont',
             'event_start_date' => 'event_start_date',
-            'name'             => 'name',
+            'name' => 'name',
         ], $mapper->getDefaultFields());
     }
 
@@ -145,7 +145,7 @@ final class ApiMapperTest extends TestCase
 
         $mapper = new ApiMapper($pdo, $this->request);
 
-        $obj    = new ReflectionClass(ApiMapper::class);
+        $obj = new ReflectionClass(ApiMapper::class);
         $method = $obj->getMethod('getTotalCount');
         $method->setAccessible(true);
 

--- a/tests/Model/EventHostMapperTest.php
+++ b/tests/Model/EventHostMapperTest.php
@@ -15,9 +15,9 @@ final class EventHostMapperTest extends TestCase
         $stmt = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
         $stmt->method('execute')
             ->with([
-                ':host_id'  => 12,
+                ':host_id' => 12,
                 ':event_id' => 10,
-                ':type'     => 'event'
+                ':type' => 'event'
             ])
             ->willReturn(true);
         $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
@@ -39,9 +39,9 @@ final class EventHostMapperTest extends TestCase
         $stmt = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
         $stmt->method('execute')
             ->with([
-                ':host_id'  => 12,
+                ':host_id' => 12,
                 ':event_id' => 10,
-                ':type'     => 'event'
+                ':type' => 'event'
             ])
             ->willReturn(false);
         $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
@@ -105,10 +105,10 @@ final class EventHostMapperTest extends TestCase
             ->method('prepare')
             ->with('SELECT count(*) AS count FROM (select a.uid as user_id, u.full_name as host_name from user_admin a inner join user u on u.ID = a.uid where rid = :event_id and rtype="event" and (rcode!="pending" OR rcode is null) order by host_name  ) as counter')
             ->willReturn($stmt2);
-        $request                       = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
-        $request->base                 = 'test';
-        $request->version              = '1';
-        $request->path_info            = '2';
+        $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
+        $request->base = 'test';
+        $request->version = '1';
+        $request->path_info = '2';
         $request->paginationParameters = ['resultsperpage' => 10, 'start' => 0];
 
         $mapper = new EventHostMapper($pdo, $request);
@@ -117,12 +117,12 @@ final class EventHostMapperTest extends TestCase
             'hosts' => [
                 [
                     'host_name' => 'Karl Napp',
-                    'host_uri'  => 'test/1/users/8',
+                    'host_uri' => 'test/1/users/8',
                 ]
             ],
-            'meta'  => [
-                'count'     => 1,
-                'total'     => null,
+            'meta' => [
+                'count' => 1,
+                'total' => null,
                 'this_page' => 'test2?resultsperpage=10&start=0'
             ]
         ], $mapper->getHostsByEventId(12, 10, 0));
@@ -133,9 +133,9 @@ final class EventHostMapperTest extends TestCase
         $stmt1 = $this->getMockBuilder(PDOStatement::class)->disableOriginalConstructor()->getMock();
         $stmt1->method('execute')
             ->with([
-                ':user_id'  => 12,
+                ':user_id' => 12,
                 ':event_id' => 14,
-                ':type'     => 'event',
+                ':type' => 'event',
             ])
             ->willReturn(true);
 

--- a/tests/Model/OauthModelTest.php
+++ b/tests/Model/OauthModelTest.php
@@ -18,13 +18,13 @@ final class OauthModelTest extends TestCase
 
     public function setup(): void
     {
-        $this->pdo              = $this->getMockBuilder(PDO::class)
+        $this->pdo = $this->getMockBuilder(PDO::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request          = $this->getMockBuilder(Request::class)
+        $this->request = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request->base    = "";
+        $this->request->base = "";
         $this->request->version = "2.1";
 
         $this->oauth = new OAuthModel($this->pdo, $this->request);
@@ -74,7 +74,7 @@ final class OauthModelTest extends TestCase
             [
                 'password' => password_hash(md5($pass), PASSWORD_BCRYPT),
                 'verified' => 1,
-                'ID'       => 1234,
+                'ID' => 1234,
             ]
         );
         $this->pdo->method('prepare')->willReturn($stmt);

--- a/tests/Model/TestApiMapper.php
+++ b/tests/Model/TestApiMapper.php
@@ -9,10 +9,10 @@ final class TestApiMapper extends ApiMapper
     public function getDefaultFields()
     {
         return [
-            'event_tz_place'   => 'event_tz_place',
-            'event_tz_cont'    => 'event_tz_cont',
+            'event_tz_place' => 'event_tz_place',
+            'event_tz_cont' => 'event_tz_cont',
             'event_start_date' => 'event_start_date',
-            'name'             => 'name',
+            'name' => 'name',
         ];
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -40,7 +40,7 @@ final class RequestTest extends TestCase
             ]
         );
 
-        $server  = [
+        $server = [
             'QUERY_STRING' => $queryString,
         ];
         $request = new Request($this->config, $server);
@@ -57,9 +57,9 @@ final class RequestTest extends TestCase
      */
     public function testGetParameterReturnsDefaultIfParameterNotSet()
     {
-        $uniq    = uniqid();
+        $uniq = uniqid();
         $request = new Request($this->config, []);
-        $result  = $request->getParameter('samoflange', $uniq);
+        $result = $request->getParameter('samoflange', $uniq);
 
         $this->assertSame($uniq, $result);
     }
@@ -140,7 +140,7 @@ final class RequestTest extends TestCase
         $request = new Request($this->config, []);
 
         $default = uniqid('', true);
-        $result  = $request->getUrlElement(22, $default);
+        $result = $request->getUrlElement(22, $default);
 
         $this->assertEquals($default, $result);
     }
@@ -155,7 +155,7 @@ final class RequestTest extends TestCase
      */
     public function testGetUrlElementReturnsRequestedElementFromPath()
     {
-        $server  = ['PATH_INFO' => 'foo/bar/baz'];
+        $server = ['PATH_INFO' => 'foo/bar/baz'];
         $request = new Request($this->config, $server);
         $this->assertEquals('foo', $request->getUrlElement(0));
         $this->assertEquals('bar', $request->getUrlElement(1));
@@ -171,7 +171,7 @@ final class RequestTest extends TestCase
      */
     public function testAcceptsHeadersAreParsedCorrectly()
     {
-        $server  = [
+        $server = [
             'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         ];
         $request = new Request($this->config, $server);
@@ -193,7 +193,7 @@ final class RequestTest extends TestCase
      */
     public function testPreferredContentTypeOfReturnsADesiredFormatIfItIsAccepted()
     {
-        $server  = [
+        $server = [
             'HTTP_ACCEPT' => 'text/text,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8',
         ];
         $request = new Request($this->config, $server);
@@ -219,7 +219,7 @@ final class RequestTest extends TestCase
      */
     public function testIfPreferredFormatIsNotAcceptedReturnJson()
     {
-        $server  = [
+        $server = [
             'HTTP_ACCEPT' => 'text/text,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8',
         ];
         $request = new Request($this->config, $server);
@@ -241,7 +241,7 @@ final class RequestTest extends TestCase
      */
     public function testHostIsSetCorrectlyFromTheHeaders()
     {
-        $server  = ['HTTP_HOST' => 'joind.in'];
+        $server = ['HTTP_HOST' => 'joind.in'];
         $request = new Request($this->config, $server);
 
         $this->assertEquals('joind.in', $request->host);
@@ -266,7 +266,7 @@ final class RequestTest extends TestCase
      */
     public function testHostCanBeSetWithSetHost()
     {
-        $host    = uniqid() . '.com';
+        $host = uniqid() . '.com';
         $request = new Request($this->config, []);
         $request->setHost($host);
 
@@ -289,17 +289,17 @@ final class RequestTest extends TestCase
     {
         $body = json_encode(
             [
-                'a'     => 'b',
+                'a' => 'b',
                 'array' => ['joind' => 'in'],
             ]
         );
 
-        $inside        = new \stdClass();
+        $inside = new \stdClass();
         $inside->joind = 'in';
 
         $server = [
             'REQUEST_METHOD' => $method,
-            'CONTENT_TYPE'   => 'application/json',
+            'CONTENT_TYPE' => 'application/json',
         ];
         /* @var $request Request */
         $request = $this->getMockBuilder('\Joindin\Api\Request')
@@ -353,7 +353,7 @@ final class RequestTest extends TestCase
      */
     public function testSchemeIsHttpsIfHttpsValueIsOn()
     {
-        $server  = ['HTTPS' => 'on'];
+        $server = ['HTTPS' => 'on'];
         $request = new Request($this->config, $server);
 
         $this->assertEquals('https://', $request->scheme);
@@ -440,7 +440,7 @@ final class RequestTest extends TestCase
      */
     public function testIfRequestIsntHTTPSReturnsFalse()
     {
-        $config  = array_merge($this->config, ['mode' => 'production']);
+        $config = array_merge($this->config, ['mode' => 'production']);
         $request = new Request($config, []);
         $request->setScheme('http://');
         $this->assertFalse($request->identifyUser('This is a bad header'));
@@ -463,7 +463,7 @@ final class RequestTest extends TestCase
         $db->method('getAvailableDrivers');
 
         $request = new Request($this->config, []);
-        $result  = $request->getOAuthModel($db);
+        $result = $request->getOAuthModel($db);
 
         $this->assertInstanceOf('Joindin\Api\Model\OAuthModel', $result);
     }
@@ -494,7 +494,7 @@ final class RequestTest extends TestCase
     {
         /* @var $mockOauth \Joindin\Api\Model\OAuthModel */
         $mockOauth = $this->getMockBuilder('Joindin\Api\Model\OAuthModel')->disableOriginalConstructor()->getMock();
-        $request   = new Request($this->config, []);
+        $request = new Request($this->config, []);
 
         $this->assertSame($request, $request->setOauthModel($mockOauth));
     }
@@ -510,7 +510,7 @@ final class RequestTest extends TestCase
     {
         /* @var $mockOauth \Joindin\Api\Model\OAuthModel */
         $mockOauth = $this->getMockBuilder(OAuthModel::class)->disableOriginalConstructor()->getMock();
-        $request   = new Request($this->config, []);
+        $request = new Request($this->config, []);
         $request->setOauthModel($mockOauth);
 
         $this->assertSame($mockOauth, $request->getOauthModel());
@@ -525,7 +525,7 @@ final class RequestTest extends TestCase
      */
     public function testIdentifyUserWithOauthTokenTypeSetsUserIdForValidHeader()
     {
-        $request   = new Request($this->config, ['HTTPS' => 'on']);
+        $request = new Request($this->config, ['HTTPS' => 'on']);
         $mockOauth = $this->getMockBuilder(OAuthModel::class)->disableOriginalConstructor()->getMock();
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
@@ -549,7 +549,7 @@ final class RequestTest extends TestCase
      */
     public function testIdentifyUserWithBearerTokenTypeSetsUserIdForValidHeader()
     {
-        $request   = new Request($this->config, ['HTTPS' => 'on']);
+        $request = new Request($this->config, ['HTTPS' => 'on']);
         $mockOauth = $this->getMockBuilder(OAuthModel::class)->disableOriginalConstructor()->getMock();
         $mockOauth->expects($this->once())
             ->method('verifyAccessToken')
@@ -584,7 +584,7 @@ final class RequestTest extends TestCase
     public function testSetUserIdAllowsForSettingOfUserId()
     {
         $request = new Request($this->config, []);
-        $user    = uniqid('', true);
+        $user = uniqid('', true);
 
         $request->setUserId($user);
         $this->assertEquals($user, $request->getUserId());
@@ -597,8 +597,8 @@ final class RequestTest extends TestCase
      */
     public function testSetPathInfoAllowsSettingOfPathInfo()
     {
-        $path    = uniqid('', true) . '/' . uniqid('', true) . '/' . uniqid('', true);
-        $parts   = explode('/', $path);
+        $path = uniqid('', true) . '/' . uniqid('', true) . '/' . uniqid('', true);
+        $parts = explode('/', $path);
         $request = new Request($this->config, []);
         $request->setPathInfo($path);
 
@@ -628,7 +628,7 @@ final class RequestTest extends TestCase
      */
     public function testSetAcceptSetsTheAcceptVariable()
     {
-        $accept      = uniqid('', true) . ',' . uniqid('', true) . ',' . uniqid('', true);
+        $accept = uniqid('', true) . ',' . uniqid('', true) . ',' . uniqid('', true);
         $acceptParts = explode(',', $accept);
 
         $request = new Request($this->config, []);
@@ -659,7 +659,7 @@ final class RequestTest extends TestCase
     public function testSetBaseAllowsSettingOfBase()
     {
         $request = new Request($this->config, []);
-        $base    = uniqid('', true);
+        $base = uniqid('', true);
         $request->setBase($base);
         $this->assertEquals($base, $request->getBase());
         $this->assertEquals($base, $request->base);
@@ -687,54 +687,54 @@ final class RequestTest extends TestCase
     {
         return [
             [ // #0
-                'parameters'    => [],
+                'parameters' => [],
                 'expectedClass' => JsonView::class,
             ],
             [ // #1
-                'parameters'    => ['format' => 'html'],
+                'parameters' => ['format' => 'html'],
                 'expectedClass' => HtmlView::class,
             ],
             [ // #2
-                'parameters'    => ['callback' => 'dave'],
+                'parameters' => ['callback' => 'dave'],
                 'expectedClass' => JsonPView::class,
             ],
             [ // #3
-                'parameters'    => ['format' => 'html'],
+                'parameters' => ['format' => 'html'],
                 'expectedClass' => HtmlView::class,
             ],
             [ // #4
-                'parameters'    => ['format' => 'html'],
+                'parameters' => ['format' => 'html'],
                 'expectedClass' => HtmlView::class,
-                'accepts'       => 'text/html',
+                'accepts' => 'text/html',
             ],
             [ // #5
-                'parameters'    => [],
+                'parameters' => [],
                 'expectedClass' => JsonView::class,
-                'accepts'       => 'application/json',
+                'accepts' => 'application/json',
             ],
             [ // #6
-                'parameters'    => [],
+                'parameters' => [],
                 'expectedClass' => JsonView::class,
-                'accepts'       => 'application/json,text/html',
+                'accepts' => 'application/json,text/html',
             ],
             [ // #7
-                'parameters'    => [],
+                'parameters' => [],
                 'expectedClass' => HtmlView::class,
-                'accepts'       => 'text/html,applicaton/json',
-                'view'          => new \Joindin\Api\View\HtmlView(),
+                'accepts' => 'text/html,applicaton/json',
+                'view' => new \Joindin\Api\View\HtmlView(),
                 //                'skip' => true // Currently we're not applying Accept correctly
                 // Can @choult check what's the reason for the skip?
             ],
             [ // #8
-                'parameters'    => ['format' => 'html'],
+                'parameters' => ['format' => 'html'],
                 'expectedClass' => HtmlView::class,
-                'accepts'       => 'applicaton/json,text/html',
+                'accepts' => 'applicaton/json,text/html',
             ],
             [ // #9
-                'parameters'    => [],
+                'parameters' => [],
                 'expectedClass' => false,
-                'accepts'       => '',
-                'view'          => new ApiView(),
+                'accepts' => '',
+                'view' => new ApiView(),
             ],
         ];
     }
@@ -765,7 +765,7 @@ final class RequestTest extends TestCase
 
         $server = [
             'QUERY_STRING' => http_build_query($parameters),
-            'HTTP_ACCEPT'  => $accept,
+            'HTTP_ACCEPT' => $accept,
         ];
 
         $request = new Request($this->config, $server);
@@ -800,14 +800,14 @@ final class RequestTest extends TestCase
                     Request::CONTENT_TYPE_HTML,
                     Request::CONTENT_TYPE_JSON,
                 ],
-                'choices'  => [
+                'choices' => [
                     Request::CONTENT_TYPE_HTML,
                     Request::CONTENT_TYPE_JSON,
                 ],
             ],
             [ // #2
                 'expected' => ['a', 'b'],
-                'choices'  => ['a', 'b'],
+                'choices' => ['a', 'b'],
             ],
         ];
     }
@@ -840,7 +840,7 @@ final class RequestTest extends TestCase
     public function testGetSetRouteParams()
     {
         $request = new Request($this->config, []);
-        $params  = ['event_id' => 10];
+        $params = ['event_id' => 10];
         $request->setRouteParams($params);
         $this->assertEquals($params, $request->getRouteParams());
     }
@@ -852,7 +852,7 @@ final class RequestTest extends TestCase
     public function testGetSetAccessToken()
     {
         $request = new Request($this->config, []);
-        $token   = 'token';
+        $token = 'token';
         $request->setAccessToken($token);
         $this->assertEquals($token, $request->getAccessToken());
     }
@@ -863,7 +863,7 @@ final class RequestTest extends TestCase
      */
     public function testConstructorParsesRequestUri()
     {
-        $server  = ['REQUEST_URI' => '/v2/one/two?three=four'];
+        $server = ['REQUEST_URI' => '/v2/one/two?three=four'];
         $request = new Request($this->config, $server);
         $this->assertEquals('/v2/one/two', $request->getPathInfo());
     }
@@ -881,9 +881,9 @@ final class RequestTest extends TestCase
     public function clientIpProvider()
     {
         return [
-            'remote_addr'     => [['REMOTE_ADDR' => '192.168.1.1']],
+            'remote_addr' => [['REMOTE_ADDR' => '192.168.1.1']],
             'x-forwarded-for' => [['HTTP_X_FORWARDED_FOR' => '192.168.1.1']],
-            'http-forwarded'  => [['HTTP_FORWARDED' => 'for=192.168.1.1, for=198.51.100.17']],
+            'http-forwarded' => [['HTTP_FORWARDED' => 'for=192.168.1.1, for=198.51.100.17']],
         ];
     }
 

--- a/tests/Router/ApiRouterTest.php
+++ b/tests/Router/ApiRouterTest.php
@@ -21,7 +21,7 @@ final class ApiRouterTest extends TestCase
     {
         return [
             [
-                'routers'  => [
+                'routers' => [
                     2 => 'B',
                     1 => 'A',
                     3 => 'C'

--- a/tests/Router/DefaultRouterTest.php
+++ b/tests/Router/DefaultRouterTest.php
@@ -38,8 +38,8 @@ final class DefaultRouterTest extends TestCase
     public function testGetRoute($url)
     {
         $request = new Request([], ['REQUEST_URI' => $url]);
-        $router  = new DefaultRouter([]);
-        $route   = $router->getRoute($request);
+        $router = new DefaultRouter([]);
+        $route = $router->getRoute($request);
         $this->assertEquals(DefaultController::class, $route->getController());
         $this->assertEquals('handle', $route->getAction());
     }

--- a/tests/Router/RouteTest.php
+++ b/tests/Router/RouteTest.php
@@ -93,27 +93,27 @@ final class RouteTest extends TestCase
     {
         return [
             [ // #0
-                'config'              => ['config'],
-                'controller'          => TestController3::class,
-                'action'              => 'action',
+                'config' => ['config'],
+                'controller' => TestController3::class,
+                'action' => 'action',
                 Request::class => $this->getRequest('v1')
             ],
             [ // #1
-                'config'                => ['config'],
-                'controller'            => TestController3::class,
-                'action'                => 'action2',
+                'config' => ['config'],
+                'controller' => TestController3::class,
+                'action' => 'action2',
                 Request::class => $this->getRequest('v1'),
-                'expectedException'     => 'Exception',
+                'expectedException' => 'Exception',
                 'expectedExceptionCode' => Http::INTERNAL_SERVER_ERROR,
             ],
             [ // #2
-                'config'                => ['config'],
-                'controller'            => 'TestController4',
-                'action'                => 'action2',
+                'config' => ['config'],
+                'controller' => 'TestController4',
+                'action' => 'action2',
                 Request::class => $this->getRequest('v1'),
-                'expectedException'     => 'Exception',
+                'expectedException' => 'Exception',
                 'expectedExceptionCode' => Http::BAD_REQUEST,
-                'controllerExists'      => false
+                'controllerExists' => false
             ]
         ];
     }
@@ -141,7 +141,7 @@ final class RouteTest extends TestCase
         $expectedExceptionCode = false,
         $controllerExists = true
     ) {
-        $db        = 'database';
+        $db = 'database';
         $container = $this->getMockBuilder(ContainerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Router/VersionedRouterTest.php
+++ b/tests/Router/VersionedRouterTest.php
@@ -24,116 +24,116 @@ final class VersionedRouterTest extends TestCase
     {
         return [
             [ // #0
-                'version'            => '2.1',
-                'rules'              => [
+                'version' => '2.1',
+                'rules' => [
                     [
-                        'path'       => '/events',
+                        'path' => '/events',
                         'controller' => 'EventController',
-                        'action'     => 'getAction'
+                        'action' => 'getAction'
                     ]
                 ],
-                'url'                => '/v2.1/events',
-                'method'             => Request::HTTP_GET,
+                'url' => '/v2.1/events',
+                'method' => Request::HTTP_GET,
                 'expectedController' => 'EventController',
-                'expectedAction'     => 'getAction'
+                'expectedAction' => 'getAction'
             ],
             [ // #1
-                'version'            => '2.1',
-                'rules'              => [
+                'version' => '2.1',
+                'rules' => [
                     [
-                        'path'       => '/aevents',
+                        'path' => '/aevents',
                         'controller' => 'AEventController',
-                        'action'     => 'getSAction'
+                        'action' => 'getSAction'
                     ],
                     [
-                        'path'       => '/events',
+                        'path' => '/events',
                         'controller' => 'EventController',
-                        'action'     => 'getAction'
+                        'action' => 'getAction'
                     ]
                 ],
-                'url'                => '/v2.1/events',
-                'method'             => Request::HTTP_GET,
+                'url' => '/v2.1/events',
+                'method' => Request::HTTP_GET,
                 'expectedController' => 'EventController',
-                'expectedAction'     => 'getAction'
+                'expectedAction' => 'getAction'
             ],
             [ // #2
-                'version'            => '2.1',
-                'rules'              => [
+                'version' => '2.1',
+                'rules' => [
                     [
-                        'path'       => '/events',
+                        'path' => '/events',
                         'controller' => 'EventController',
-                        'action'     => 'getAction',
-                        'verbs'      => [Request::HTTP_POST]
+                        'action' => 'getAction',
+                        'verbs' => [Request::HTTP_POST]
                     ],
                     [
-                        'path'       => '/events',
+                        'path' => '/events',
                         'controller' => 'EventController2',
-                        'action'     => 'getAction2',
-                        'verbs'      => [Request::HTTP_GET, Request::HTTP_PUT]
+                        'action' => 'getAction2',
+                        'verbs' => [Request::HTTP_GET, Request::HTTP_PUT]
                     ]
                 ],
-                'url'                => '/v2.1/events',
-                'method'             => Request::HTTP_GET,
+                'url' => '/v2.1/events',
+                'method' => Request::HTTP_GET,
                 'expectedController' => 'EventController2',
-                'expectedAction'     => 'getAction2'
+                'expectedAction' => 'getAction2'
             ],
             [ // #3
-                'version'            => '2.1',
-                'rules'              => [
+                'version' => '2.1',
+                'rules' => [
                     [
-                        'path'       => '/events/(?P<event_id>\d+)$',
+                        'path' => '/events/(?P<event_id>\d+)$',
                         'controller' => 'EventController',
-                        'action'     => 'getAction'
+                        'action' => 'getAction'
                     ],
                 ],
-                'url'                => '/v2.1/events/10',
-                'method'             => Request::HTTP_GET,
+                'url' => '/v2.1/events/10',
+                'method' => Request::HTTP_GET,
                 'expectedController' => 'EventController',
-                'expectedAction'     => 'getAction',
-                'routeParams'        => ['event_id' => 10]
+                'expectedAction' => 'getAction',
+                'routeParams' => ['event_id' => 10]
             ],
             [ // #4
-                'version'               => '2.1',
-                'rules'                 => [
+                'version' => '2.1',
+                'rules' => [
                     [
-                        'path'       => '/aevents',
+                        'path' => '/aevents',
                         'controller' => 'AEventController',
-                        'action'     => 'getSAction'
+                        'action' => 'getSAction'
                     ],
                     [
-                        'path'       => '/events',
+                        'path' => '/events',
                         'controller' => 'EventController',
-                        'action'     => 'getAction',
-                        'verbs'      => [Request::HTTP_GET]
+                        'action' => 'getAction',
+                        'verbs' => [Request::HTTP_GET]
                     ]
                 ],
-                'url'                   => '/v2.1/events',
-                'method'                => Request::HTTP_POST,
-                'expectedController'    => 'N/A',
-                'expectedAction'        => 'N/A',
-                'routeParams'           => [],
+                'url' => '/v2.1/events',
+                'method' => Request::HTTP_POST,
+                'expectedController' => 'N/A',
+                'expectedAction' => 'N/A',
+                'routeParams' => [],
                 'expectedExceptionCode' => Http::METHOD_NOT_ALLOWED
             ],
             [ // #5
-                'version'               => '2.1',
-                'rules'                 => [
+                'version' => '2.1',
+                'rules' => [
                     [
-                        'path'       => '/aevents',
+                        'path' => '/aevents',
                         'controller' => 'AEventController',
-                        'action'     => 'getSAction'
+                        'action' => 'getSAction'
                     ],
                     [
-                        'path'       => '/events',
+                        'path' => '/events',
                         'controller' => 'EventController',
-                        'action'     => 'getAction',
-                        'verbs'      => [Request::HTTP_GET]
+                        'action' => 'getAction',
+                        'verbs' => [Request::HTTP_GET]
                     ]
                 ],
-                'url'                   => '/v2.2/events',
-                'method'                => Request::HTTP_GET,
-                'expectedController'    => 'N/A',
-                'expectedAction'        => 'N/A',
-                'routeParams'           => [],
+                'url' => '/v2.2/events',
+                'method' => Request::HTTP_GET,
+                'expectedController' => 'N/A',
+                'expectedAction' => 'N/A',
+                'routeParams' => [],
                 'expectedExceptionCode' => Http::NOT_FOUND
             ]
         ];
@@ -164,7 +164,7 @@ final class VersionedRouterTest extends TestCase
         $expectedExceptionCode = false
     ) {
         $request = new Request([], ['REQUEST_URI' => $url, 'REQUEST_METHOD' => $method]);
-        $router  = new VersionedRouter($version, [], $rules);
+        $router = new VersionedRouter($version, [], $rules);
 
         try {
             $route = $router->getRoute($request);

--- a/tests/Service/TalkCommentEmailServiceTest.php
+++ b/tests/Service/TalkCommentEmailServiceTest.php
@@ -12,8 +12,8 @@ final class TalkCommentEmailServiceTest extends Testcase
         'email' => [
             "from" => "test@joind.in",
             'smtp' => [
-                'host'     => 'localhost',
-                'port'     => 25,
+                'host' => 'localhost',
+                'port' => 25,
                 'username' => 'username',
                 'password' => 'ChangeMeSeymourChangeMe',
                 'security' => null,
@@ -27,8 +27,8 @@ final class TalkCommentEmailServiceTest extends Testcase
     public function testCreateService()
     {
         $recipients = ["test@joind.in"];
-        $talk       = new TalkModel(["talk_title" => "sample talk"]);
-        $comment    = ["comments" => [["comment" => "test comment", "rating" => 3]]];
+        $talk = new TalkModel(["talk_title" => "sample talk"]);
+        $comment = ["comments" => [["comment" => "test comment", "rating" => 3]]];
 
         $service = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
         $this->assertInstanceOf(TalkCommentEmailService::class, $service);
@@ -39,11 +39,11 @@ final class TalkCommentEmailServiceTest extends Testcase
      */
     public function testCreateServiceWithEmailRedirect()
     {
-        $config                   = $this->config;
+        $config = $this->config;
         $config["email"]["forward_all_to"] = "blackhole@joind.in";
-        $recipients               = ["test@joind.in"];
-        $talk                     = new TalkModel(["talk_title" => "sample talk"]);
-        $comment                  = ["comments" => [["comment" => "test comment", "rating" => 3]]];
+        $recipients = ["test@joind.in"];
+        $talk = new TalkModel(["talk_title" => "sample talk"]);
+        $comment = ["comments" => [["comment" => "test comment", "rating" => 3]]];
 
         $service = new TalkCommentEmailService($config, $recipients, $talk, $comment);
         $this->assertEquals(["blackhole@joind.in"], $service->getRecipients());
@@ -55,16 +55,16 @@ final class TalkCommentEmailServiceTest extends Testcase
     public function testTemplateReplacements()
     {
         $recipients = ["test@joind.in"];
-        $talk       = new TalkModel(["talk_title" => "sample talk"]);
-        $comment    = ["comments" => [["comment" => "test comment", "rating" => 3]]];
+        $talk = new TalkModel(["talk_title" => "sample talk"]);
+        $comment = ["comments" => [["comment" => "test comment", "rating" => 3]]];
 
-        $service               = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
+        $service = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
         $service->templatePath = __DIR__ . '/../../src/View/emails/';
 
-        $template     = "testTemplate.md";
+        $template = "testTemplate.md";
         $replacements = ["cat" => "Camel", "mat" => "magic carpet"];
-        $message      = $service->parseEmail($template, $replacements);
-        $expected     = "The Camel sat on the magic carpet
+        $message = $service->parseEmail($template, $replacements);
+        $expected = "The Camel sat on the magic carpet
 
 
 ----
@@ -80,10 +80,10 @@ Questions? Comments?  Get in touch: [feedback@joind.in](mailto:feedback@joind.in
      */
     public function testMarkdownTransform()
     {
-        $markdown   = "A *sunny* day";
+        $markdown = "A *sunny* day";
         $recipients = ["test@joind.in"];
-        $talk       = new TalkModel(["talk_title" => "sample talk"]);
-        $comment    = ["comments" => [["comment" => "test comment", "rating" => 3]]];
+        $talk = new TalkModel(["talk_title" => "sample talk"]);
+        $comment = ["comments" => [["comment" => "test comment", "rating" => 3]]];
 
         $service = new TalkCommentEmailService($this->config, $recipients, $talk, $comment);
 

--- a/tests/View/JsonViewTest.php
+++ b/tests/View/JsonViewTest.php
@@ -19,15 +19,15 @@ final class JsonViewTest extends TestCase
     {
         return [
             [ // #0
-                'input'    => ['a' => 'b', 'c' => 10],
+                'input' => ['a' => 'b', 'c' => 10],
                 'expected' => '{"a":"b","c":10}'
             ],
             [ // #1
-                'input'    => ['stub' => '10', 'b' => ['c', 'd']],
+                'input' => ['stub' => '10', 'b' => ['c', 'd']],
                 'expected' => '{"stub":"10","b":["c","d"],"meta":{"count":2}}'
             ],
             [ // #2 - JOINDIN-519
-                'input'    => false,
+                'input' => false,
                 'expected' => 'false'
             ],
         ];

--- a/tools/dbgen/generator.class.php
+++ b/tools/dbgen/generator.class.php
@@ -20,8 +20,8 @@ class DataGenerator
      */
     public function __construct(Generator_Data_Interface $data)
     {
-        $this->_data            = $data;
-        $this->_existing_stubs  = [];
+        $this->_data = $data;
+        $this->_existing_stubs = [];
         $this->_users_attending = [];
         $this->_talk_comment_max_timestamp = [];
         $this->_event_comment_max_timestamp = [];
@@ -169,9 +169,9 @@ class DataGenerator
 
         $first = true;
 
-        for ($id=1; $id!=$count+1; $id++) {
+        for ($id = 1; $id != $count + 1; $id++) {
             if ($id % 100 == 0) {
-                fwrite(STDERR, "TALK: $id         (" . (memory_get_usage(true)/1024) . " Kb)        \r");
+                fwrite(STDERR, "TALK: $id         (" . (memory_get_usage(true) / 1024) . " Kb)        \r");
             }
             
             $talk = new StdClass();
@@ -251,7 +251,7 @@ class DataGenerator
             // Check if we need multiple speakers or not
             $speaker_count = $this->_chance(TALK_HAS_MULTIPLE_SPEAKERS) ? rand(2, 4) : 1;
 
-            for ($i=0; $i!=$speaker_count; $i++) {
+            for ($i = 0; $i != $speaker_count; $i++) {
                 if ($this->_chance(TALK_IS_CLAIMED_BY_REGISTERED_USER)) {
                     $user = $this->_cacheFetchRandom('users');
                     $speaker_name = $user->fullname;
@@ -288,9 +288,9 @@ class DataGenerator
 
         $first = true;
 
-        for ($id=1; $id!=$count+1; $id++) {
+        for ($id = 1; $id != $count + 1; $id++) {
             if ($id % 100 == 0) {
-                fwrite(STDERR, "TRACK: $id       (" . (memory_get_usage(true)/1024) . " Kb)        \r");
+                fwrite(STDERR, "TRACK: $id       (" . (memory_get_usage(true) / 1024) . " Kb)        \r");
             }
             $event = $this->_cacheFetchRandom('events');
 
@@ -340,9 +340,9 @@ class DataGenerator
 
         $first = true;
 
-        for ($id=1; $id!=$count+1; $id++) {
+        for ($id = 1; $id != $count + 1; $id++) {
             if ($id % 100 == 0) {
-                fwrite(STDERR, "TALK COMMENT ID: $id       (" . (memory_get_usage(true)/1024) . " Kb)        \r");
+                fwrite(STDERR, "TALK COMMENT ID: $id       (" . (memory_get_usage(true) / 1024) . " Kb)        \r");
             }
 
             $talk = $this->_cacheFetchRandom('talks');
@@ -367,7 +367,7 @@ class DataGenerator
 
             // Exponential randomness, 0 will be the least given, 5 the most. Will take the dampening
             // factor of the talk into account.
-            $rating = floor(log(rand(1, 1 << (3+$talk->dampening)) / log(2)));
+            $rating = floor(log(rand(1, 1 << (3 + $talk->dampening)) / log(2)));
 
             $private = $this->_chance("COMMENT_IS_PRIVATE") ? 1 : 0;
 
@@ -411,9 +411,9 @@ class DataGenerator
         $first = true;
         $have_event_comments = false;
 
-        for ($id=1; $id!=$count+1; $id++) {
+        for ($id = 1; $id != $count + 1; $id++) {
             if ($id % 100 == 0) {
-                fwrite(STDERR, "EVENT COMMENT ID: $id       (" . (memory_get_usage(true)/1024) . " Kb)        \r");
+                fwrite(STDERR, "EVENT COMMENT ID: $id       (" . (memory_get_usage(true) / 1024) . " Kb)        \r");
             }
 
             $event = $this->_cacheFetchRandom('events');
@@ -447,7 +447,7 @@ class DataGenerator
 
             // Exponential randomness, 0 will be the least given, 5 the most. Will take the dampening
             // factor of the talk into account.
-            $rating = floor(log(rand(1, 1 << (3+$event->dampening)) / log(2)));
+            $rating = floor(log(rand(1, 1 << (3 + $event->dampening)) / log(2)));
 
             $tmp = $this->getData()->getCommentSourceData();
             $source = $tmp[array_rand($tmp)];
@@ -505,7 +505,7 @@ class DataGenerator
             // query. This is here to make sure that never can happen.
             $attended_events = rand($first ? 1 : 0, $event_count / 2);
 
-            for ($i=0; $i!=$attended_events; $i++) {
+            for ($i = 0; $i != $attended_events; $i++) {
                 $event = $this->_cacheFetchRandom('events');
 
                 // if the user is already attending this event, move on
@@ -545,7 +545,7 @@ class DataGenerator
 
             $userids = [];
 
-            for ($i=0; $i!=$admin_count; $i++) {
+            for ($i = 0; $i != $admin_count; $i++) {
                 // Make sure we don't add the same user twice
                 do {
                     $user = $this->_cacheFetchRandom('users');
@@ -593,9 +593,9 @@ class DataGenerator
 
         $first = true;
 
-        for ($id=1; $id!=$count+1; $id++) {
+        for ($id = 1; $id != $count + 1; $id++) {
             if ($id % 100 == 0) {
-                fwrite(STDERR, "EVENT ID: $id       (" . (memory_get_usage(true)/1024) . " Kb)        \r");
+                fwrite(STDERR, "EVENT ID: $id       (" . (memory_get_usage(true) / 1024) . " Kb)        \r");
             }
 
             $event = new StdClass();
@@ -718,9 +718,9 @@ class DataGenerator
         $usernames = [];
         $id = 2;
 
-        while ($id < ($count+2)) {
+        while ($id < ($count + 2)) {
             if ($id % 100 == 0) {
-                fwrite(STDERR, "USER ID: $id    (" . (memory_get_usage(true)/1024) . " Kb)        \r");
+                fwrite(STDERR, "USER ID: $id    (" . (memory_get_usage(true) / 1024) . " Kb)        \r");
             }
 
             // Generate and store user
@@ -866,10 +866,10 @@ class DataGenerator
 
         $number = rand(1, $max);
 
-        for ($i=0, $ret="", $r=$number; $i!=$r; $i++) {
+        for ($i = 0, $ret = "", $r = $number; $i != $r; $i++) {
             $ret .= $lorum[array_rand($lorum)];
 
-            if ($number > 10 && $i == (int) ($number/2)) {
+            if ($number > 10 && $i == (int) ($number / 2)) {
                 $ret .= "\\n\\n";
             }
         }

--- a/tools/dbgen/generator_data.class.php
+++ b/tools/dbgen/generator_data.class.php
@@ -10,7 +10,7 @@ class Generator_Data implements Generator_Data_Interface
     {
         $events = new StdClass();
         $events->firstpart = ["PHP", "Perl", "Python", "Ruby", "C", "MySQL", "DevOp", "Linux", "Debian", "CentOS", "Zend", "Developer", "Web", "Symfony", "Apache", "Computer", "IT", "Dev"];
-        $events->lastpart  = ["Con", "Conf", " meetup", "UUG", " day", "Congress"];
+        $events->lastpart = ["Con", "Conf", " meetup", "UUG", " day", "Congress"];
 
         return $events;
     }


### PR DESCRIPTION
This PR

* [x] enables and configures the `binary_operator_spaces` fixer
* [x] runs `composer cs`

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.1#usage:

>**binary_operator_spaces** [`@Symfony`, `@PhpCsFixer`]
>
>Binary operators should be surrounded by space as configured.
>
>Configuration options:
>
>* `align_double_arrow` (`false`, `null`, `true`): whether to apply, remove or ignore double arrows alignment; defaults to `false`. DEPRECATED: use options `operators` and `default` instead
>* `align_equals` (`false`, `null`, `true`): whether to apply, remove or ignore equals alignment; defaults to `false`. DEPRECATED: use options `operators` and `default` instead
>* `default` (`'align'`, `'align_single_space'`, `'align_single_space_minimal'`, `'no_space'`, `'single_space'`, `null`): default fix strategy; defaults to `'single_space'`
>* `operators` (`array`): dictionary of binary operator => fix strategy values that differ from the default strategy; defaults to `[]`