### PR TITLE
New account creation Fix for username exists and email exists errors

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -153,7 +153,6 @@ class UsersController extends BaseApiController
             } else {
                 // does anyone else have this username?
                 $existingUser = $userMapper->getUserByUsername($user['username']);
-                var_dump($existingUser);
                 if (is_array($existingUser) && array_key_exists('users', $existingUser)) {
                     if (count($existingUser['users']) > 0) {
                         $errors[] = "That username is already in use. Choose another";

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -153,9 +153,11 @@ class UsersController extends BaseApiController
             } else {
                 // does anyone else have this username?
                 $existingUser = $userMapper->getUserByUsername($user['username']);
-
+                var_dump($existingUser);
                 if (is_array($existingUser) && array_key_exists('users', $existingUser)) {
-                    $errors[] = "That username is already in use. Choose another";
+                    if (count($existingUser['users']) > 0) {
+                        $errors[] = "That username is already in use. Choose another";
+                    }
                 }
             }
 
@@ -182,7 +184,9 @@ class UsersController extends BaseApiController
                 $existingUser = $userMapper->getUserByEmail($user['email']);
 
                 if (is_array($existingUser) && array_key_exists('users', $existingUser)) {
-                    $errors[] = "That email is already associated with another account";
+                    if (count($existingUser['users']) > 0) {
+                        $errors[] = "That email is already associated with another account";
+                    }
                 }
             }
 


### PR DESCRIPTION
Originally reported by Matteo from GrUSP.

Able to replicate locally with prod dataset. This is so weird to have just started happening…

```
            if (empty($user['username'])) {
                $errors[] = "'username' is a required field";
            } else {
                // does anyone else have this username?
                $existingUser = $userMapper->getUserByUsername($user['username']);
                echo "<pre>";
                var_dump($existingUser);
                exit();
                if (is_array($existingUser) && array_key_exists('users', $existingUser)) {
                    $errors[] = "That username is already in use. Choose another";
                }
            }
```
outputs:
```
/home/vagrant/joindin-vm/joindin-web2/app/src/Application/BaseApi.php:137:string '<pre>/home/vagrant/joindin-vm/joindin-api/src/Controller/UsersController.php:157:
array(2) {
  'users' =>
  array(0) {
  }
  'meta' =>
  array(3) {
    'count' =>
    int(0)
    'total' =>
    string(1) "0"
    'this_page' =>
    string(52) "http://api.dev.joind.in/v2.1/users?resultsperpage=20"
  }
}
' (length=302)
```