### PR TITLE
Evaluate more-specific talk comment report/moderation routes ahead of less-specific talk comment update routes

### DIFF
--- a/src/config/routes/2.1.php
+++ b/src/config/routes/2.1.php
@@ -454,22 +454,6 @@ return [
         ],
     ],
     [
-        'path'       => '/talk_comments(/[^/]+)*/?$',
-        'controller' => TalkCommentsController::class,
-        'action'     => 'getComments',
-        'verbs'      => [
-            Request::HTTP_GET,
-        ],
-    ],
-    [
-        'path'       => '/talk_comments(/[^/]+)*/?$',
-        'controller' => TalkCommentsController::class,
-        'action'     => 'updateComment',
-        'verbs'      => [
-            Request::HTTP_PUT,
-        ],
-    ],
-    [
         'path'       => '/talk_comments(/[^/]+)*/reported?$',
         'controller' => TalkCommentsController::class,
         'action'     => 'reportComment',
@@ -481,6 +465,22 @@ return [
         'path'       => '/talk_comments(/[^/]+)*/reported?$',
         'controller' => TalkCommentsController::class,
         'action'     => 'moderateReportedComment',
+        'verbs'      => [
+            Request::HTTP_PUT,
+        ],
+    ],
+    [
+        'path'       => '/talk_comments(/[^/]+)*/?$',
+        'controller' => TalkCommentsController::class,
+        'action'     => 'getComments',
+        'verbs'      => [
+            Request::HTTP_GET,
+        ],
+    ],
+    [
+        'path'       => '/talk_comments(/[^/]+)*/?$',
+        'controller' => TalkCommentsController::class,
+        'action'     => 'updateComment',
         'verbs'      => [
             Request::HTTP_PUT,
         ],


### PR DESCRIPTION
This fixes talk comment report moderation being shadowed by talk comment updates due to an overly-wide regex for the latter. One could argue that the proper way to fix this is by fixing the regex for the latter, but I'm not comfortable enough with regex-fu to attempt that, and since our router evaluates routes one by one, in order, this will do the trick.

Technically we don't need to move *both* report routes, as POST has no routes shadowing it, but having two talk comment routes separated in the code looks weird enough that someone might attempt to reorder the routes back, causing the bug to resurface.

This bug manifests itself as a 500 on web2 when attempting to take action on a talk comment report, wrapping a 400 on the API side, with the API side complaining about "comment" not being supplied when required (which is a requirement of the comment update action but not the comment moderation action).