### PR TITLE
Allow renaming username

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -357,7 +357,7 @@ class UsersController extends BaseApiController
             // does anyone else have this username?
             $existingUser = $userMapper->getUserByUsername($user['username']);
 
-            if (is_array($existingUser) && array_key_exists('users', $existingUser)) {
+            if (is_array($existingUser) && array_key_exists('users', $existingUser) && $existingUser['users'] !== []) {
                 // yes but is that our existing user being found?
                 $oldUser = $userMapper->getUserById($userId);
 


### PR DESCRIPTION
This checks that there actually is a user returned with the new name and if not just allow the renaming.

THis fixes the issue described in https://github.com/joindin/joindin-api/issues/916#issuecomment-1642395390